### PR TITLE
built-in s-dftd3/dftd4 with OpenMP disabled

### DIFF
--- a/builder/build_dftd3.sh
+++ b/builder/build_dftd3.sh
@@ -10,6 +10,8 @@ TAR_GZ_NAME="dftd3-1.0.0-sdist.tar.gz"
 BUILD_DIR="${WORK_DIR}/_build"
 INSTALL_DIR="${WORK_DIR}/dftd3-build"
 
+pip3 install meson ninja
+
 cd ${WORK_DIR}
 
 echo "Downloading source code from $SOURCE_URL..."
@@ -20,6 +22,15 @@ tar -xzf $TAR_GZ_NAME
 
 SOURCE_DIR=$(tar -tf $TAR_GZ_NAME | head -1 | cut -f1 -d"/")
 cd $SOURCE_DIR
+
+echo "
+option(
+  'openmp',
+  type: 'boolean',
+  value: false,
+  yield: true,
+  description: 'Use OpenMP parallelisation',
+)" >> meson_options.txt
 
 echo "Setting up build system with meson..."
 meson setup $BUILD_DIR -Dopenmp=false

--- a/builder/build_dftd3.sh
+++ b/builder/build_dftd3.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+WORK_DIR="./tmp"
+mkdir -p ${WORK_DIR}
+
+SOURCE_URL="https://github.com/dftd3/simple-dftd3/releases/download/v1.0.0/dftd3-1.0.0-sdist.tar.gz"
+
+TAR_GZ_NAME="dftd3-1.0.0-sdist.tar.gz"
+
+BUILD_DIR="${WORK_DIR}/_build"
+INSTALL_DIR="${WORK_DIR}/dftd3-build"
+
+cd ${WORK_DIR}
+
+echo "Downloading source code from $SOURCE_URL..."
+curl -L $SOURCE_URL -o $TAR_GZ_NAME
+
+echo "Extracting $TAR_GZ_NAME..."
+tar -xzf $TAR_GZ_NAME
+
+SOURCE_DIR=$(tar -tf $TAR_GZ_NAME | head -1 | cut -f1 -d"/")
+cd $SOURCE_DIR
+
+echo "Setting up build system with meson..."
+meson setup $BUILD_DIR -Dopenmp=false
+
+echo "Compiling the code..."
+meson compile -C $BUILD_DIR
+
+echo "Configuring build system with prefix..."
+meson configure $BUILD_DIR --prefix=$(realpath ${INSTALL_DIR})
+
+echo "Installing to $INSTALL_DIR..."
+meson install -C $BUILD_DIR
+
+echo "Installation complete."
+
+cd ../../
+
+echo "All operations completed in tmp/lib/python3/dist-packages/dftd3."

--- a/builder/build_dftdx.sh
+++ b/builder/build_dftdx.sh
@@ -35,7 +35,7 @@ option(
 )" >> meson_options.txt
 
 echo "Setting up build system with meson..."
-meson setup $BUILD_DIR -Dopenmp=false
+meson setup --wipe $BUILD_DIR -Dopenmp=false
 
 echo "Compiling the code..."
 meson compile -C $BUILD_DIR

--- a/builder/build_dftdx.sh
+++ b/builder/build_dftdx.sh
@@ -3,12 +3,14 @@
 WORK_DIR="./tmp"
 mkdir -p ${WORK_DIR}
 
-SOURCE_URL="https://github.com/dftd3/simple-dftd3/releases/download/v1.0.0/dftd3-1.0.0-sdist.tar.gz"
+PROJECT_NAME=${PROJECT_NAME:-"dftd3"}
 
-TAR_GZ_NAME="dftd3-1.0.0-sdist.tar.gz"
+SOURCE_URL=${SOURCE_URL:-"https://github.com/dftd3/simple-dftd3/releases/download/v1.0.0/dftd3-1.0.0-sdist.tar.gz"}
+
+TAR_GZ_NAME=$(basename ${SOURCE_URL})
 
 BUILD_DIR="${WORK_DIR}/_build"
-INSTALL_DIR="${WORK_DIR}/dftd3-build"
+INSTALL_DIR="${WORK_DIR}/${PROJECT_NAME}-build"
 
 pip3 install meson ninja
 
@@ -48,4 +50,4 @@ echo "Installation complete."
 
 cd ../../
 
-echo "All operations completed in tmp/lib/python3/dist-packages/dftd3."
+echo "All operations completed."

--- a/builder/build_dftdx.sh
+++ b/builder/build_dftdx.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 WORK_DIR="./tmp"
+rm -r ${WORK_DIR}
 mkdir -p ${WORK_DIR}
 
 PROJECT_NAME=${PROJECT_NAME:-"dftd3"}

--- a/gpu4pyscf/dft/rks.py
+++ b/gpu4pyscf/dft/rks.py
@@ -250,7 +250,7 @@ class RKS(scf.hf.RHF, rks.RKS):
             # multi-threads in DFTD3 conflicts with PyTorch, set it to be 1 for safty
             from pyscf import lib
             with lib.with_omp_threads(1):
-                import dftd3.pyscf as disp
+                import gpu4pyscf.dftd3.pyscf as disp
                 d3 = disp.DFTD3Dispersion(self.mol, xc=self.xc, version=self.disp)
                 e_d3, _ = d3.kernel()
             return e_d3

--- a/gpu4pyscf/dft/rks.py
+++ b/gpu4pyscf/dft/rks.py
@@ -261,7 +261,7 @@ class RKS(scf.hf.RHF, rks.RKS):
             coords = self.mol.atom_coords()
             from pyscf import lib
             with lib.with_omp_threads(1):
-                from dftd4.interface import DampingParam, DispersionModel
+                from gpu4pyscf.dftd4.interface import DampingParam, DispersionModel
                 model = DispersionModel(atoms, coords)
                 res = model.get_dispersion(DampingParam(method=self.xc), grad=False)
             return res.get("energy")

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -504,7 +504,7 @@ class Gradients(rhf_grad.Gradients, pyscf.grad.rks.Gradients):
         if self.base.disp[:2].upper() == 'D3':
             from pyscf import lib
             with lib.with_omp_threads(1):
-                import dftd3.pyscf as disp
+                import gpu4pyscf.dftd3.pyscf as disp
                 d3 = disp.DFTD3Dispersion(self.mol, xc=self.base.xc, version=self.base.disp)
                 _, g_d3 = d3.kernel()
             return g_d3

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -516,7 +516,7 @@ class Gradients(rhf_grad.Gradients, pyscf.grad.rks.Gradients):
 
             from pyscf import lib
             with lib.with_omp_threads(1):
-                from dftd4.interface import DampingParam, DispersionModel
+                from gpu4pyscf.dftd4.interface import DampingParam, DispersionModel
                 model = DispersionModel(atoms, coords)
                 res = model.get_dispersion(DampingParam(method=self.base.xc), grad=True)
             return res.get("gradient")

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -681,7 +681,7 @@ class Hessian(rhf_hess.Hessian):
         if self.base.disp[:2].upper() == 'D3':
             from pyscf import lib
             with lib.with_omp_threads(1):
-                import dftd3.pyscf as disp
+                import gpu4pyscf.dftd3.pyscf as disp
                 coords = self.mol.atom_coords()
                 natm = self.mol.natm
                 h_d3 = numpy.zeros([self.mol.natm, self.mol.natm, 3,3])

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -710,7 +710,7 @@ class Hessian(rhf_hess.Hessian):
             natm = self.mol.natm
             from pyscf import lib
             with lib.with_omp_threads(1):
-                from dftd4.interface import DampingParam, DispersionModel
+                from gpu4pyscf.dftd4.interface import DampingParam, DispersionModel
                 params = DampingParam(method=self.base.xc)
                 mol = self.mol.copy()
                 h_d3 = numpy.zeros([self.mol.natm, self.mol.natm, 3,3])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cutensor==1.6.0.3
 cutensor-cu11==1.6.1
 cutensornet-cu11==2.0.0
 Cython==0.29.32
-dftd3==0.7.0
+# dftd3==0.7.0
 geometric==1.0
 h5py==3.7.0
 numpy==1.23.5

--- a/setup.py
+++ b/setup.py
@@ -102,12 +102,7 @@ class CMakeBuildPy(build_py):
         if not os.path.exists(script_path):
             raise FileNotFoundError("Cannot find build script: {}".format(script_path))
 
-        env_vars = {
-            'PROJECT_NAME': project_name,
-            'SOURCE_URL': source_url
-        }
-
-        subprocess.run(['sh', script_path], env=env_vars, shell=True, check=True)
+        subprocess.run(f"PROJECT_NAME={project_name} SOURCE_URL={source_url} sh {script_path}", shell=True, check=True)
 
         build_dir_pattern = f'tmp/{project_name}-*/tmp/{project_name}-build/lib/python3/dist-packages/{project_name}'
         build_dirs = glob.glob(build_dir_pattern)

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ class CMakeBuildPy(build_py):
             'SOURCE_URL': source_url
         }
 
-        check_call(['sh', script_path], env=env_vars)
+        check_call(['bash', script_path], env=env_vars, shell=True)
 
         build_dir_pattern = f'tmp/{project_name}-*/tmp/{project_name}-build/lib/python3/dist-packages/{project_name}'
         build_dirs = glob.glob(build_dir_pattern)
@@ -158,7 +158,7 @@ setup(
         'pyscf>=2.4.0',
         f'cupy-cuda{CUDA_VERSION}>=12.0',
         # 'dftd3==0.7.0',
-        'dftd4==3.5.0',
+        # 'dftd4==3.5.0',
         'geometric',
         f'gpu4pyscf-libxc-cuda{CUDA_VERSION}',
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ import sys
 import subprocess
 import re
 import glob
+import subprocess
 
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_py import build_py
 from distutils.util import get_platform
-from subprocess import check_call
 
 NAME = 'gpu4pyscf'
 AUTHOR = 'Qiming Sun'
@@ -107,7 +107,7 @@ class CMakeBuildPy(build_py):
             'SOURCE_URL': source_url
         }
 
-        check_call(['bash', script_path], env=env_vars, shell=True)
+        subprocess.run(['sh', script_path], env=env_vars, shell=True, check=True)
 
         build_dir_pattern = f'tmp/{project_name}-*/tmp/{project_name}-build/lib/python3/dist-packages/{project_name}'
         build_dirs = glob.glob(build_dir_pattern)

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ class CMakeBuildPy(build_py):
             self.spawn(cmd)
         super().run()
 
+
 class DFTD3Build(build_py):
     def run(self):
         script_path = 'builder/build_dftd3.sh'
@@ -138,7 +139,10 @@ setup(
         "pytest-cover==3.0.0",
         "pytest-coverage==0.0",
     ],
-    cmdclass={'build_py': CMakeBuildPy},
+    cmdclass={
+        'build_py': CMakeBuildPy,
+        'build_dftd3': DFTD3Build,
+    },
     install_requires=[
         'pyscf>=2.4.0',
         f'cupy-cuda{CUDA_VERSION}>=12.0',


### PR DESCRIPTION
Add the build logic of [simple-dftd3](https://github.com/dftd3/simple-dftd3) and [dftd4](https://github.com/dftd4/dftd4) to this project and disable OpenMP when building. Uses gpu4pyscf.dftd3 or gpu4pyscf.dftd4.