### PR TITLE
Fix meson clock skew error and test import bug

### DIFF
--- a/builder/build_dftdx.sh
+++ b/builder/build_dftdx.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-WORK_DIR="./tmp"
+WORK_DIR="/tmp/build_dftdx"
 rm -r ${WORK_DIR}
 mkdir -p ${WORK_DIR}
 

--- a/gpu4pyscf/df/tests/test_jk.py
+++ b/gpu4pyscf/df/tests/test_jk.py
@@ -17,7 +17,7 @@ import unittest
 import numpy as np
 import cupy
 import pyscf
-import dftd3.pyscf as disp
+import gpu4pyscf.dftd3.pyscf as disp
 from pyscf import lib, df
 from pyscf.geomopt.geometric_solver import optimize
 from gpu4pyscf import scf

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ class CMakeBuildPy(build_py):
 
         subprocess.run(f"PROJECT_NAME={project_name} SOURCE_URL={source_url} sh {script_path}", shell=True, check=True)
 
-        build_dir_pattern = f'tmp/{project_name}-*/tmp/{project_name}-build/lib/python3/dist-packages/{project_name}'
+        work_dir = "/tmp/build_dftdx"
+        build_dir_pattern = f'{work_dir}/{project_name}-build/lib/python3/dist-packages/{project_name}'
         build_dirs = glob.glob(build_dir_pattern)
         if not len(build_dirs) == 1:
             raise FileNotFoundError("Cannot find build directory: {}".format(build_dir_pattern))


### PR DESCRIPTION
- Meson will report a clock skew error on NFS. Use /tmp to avoid this error.
- Completed a missing modification to dftd3 -> gpu4pyscf.dftd3.