### PR TITLE
Align setups with pyscf

### DIFF
--- a/examples/00-h2o.py
+++ b/examples/00-h2o.py
@@ -36,7 +36,7 @@ mol = pyscf.M(
     atom=atom,                         # water molecule
     basis='def2-tzvpp',                # basis set
     output='./pyscf.log',              # save log file
-    verbose=1                          # control
+    verbose=1                          # control the level of print info
     )
 
 mf_GPU = rks.RKS(                      # restricted Kohn-Sham DFT

--- a/gpu4pyscf/df/df.py
+++ b/gpu4pyscf/df/df.py
@@ -20,7 +20,7 @@ import ctypes
 import numpy as np
 from cupyx.scipy.linalg import solve_triangular
 from pyscf import lib
-from pyscf.df import df, addons
+from pyscf.df import df, addons, incore
 from gpu4pyscf.lib.cupy_helper import (
     cholesky, tag_array, get_avail_mem, cart2sph, take_last2d, transpose_sum)
 from gpu4pyscf.df import int3c2e, df_jk
@@ -30,7 +30,7 @@ from cupyx import scipy
 
 MIN_BLK_SIZE = getattr(__config__, 'min_ao_blksize', 128)
 ALIGNED = getattr(__config__, 'ao_aligned', 32)
-LINEAR_DEP_TOL = 1e-7
+LINEAR_DEP_TOL = incore.LINEAR_DEP_THR
 
 class DF(lib.StreamObject):
     from gpu4pyscf.lib.utils import to_gpu, device

--- a/gpu4pyscf/df/df_jk.py
+++ b/gpu4pyscf/df/df_jk.py
@@ -124,7 +124,7 @@ class _DFHF:
     '''
     to_gpu = utils.to_gpu
     device = utils.device
-
+    __name_mixin__ = 'DF'
     _keys = {'rhoj', 'rhok', 'disp', 'screen_tol'}
 
     def __init__(self, mf, dfobj, only_dfj):

--- a/gpu4pyscf/df/grad/rhf.py
+++ b/gpu4pyscf/df/grad/rhf.py
@@ -243,9 +243,9 @@ class Gradients(rhf_grad.Gradients):
     def __init__(self, mf):
         # Whether to include the response of DF auxiliary basis when computing
         # nuclear gradients of J/K matrices
-        self.auxbasis_response = True
         rhf_grad.Gradients.__init__(self, mf)
 
+    auxbasis_response = True
     get_jk = get_jk
     grad_elec = rhf_grad.grad_elec
     check_sanity = NotImplemented

--- a/gpu4pyscf/df/grad/rks.py
+++ b/gpu4pyscf/df/grad/rks.py
@@ -119,8 +119,14 @@ def get_veff(ks_grad, mol=None, dm=None):
 class Gradients(rks_grad.Gradients):
     from gpu4pyscf.lib.utils import to_gpu, device
 
-    _keys = df_rks_grad.Gradients._keys
-    __init__ = df_rks_grad.Gradients.__init__
+    _keys = {'with_df', 'auxbasis_response'}
+
+    def __init__(self, mf):
+        rks_grad.Gradients.__init__(self, mf)
+
+    # Whether to include the response of DF auxiliary basis when computing
+    # nuclear gradients of J/K matrices
+    auxbasis_response = True
 
     get_jk = df_rhf_grad.Gradients.get_jk
     grad_elec = df_rhf_grad.Gradients.grad_elec

--- a/gpu4pyscf/df/grad/uhf.py
+++ b/gpu4pyscf/df/grad/uhf.py
@@ -266,12 +266,12 @@ class Gradients(uhf_grad.Gradients):
     _keys = {'with_df', 'auxbasis_response'}
 
     def __init__(self, mf):
-        # Whether to include the response of DF auxiliary basis when computing
-        # nuclear gradients of J/K matrices
-        self.auxbasis_response = True
         self._keys = self._keys.union(['auxbasis_response'])
         uhf_grad.Gradients.__init__(self, mf)
 
+    # Whether to include the response of DF auxiliary basis when computing
+    # nuclear gradients of J/K matrices
+    auxbasis_response = True
     get_jk = get_jk
 
     # TODO: finish these two functions

--- a/gpu4pyscf/df/grad/uks.py
+++ b/gpu4pyscf/df/grad/uks.py
@@ -140,11 +140,11 @@ class Gradients(uks_grad.Gradients):
     _keys = {'with_df', 'auxbasis_response'}
 
     def __init__(self, mf):
-        # Whether to include the response of DF auxiliary basis when computing
-        # nuclear gradients of J/K matrices
-        self.auxbasis_response = True
         uks_grad.Gradients.__init__(self, mf)
 
+    # Whether to include the response of DF auxiliary basis when computing
+    # nuclear gradients of J/K matrices
+    auxbasis_response = True
     get_jk = get_jk
 
     def get_j(self, mol=None, dm=None, hermi=0, mo_coeff=None, mo_occ=None, dm2 = None, omega=None):

--- a/gpu4pyscf/df/hessian/rhf.py
+++ b/gpu4pyscf/df/hessian/rhf.py
@@ -580,9 +580,9 @@ class Hessian(rhf_hess.Hessian):
 
     from gpu4pyscf.lib.utils import to_gpu, device
     def __init__(self, mf):
-        self.auxbasis_response = 1
         rhf_hess.Hessian.__init__(self, mf)
 
+    auxbasis_response = 1
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
     kernel = rhf_hess.kernel

--- a/gpu4pyscf/df/hessian/rks.py
+++ b/gpu4pyscf/df/hessian/rks.py
@@ -111,9 +111,9 @@ class Hessian(rks_hess.Hessian):
     from gpu4pyscf.lib.utils import to_gpu, device
 
     def __init__(self, mf):
-        self.auxbasis_response = 1
         rks_hess.Hessian.__init__(self, mf)
 
+    auxbasis_response = 1
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
     kernel = rhf_hess.kernel

--- a/gpu4pyscf/df/hessian/uhf.py
+++ b/gpu4pyscf/df/hessian/uhf.py
@@ -687,9 +687,9 @@ class Hessian(uhf_hess.Hessian):
     from gpu4pyscf.lib.utils import to_gpu, device
 
     def __init__(self, mf):
-        self.auxbasis_response = 1
         uhf_hess.Hessian.__init__(self, mf)
 
+    auxbasis_response = 1
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
     kernel = rhf_hess.kernel

--- a/gpu4pyscf/df/hessian/uks.py
+++ b/gpu4pyscf/df/hessian/uks.py
@@ -123,7 +123,6 @@ class Hessian(uks_hess.Hessian):
     from gpu4pyscf.lib.utils import to_gpu, device
 
     def __init__(self, mf):
-        self.auxbasis_response = 1
         uks_hess.Hessian.__init__(self, mf)
 
     def solve_mo1(self, mo_energy, mo_coeff, mo_occ, h1ao_or_chkfile,
@@ -131,6 +130,7 @@ class Hessian(uks_hess.Hessian):
         return uhf_hess.solve_mo1(self.base, mo_energy, mo_coeff, mo_occ, h1ao_or_chkfile,
                          fx, atmlst, max_memory, verbose)
 
+    auxbasis_response = 1
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
     hess_elec = uhf_hess.hess_elec

--- a/gpu4pyscf/grad/dispersion.py
+++ b/gpu4pyscf/grad/dispersion.py
@@ -46,8 +46,6 @@ def get_dispersion(mf_grad, disp_version=None):
         from gpu4pyscf.lib import dftd4
         dftd4_model = dftd4.DFTD4Dispersion(mol, xc=method)
         res = dftd4_model.get_dispersion(grad=True)
-        print(method, disp_version)
-        print(res.get("gradient"))
         return res.get("gradient")
     else:
         raise RuntimeError(f'dispersion correction: {disp_version} is not supported.')

--- a/gpu4pyscf/grad/rhf.py
+++ b/gpu4pyscf/grad/rhf.py
@@ -547,8 +547,8 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     if log.verbose >= logger.DEBUG:
         log.timer_debug1('gradients of electronic part', *t0)
 
-    # net force should be zero
-    de -= cupy.sum(de, axis=0)/len(atmlst)
+    ## net force should be zero
+    #de -= cupy.sum(de, axis=0)/len(atmlst)
     return de.get()
 
 def get_grad_hcore(mf_grad, mo_coeff=None, mo_occ=None):

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -514,7 +514,6 @@ class Gradients(rhf_grad.Gradients):
         rhf_grad.Gradients.__init__(self, mf)
         self.grids = None
         self.nlcgrids = None
-        self.grid_response = False
 
     get_veff = _get_veff
     # TODO: add grid response into this function

--- a/gpu4pyscf/lib/tests/test_to_gpu.py
+++ b/gpu4pyscf/lib/tests/test_to_gpu.py
@@ -69,7 +69,7 @@ class KnownValues(unittest.TestCase):
         mf = rks.RKS(mol).run()
         gobj = mf.nuc_grad_method().to_gpu()
         g = gobj.kernel()
-        assert numpy.abs(lib.fp(g) - -0.04339987221752033) < 1e-7
+        assert numpy.abs(lib.fp(g) - -0.04340162663176693) < 1e-7
 
         # RKS Hessian it not supported yet
         # mf = rks.RKS(mol).run()
@@ -102,7 +102,7 @@ class KnownValues(unittest.TestCase):
         mf = rks.RKS(mol, xc='b3lyp').density_fit().run()
         gobj = mf.nuc_grad_method().to_gpu()
         g = gobj.kernel()
-        assert numpy.abs(lib.fp(g) - -0.04079190644707999) < 1e-7
+        assert numpy.abs(lib.fp(g) - -0.04079319540057938) < 1e-5
 
         mf = rks.RKS(mol, xc='b3lyp').density_fit().run()
         mf.conv_tol_cpscf = 1e-7
@@ -119,8 +119,7 @@ class KnownValues(unittest.TestCase):
         mf = rks.RKS(mol, xc='wb97x').density_fit().run()
         gobj = mf.nuc_grad_method().to_gpu()
         g = gobj.kernel()
-        g -= g.sum(axis=0)/len(g)
-        assert numpy.abs(lib.fp(g) - -0.034343799164131) < 1e-5
+        assert numpy.abs(lib.fp(g) - -0.03432881437746617) < 1e-5
 
         mf = rks.RKS(mol, xc='wb97x').density_fit().run()
         mf.conv_tol_cpscf = 1e-7


### PR DESCRIPTION
- Use the same linear dependence threshold in DF as PySCF.
- Move `auxbasis_response` out of `__init__`.
- Remove enforcing translational symmetry in gradient