### PR TITLE
add skipping SCF cycles

### DIFF
--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -177,6 +177,14 @@ def _kernel(mf, conv_tol=1e-10, conv_tol_grad=None,
     logger.info(mf, 'init E= %.15g', e_tot)
     t1 = log.timer_debug1('total prep', *t0)
     scf_conv = False
+
+    # Skip SCF iterations. Compute only the total energy of the initial density
+    if mf.max_cycle <= 0:
+        fock = mf.get_fock(h1e, s1e, vhf, dm)  # = h1e + vhf, no DIIS
+        mo_energy, mo_coeff = mf.eig(fock, s1e)
+        mo_occ = mf.get_occ(mo_energy, mo_coeff)
+        return scf_conv, e_tot, mo_energy, mo_coeff, mo_occ
+
     if isinstance(mf.diis, lib.diis.DIIS):
         mf_diis = mf.diis
     elif mf.diis:


### PR DESCRIPTION
`max_cycles<=0` in `gpu4pyscf.scf` is now handled analogously to PySCF, _i.e._ the SCF cycles are skipped and initial density is used for all quantities.