### PR TITLE
Refactor _VHFOpt and _GDFTOpt

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,7 +24,7 @@ jobs:
         pip3 config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
         python3 -m pip install --upgrade pip
         pip3 install flake8 pytest coverage pytest-cov pyscf-dispersion
-        pip3 install "pyscf>2.5"
+        pip3 install pyscf --upgrade
         pip3 install numpy --upgrade
         pip3 install h5py --upgrade
         pip3 install gpu4pyscf-libxc-cuda12x --upgrade

--- a/gpu4pyscf/df/df.py
+++ b/gpu4pyscf/df/df.py
@@ -91,7 +91,7 @@ class DF(lib.StreamObject):
         log.timer_debug1('prepare intopt', *t0)
         self.j2c = j2c.copy()
 
-        j2c = take_last2d(j2c, intopt.aux_ao_idx)
+        j2c = intopt.sort_orbitals(j2c, aux_axis=[0,1])
         try:
             self.cd_low = cholesky(j2c)
             self.cd_low = tag_array(self.cd_low, tag='cd')

--- a/gpu4pyscf/df/df_jk.py
+++ b/gpu4pyscf/df/df_jk.py
@@ -268,11 +268,11 @@ def get_jk(dfobj, dms_tag, hermi=0, with_j=True, with_k=True, direct_scf_tol=1e-
 
     assert nao == dfobj.nao
     vj = vk = None
-    ao_idx = dfobj.intopt.ao_idx
-    dms = take_last2d(dms, ao_idx)
+    intopt = dfobj.intopt
+    dms = intopt.sort_orbitals(dms, axis=[1,2])
     dms_shape = dms.shape
-    rows = dfobj.intopt.cderi_row
-    cols = dfobj.intopt.cderi_col
+    rows = intopt.cderi_row
+    cols = intopt.cderi_col
 
     if with_j:
         dm_sparse = dms[:,rows,cols]
@@ -280,7 +280,7 @@ def get_jk(dfobj, dms_tag, hermi=0, with_j=True, with_k=True, direct_scf_tol=1e-
             dm_sparse += dms[:,cols,rows]
         else:
             dm_sparse *= 2
-        dm_sparse[:, dfobj.intopt.cderi_diag] *= .5
+        dm_sparse[:, intopt.cderi_diag] *= .5
 
     if with_k:
         vk = cupy.zeros_like(dms)
@@ -293,11 +293,12 @@ def get_jk(dfobj, dms_tag, hermi=0, with_j=True, with_k=True, direct_scf_tol=1e-
         nmo = mo_occ.shape[-1]
         mo_coeff = mo_coeff.reshape(-1,nao,nmo)
         mo_occ   = mo_occ.reshape(-1,nmo)
+        mo_coeff = intopt.sort_orbitals(mo_coeff, axis=[1])
         nocc = 0
         occ_coeff = [0]*nset
         for i in range(nset):
             occ_idx = mo_occ[i] > 0
-            occ_coeff[i] = mo_coeff[i][:,occ_idx][ao_idx] * mo_occ[i][occ_idx]**0.5
+            occ_coeff[i] = mo_coeff[i][:,occ_idx] * mo_occ[i][occ_idx]**0.5
             nocc += mo_occ[i].sum()
         blksize = dfobj.get_blksize(extra=nao*nocc)
         if with_j:
@@ -330,8 +331,8 @@ def get_jk(dfobj, dms_tag, hermi=0, with_j=True, with_k=True, direct_scf_tol=1e-
         if not isinstance(mo1s, (tuple, list)):
             mo1s = [mo1s]
 
-        occ_coeffs = [occ_coeff[ao_idx] for occ_coeff in occ_coeffs]
-        mo1s = [mo1[:,ao_idx] for mo1 in mo1s]
+        occ_coeffs = [intopt.sort_orbitals(occ_coeff, axis=[0]) for occ_coeff in occ_coeffs]
+        mo1s = [intopt.sort_orbitals(mo1, axis=[1]) for mo1 in mo1s]
 
         if with_j:
             vj_sparse = cupy.zeros_like(dm_sparse)
@@ -383,12 +384,11 @@ def get_jk(dfobj, dms_tag, hermi=0, with_j=True, with_k=True, direct_scf_tol=1e-
             vj[:,cols,rows] = vj_sparse
         rhok = None
 
-    rev_ao_idx = dfobj.intopt.rev_ao_idx
     if with_j:
-        vj = take_last2d(vj, rev_ao_idx)
+        vj = intopt.unsort_orbitals(vj, axis=[1,2])
         vj = vj.reshape(out_shape)
     if with_k:
-        vk = take_last2d(vk, rev_ao_idx)
+        vk = intopt.unsort_orbitals(vk, axis=[1,2])
         vk = vk.reshape(out_shape)
     t1 = log.timer_debug1('vj and vk', *t1)
     if out_cupy:

--- a/gpu4pyscf/df/grad/rhf.py
+++ b/gpu4pyscf/df/grad/rhf.py
@@ -17,7 +17,7 @@ import copy
 import numpy
 import cupy
 from cupyx.scipy.linalg import solve_triangular
-from pyscf import scf
+from pyscf import scf, gto
 from gpu4pyscf.df import int3c2e, df
 from gpu4pyscf.lib.cupy_helper import (print_mem_info, tag_array,
 unpack_tril, contract, load_library, take_last2d, cholesky)
@@ -88,11 +88,11 @@ def get_jk(mf_grad, mol=None, dm0=None, hermi=0, with_j=True, with_k=True, omega
         raise NotImplementedError()
     mo_coeff = cupy.asarray(mf_grad.base.mo_coeff)
     mo_occ = cupy.asarray(mf_grad.base.mo_occ)
-    ao_idx = intopt.ao_idx
 
-    dm = take_last2d(dm0, ao_idx)
+    dm = intopt.sort_orbitals(dm0, axis=[0,1])
     orbo = mo_coeff[:,mo_occ>0] * mo_occ[mo_occ>0] ** 0.5
-    orbo = orbo[ao_idx, :]
+    mo_coeff = None
+    orbo = intopt.sort_orbitals(orbo, axis=[0])
     nocc = orbo.shape[-1]
 
     # (L|ij) -> rhoj: (L), rhok: (L|oo)
@@ -126,8 +126,7 @@ def get_jk(mf_grad, mol=None, dm0=None, hermi=0, with_j=True, with_k=True, omega
     else:
         int2c_e1 = auxmol.intor('int2c2e_ip1')
     int2c_e1 = cupy.asarray(int2c_e1)
-    aux_ao_idx = intopt.aux_ao_idx
-    rev_aux_idx = numpy.argsort(aux_ao_idx)
+
     auxslices = auxmol.aoslice_by_atom()
     aux_cart2sph = intopt.aux_cart2sph
     low_t = low.T.copy()
@@ -141,7 +140,8 @@ def get_jk(mf_grad, mol=None, dm0=None, hermi=0, with_j=True, with_k=True, omega
             rhoj_cart = contract('pq,q->p', aux_cart2sph, rhoj)
         else:
             rhoj_cart = rhoj
-        rhoj = rhoj[rev_aux_idx]
+
+        rhoj = intopt.unsort_orbitals(rhoj, aux_axis=[0])
         tmp = contract('xpq,q->xp', int2c_e1, rhoj)
         vjaux = -contract('xp,p->xp', tmp, rhoj)
         vjaux_2c = cupy.array([-vjaux[:,p0:p1].sum(axis=1) for p0, p1 in auxslices[:,2:]])
@@ -153,7 +153,7 @@ def get_jk(mf_grad, mol=None, dm0=None, hermi=0, with_j=True, with_k=True, omega
             #rhok = solve_triangular(low_t, rhok, lower=False)
             rhok = solve_triangular(low_t, rhok.reshape(naux, -1), lower=False, overwrite_b=True).reshape(naux, nocc, nocc)
         tmp = contract('pij,qij->pq', rhok, rhok)
-        tmp = take_last2d(tmp, rev_aux_idx)
+        tmp = intopt.unsort_orbitals(tmp, aux_axis=[0,1])
         vkaux = -contract('xpq,pq->xp', int2c_e1, tmp)
         vkaux_2c = cupy.array([-vkaux[:,p0:p1].sum(axis=1) for p0, p1 in auxslices[:,2:]])
         vkaux = tmp = None
@@ -166,26 +166,25 @@ def get_jk(mf_grad, mol=None, dm0=None, hermi=0, with_j=True, with_k=True, omega
     t0 = log.timer_debug1('rhoj and rhok', *t0)
     int2c_e1 = None
 
-    nao_cart = intopt.mol.nao
+    nao_cart = intopt._sorted_mol.nao
     block_size = with_df.get_blksize(nao=nao_cart)
 
     intopt = int3c2e.VHFOpt(mol, auxmol, 'int2e')
     intopt.build(mf.direct_scf_tol, diag_block_with_triu=True, aosym=False,
                  group_size_aux=block_size)#, group_size=block_size)
-    if not intopt._mol.cart:
+    dm_cart = dm
+    orbo_cart = orbo
+    if not mol.cart:
         # sph2cart for ao
         cart2sph = intopt.cart2sph
         orbo_cart = cart2sph @ orbo
         dm_cart = cart2sph @ dm @ cart2sph.T
-    else:
-        dm_cart = dm
-        orbo_cart = orbo
-    dm = orbo = None
 
+    dm = orbo = None
     vj = vk = rhoj_tmp = rhok_tmp = None
     vjaux = vkaux = None
 
-    naux_cart = intopt.auxmol.nao
+    naux_cart = intopt._sorted_auxmol.nao
     if with_j:
         vj = cupy.zeros((3,nao_cart), order='C')
         vjaux = cupy.zeros((3,naux_cart))
@@ -193,8 +192,8 @@ def get_jk(mf_grad, mol=None, dm0=None, hermi=0, with_j=True, with_k=True, omega
         vk = cupy.zeros((3,nao_cart), order='C')
         vkaux = cupy.zeros((3,naux_cart))
     cupy.get_default_memory_pool().free_all_blocks()
+    t1 = log.init_timer()
     for cp_kl_id in range(len(intopt.aux_log_qs)):
-        t1 = log.init_timer()
         k0, k1 = intopt.cart_aux_loc[cp_kl_id], intopt.cart_aux_loc[cp_kl_id+1]
         assert k1-k0 <= block_size
         if with_j:
@@ -233,33 +232,36 @@ def get_jk(mf_grad, mol=None, dm0=None, hermi=0, with_j=True, with_k=True, omega
 
         rhoj_tmp = rhok_tmp = vj_tmp = vk_tmp = None
         t1 = log.timer_debug1(f'calculate {cp_kl_id:3d} / {len(intopt.aux_log_qs):3d}, {k1-k0:3d} slices', *t1)
-
-    # vj and vk are still in cartesian
-    cart_ao_idx = intopt.cart_ao_idx
-    rev_cart_ao_idx = numpy.argsort(cart_ao_idx)
-    aoslices = intopt.mol.aoslice_by_atom()
+    
+    # NOTE: vj and vk are still in cartesian
+    _sorted_mol = intopt._sorted_mol
+    natm = _sorted_mol.natm
+    ao2atom = numpy.zeros([nao_cart, natm])
+    ao_loc = _sorted_mol.ao_loc
+    for ibas, iatm in enumerate(_sorted_mol._bas[:,gto.ATOM_OF]):
+        ao2atom[ao_loc[ibas]:ao_loc[ibas+1],iatm] = 1
+    ao2atom = cupy.asarray(ao2atom)
     if with_j:
-        vj = vj[:, rev_cart_ao_idx]
-        vj = [-vj[:,p0:p1].sum(axis=1) for p0, p1 in aoslices[:,2:]]
-        vj = cupy.asarray(vj)
+        vj = -ao2atom.T @ vj.T
     if with_k:
-        vk = vk[:, rev_cart_ao_idx]
-        vk = [-vk[:,p0:p1].sum(axis=1) for p0, p1 in aoslices[:,2:]]
-        vk = cupy.asarray(vk)
+        vk = -ao2atom.T @ vk.T
     t0 = log.timer_debug1('(di,j|P) and (i,j|dP)', *t0)
-    cart_aux_idx = intopt.cart_aux_idx
-    rev_cart_aux_idx = numpy.argsort(cart_aux_idx)
-    auxslices = intopt.auxmol.aoslice_by_atom()
 
+    _sorted_auxmol = intopt._sorted_auxmol
+    natm = _sorted_auxmol.natm
+    aux2atom = numpy.zeros([naux_cart, natm])
+    ao_loc = _sorted_auxmol.ao_loc
+    for ibas, iatm in enumerate(_sorted_auxmol._bas[:,gto.ATOM_OF]):
+        aux2atom[ao_loc[ibas]:ao_loc[ibas+1],iatm] = 1
+    aux2atom = cupy.asarray(aux2atom)
     if with_j:
-        vjaux = vjaux[:, rev_cart_aux_idx]
-        vjaux_3c = cupy.asarray([-vjaux[:,p0:p1].sum(axis=1) for p0, p1 in auxslices[:,2:]])
-        vjaux = vjaux_2c + vjaux_3c
+        vjaux_3c = aux2atom.T @ vjaux.T
+        vjaux = vjaux_2c - vjaux_3c
 
     if with_k:
-        vkaux = vkaux[:, rev_cart_aux_idx]
-        vkaux_3c = cupy.asarray([-vkaux[:,p0:p1].sum(axis=1) for p0, p1 in auxslices[:,2:]])
-        vkaux = vkaux_2c + vkaux_3c
+        vkaux_3c = aux2atom.T @ vkaux.T
+        vkaux = vkaux_2c - vkaux_3c
+    
     return vj, vk, vjaux, vkaux
 
 

--- a/gpu4pyscf/df/hessian/uhf.py
+++ b/gpu4pyscf/df/hessian/uhf.py
@@ -100,23 +100,23 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     # ================================ sorted AO begin ===============================================
     intopt = int3c2e.VHFOpt(mol, auxmol, 'int2e')
     intopt.build(mf.direct_scf_tol, diag_block_with_triu=True, aosym=False, group_size=BLKSIZE, group_size_aux=BLKSIZE)
-    ao_idx = intopt.ao_idx
-    aux_ao_idx = intopt.aux_ao_idx
 
-    mocca = mocca[ao_idx, :]
-    moccb = moccb[ao_idx, :]
-    dm0a = take_last2d(dm0a, ao_idx)
-    dm0b = take_last2d(dm0b, ao_idx)
+    mocca = intopt.sort_orbitals(mocca, axis=[0])
+    moccb = intopt.sort_orbitals(moccb, axis=[0])
+    dm0a = intopt.sort_orbitals(dm0a, axis=[0,1])
+    dm0b = intopt.sort_orbitals(dm0b, axis=[0,1])
+
     dm0a_tag = tag_array(dm0a, occ_coeff=mocca)
     dm0b_tag = tag_array(dm0b, occ_coeff=moccb)
     int2c = cupy.asarray(int2c, order='C')
-    int2c = take_last2d(int2c, aux_ao_idx)
+    int2c = intopt.sort_orbitals(int2c, aux_axis=[0,1])
+
     int2c_inv = pinv(int2c, lindep=LINEAR_DEP_THR)
     solve_j2c = _gen_metric_solver(int2c)
     int2c = None
 
     int2c_ip1 = cupy.asarray(int2c_ip1, order='C')
-    int2c_ip1 = take_last2d(int2c_ip1, aux_ao_idx)
+    int2c_ip1 = intopt.sort_orbitals(int2c_ip1, aux_axis=[1,2])
 
     hj_ao_ao = cupy.zeros([nao,nao,3,3])
     hk_ao_ao = cupy.zeros([nao,nao,3,3])
@@ -272,7 +272,7 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
         else:
             int2c_ipip1 = auxmol.intor('int2c2e_ipip1', aosym='s1')
         int2c_ipip1 = cupy.asarray(int2c_ipip1, order='C')
-        int2c_ipip1 = take_last2d(int2c_ipip1, aux_ao_idx)
+        int2c_ipip1 = intopt.sort_orbitals(int2c_ipip1, aux_axis=[1,2])
         rhoj2c_P = contract('xpq,q->xp', int2c_ipip1, rhoj0_P)
         # (00|0)(2|0)(0|00)
         # p,xp->px
@@ -289,7 +289,7 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
         else:
             int2c_ip1ip2 = auxmol.intor('int2c2e_ip1ip2', aosym='s1')
         int2c_ip1ip2 = cupy.asarray(int2c_ip1ip2, order='C')
-        int2c_ip1ip2 = take_last2d(int2c_ip1ip2, aux_ao_idx)
+        int2c_ip1ip2 = intopt.sort_orbitals(int2c_ip1ip2, aux_axis=[1,2])
         hj_aux_aux = -.5 * contract('p,xpq->pqx', rhoj0_P, int2c_ip1ip2*rhoj0_P).reshape(naux, naux,3,3)
         if with_k:
             hk_aux_aux = -.5 * contract('xpq,pq->pqx', int2c_ip1ip2, rho2c_0).reshape(naux,naux,3,3)
@@ -349,32 +349,23 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
             rho2c_10= int2c_ip1_inv = None
     t1 = log.timer_debug1('contract int2c_*', *t1)
 
-    ao_idx = np.argsort(intopt.ao_idx)
-    aux_idx = np.argsort(intopt.aux_ao_idx)
-    rev_ao_ao = cupy.ix_(ao_idx, ao_idx)
-    #dm0 = dm0[rev_ao_ao]
-    hj_ao_diag = hj_ao_diag[ao_idx]
-    hj_ao_ao = hj_ao_ao[rev_ao_ao]
+    hj_ao_diag = intopt.unsort_orbitals(hj_ao_diag, axis=[0])
+    hj_ao_ao = intopt.unsort_orbitals(hj_ao_ao, axis=[0,1])
     if hessobj.auxbasis_response:
-        rev_ao_aux = cupy.ix_(ao_idx, aux_idx)
-        hj_ao_aux = hj_ao_aux[rev_ao_aux]
+        hj_ao_aux = intopt.unsort_orbitals(hj_ao_aux, axis=[0], aux_axis=[1])
     if hessobj.auxbasis_response > 1:
-        rev_aux_aux = cupy.ix_(aux_idx, aux_idx)
-        hj_aux_diag = hj_aux_diag[aux_idx]
-        hj_aux_aux = hj_aux_aux[rev_aux_aux]
-
+        hj_aux_diag = intopt.unsort_orbitals(hj_aux_diag, aux_axis=[0])
+        hj_aux_aux = intopt.unsort_orbitals(hj_aux_aux, aux_axis=[0,1])
     if with_k:
-        hk_ao_diag = hk_ao_diag[ao_idx]
-        hk_ao_ao = hk_ao_ao[rev_ao_ao]
+        hk_ao_diag = intopt.unsort_orbitals(hk_ao_diag, axis=[0])
+        hk_ao_ao = intopt.unsort_orbitals(hk_ao_ao, axis=[0,1])
         if hessobj.auxbasis_response:
-            hk_ao_aux = hk_ao_aux[rev_ao_aux]
+            hk_ao_aux = intopt.unsort_orbitals(hk_ao_aux, axis=[0], aux_axis=[1])
         if hessobj.auxbasis_response > 1:
-            hk_aux_diag = hk_aux_diag[aux_idx]
-            hk_aux_aux = hk_aux_aux[rev_aux_aux]
-
-    mocca = mocca[ao_idx]
-    moccb = moccb[ao_idx]
-
+            hk_aux_diag = intopt.unsort_orbitals(hk_aux_diag, aux_axis=[0])
+            hk_aux_aux = intopt.unsort_orbitals(hk_aux_aux, aux_axis=[0,1])
+    mocca = intopt.unsort_orbitals(mocca, axis=[0])
+    moccb = intopt.unsort_orbitals(moccb, axis=[0])
     #======================================== sort AO end ===========================================
     # Energy weighted density matrix
     # pi,qi,i->pq
@@ -517,17 +508,15 @@ def _gen_jk(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None,
                  aosym=False, 
                  group_size_aux=BLKSIZE, 
                  group_size=BLKSIZE)
-    ao_idx = intopt.ao_idx
-    aux_ao_idx = intopt.aux_ao_idx
-
-    mocca = mocca[ao_idx, :]
-    moccb = moccb[ao_idx, :]
-    mo_coeff = mo_coeff[:, ao_idx,:]
-    dm0a = take_last2d(dm0a, ao_idx)
-    dm0b = take_last2d(dm0b, ao_idx)
+    
+    mocca = intopt.sort_orbitals(mocca, axis=[0])
+    moccb = intopt.sort_orbitals(moccb, axis=[0])
+    mo_coeff = intopt.sort_orbitals(mo_coeff, axis=[1])
+    dm0a = intopt.sort_orbitals(dm0a, axis=[0,1])
+    dm0b = intopt.sort_orbitals(dm0b, axis=[0,1])
     dm0 = dm0a + dm0b
 
-    int2c = take_last2d(int2c, aux_ao_idx)
+    int2c = intopt.sort_orbitals(int2c, aux_axis=[0,1])
     solve_j2c = _gen_metric_solver(int2c)
     int2c = None
 
@@ -567,10 +556,10 @@ def _gen_jk(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None,
     vj1_buf, vk1a_buf, vj1a_ao, vk1a_ao = fn(intopt, rhoj0, rhok0a_Pl_, dm0_tag, aoslices, omega=omega)
     dm0_tag = tag_array(dm0, occ_coeff=moccb)
     vj1_buf, vk1b_buf, vj1b_ao, vk1b_ao = fn(intopt, rhoj0, rhok0b_Pl_, dm0_tag, aoslices, omega=omega)
-    rev_ao_idx = np.argsort(ao_idx)
-    vj1_buf = take_last2d(vj1_buf, rev_ao_idx)
-    vk1a_buf = take_last2d(vk1a_buf, rev_ao_idx)
-    vk1b_buf = take_last2d(vk1b_buf, rev_ao_idx)
+
+    vj1_buf = intopt.unsort_orbitals(vj1_buf, axis=[1,2])
+    vk1a_buf = intopt.unsort_orbitals(vk1a_buf, axis=[1,2])
+    vk1b_buf = intopt.unsort_orbitals(vk1b_buf, axis=[1,2])
 
     vj1a_int3c = -contract('nxiq,ip->nxpq', vj1a_ao, mo_coeff[0])
     vj1b_int3c = -contract('nxiq,ip->nxpq', vj1b_ao, mo_coeff[1])
@@ -597,13 +586,13 @@ def _gen_jk(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None,
         else:
             int2c_ip1 = auxmol.intor('int2c2e_ip1', aosym='s1')
         int2c_ip1 = cupy.asarray(int2c_ip1, order='C')
-        int2c_ip1 = take_last2d(int2c_ip1, aux_ao_idx)
+        int2c_ip1 = intopt.sort_orbitals(int2c_ip1, aux_axis=[1,2])
 
         # generate rhok0_P__
         if isinstance(rhok0a_Pl_, cupy.ndarray):
             rhok0a_P__ = contract('pio,ir->pro', rhok0a_Pl_, mocca)
         else:
-            naux = len(aux_ao_idx)
+            naux = auxmol.nao
             nocc = mocca.shape[1]
             rhok0a_P__ = cupy.empty([naux,nocc,nocc])
             for p0, p1 in lib.prange(0,naux,64):
@@ -615,7 +604,7 @@ def _gen_jk(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None,
         if isinstance(rhok0b_Pl_, cupy.ndarray):
             rhok0b_P__ = contract('pio,ir->pro', rhok0b_Pl_, moccb)
         else:
-            naux = len(aux_ao_idx)
+            naux = auxmol.nao
             nocc = moccb.shape[1]
             rhok0b_P__ = cupy.empty([naux,nocc,nocc])
             for p0, p1 in lib.prange(0,naux,64):
@@ -670,9 +659,9 @@ def _gen_jk(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None,
         vk1a_int3c_ip2 = vk1b_int3c_ip2 = None
         t0 = log.timer_debug1('Fock matrix due to int3c2e_ip2', *t0)
 
-    mocca = mocca[rev_ao_idx]
-    moccb = moccb[rev_ao_idx]
-    mo_coeff = mo_coeff[:,rev_ao_idx]
+    mocca = intopt.unsort_orbitals(mocca, axis=[0])
+    moccb = intopt.unsort_orbitals(moccb, axis=[0])
+    mo_coeff = intopt.unsort_orbitals(mo_coeff, axis=[1])
     release_gpu_stack()
 
     # ========================== sorted AO end ================================

--- a/gpu4pyscf/df/int3c2e.py
+++ b/gpu4pyscf/df/int3c2e.py
@@ -66,17 +66,17 @@ class VHFOpt(_vhf.VHFOpt):
                  qcondname='CVHFsetnr_direct_scf', dmcondname=None):
         # use local basis_seg_contraction for efficiency
         # TODO: switch _mol and mol
-        self.mol = basis_seg_contraction(mol,allow_replica=True)
-        self.auxmol = basis_seg_contraction(auxmol, allow_replica=True)
-        self._mol = mol
-        self._auxmol = auxmol
+        self._mol_ = mol            # original mol
+        self._auxmol_ = auxmol      # original auxiliary mol
+        self._sorted_mol = None     # sorted mol
+        self._sorted_auxmol = None  # sorted auxilary mol
 
+        self.ao_idx = None
+        self.aux_ao_idx = None
         '''
         # Note mol._bas will be sorted in .build() method. VHFOpt should be
         # initialized after mol._bas updated.
         '''
-        self.nao = self.mol.nao
-        self.naux = self.auxmol.nao
 
         self._intor = intor
         self._prescreen = prescreen
@@ -85,10 +85,10 @@ class VHFOpt(_vhf.VHFOpt):
 
         self.bpcache = None
 
-        self.cart_ao_idx = None
-        self.sph_ao_idx = None
-        self.cart_aux_idx = None
-        self.sph_aux_idx = None
+        #self.cart_ao_idx = None
+        #self.sph_ao_idx = None
+        #self.cart_aux_idx = None
+        #self.sph_aux_idx = None
 
         self.cart_ao_loc = []
         self.cart_aux_loc = []
@@ -128,14 +128,16 @@ class VHFOpt(_vhf.VHFOpt):
         a tot_mol is created with concatenating [mol, fake_mol, aux_mol]
         we will pair (ao,ao) and (aux,1) separately.
         '''
-        _mol = self._mol
-        _auxmol = self._auxmol
-        mol = self.mol
-        auxmol = self.auxmol
+        _mol = self._mol_
+        _auxmol = self._auxmol_
 
+        mol = basis_seg_contraction(_mol,allow_replica=True)
+        auxmol = basis_seg_contraction(_auxmol, allow_replica=True)
+        
         log = logger.new_logger(_mol, _mol.verbose)
         cput0 = log.init_timer()
-        sorted_mol, sorted_idx, uniq_l_ctr, l_ctr_counts = sort_mol(mol, log=log)
+        _sorted_mol, sorted_idx, uniq_l_ctr, l_ctr_counts = sort_mol(mol, log=log)
+
         if group_size is not None :
             uniq_l_ctr, l_ctr_counts = _split_l_ctr_groups(uniq_l_ctr, l_ctr_counts, group_size)
         self.nctr = len(uniq_l_ctr)
@@ -145,16 +147,16 @@ class VHFOpt(_vhf.VHFOpt):
         _, _, fake_uniq_l_ctr, fake_l_ctr_counts = sort_mol(fake_mol, log=log)
 
         # sort auxiliary mol
-        sorted_auxmol, sorted_aux_idx, aux_uniq_l_ctr, aux_l_ctr_counts = sort_mol(auxmol, log=log)
+        _sorted_auxmol, sorted_aux_idx, aux_uniq_l_ctr, aux_l_ctr_counts = sort_mol(auxmol, log=log)
         if group_size_aux is not None:
             aux_uniq_l_ctr, aux_l_ctr_counts = _split_l_ctr_groups(aux_uniq_l_ctr, aux_l_ctr_counts, group_size_aux)
-
-        tot_mol = sorted_mol + fake_mol + sorted_auxmol
-        tot_mol.cart = True
-        self.tot_mol = tot_mol
+        
+        _tot_mol = _sorted_mol + fake_mol + _sorted_auxmol
+        _tot_mol.cart = True
+        self._tot_mol = _tot_mol
 
         # Initialize vhfopt after reordering mol._bas
-        _vhf.VHFOpt.__init__(self, sorted_mol, self._intor, self._prescreen,
+        _vhf.VHFOpt.__init__(self, _sorted_mol, self._intor, self._prescreen,
                              self._qcondname, self._dmcondname)
         self.direct_scf_tol = cutoff
 
@@ -169,32 +171,19 @@ class VHFOpt(_vhf.VHFOpt):
         cput1 = log.timer_debug1('Get pairing', *cput1)
 
         # contraction coefficient for ao basis
-        cart_ao_loc = sorted_mol.ao_loc_nr(cart=True)
-        sph_ao_loc = sorted_mol.ao_loc_nr(cart=False)
+        cart_ao_loc = _sorted_mol.ao_loc_nr(cart=True)
+        sph_ao_loc = _sorted_mol.ao_loc_nr(cart=False)
         self.cart_ao_loc = [cart_ao_loc[cp] for cp in l_ctr_offsets]
         self.sph_ao_loc = [sph_ao_loc[cp] for cp in l_ctr_offsets]
         self.angular = [l[0] for l in uniq_l_ctr]
 
-        cart_ao_loc = mol.ao_loc_nr(cart=True)
-        sph_ao_loc = mol.ao_loc_nr(cart=False)
-        nao = sph_ao_loc[-1]
-        ao_idx = np.array_split(np.arange(nao), sph_ao_loc[1:-1])
-        self.sph_ao_idx = np.hstack([ao_idx[i] for i in sorted_idx])
+        # Sorted AO indices
+        ao_loc = mol.ao_loc_nr(cart=_mol.cart)
+        ao_idx = np.array_split(np.arange(_mol.nao), ao_loc[1:-1])
+        self.ao_idx = np.hstack([ao_idx[i] for i in sorted_idx])
 
         # cartesian ao index
-        nao = cart_ao_loc[-1]
-        ao_idx = np.array_split(np.arange(nao), cart_ao_loc[1:-1])
-        self.cart_ao_idx = np.hstack([ao_idx[i] for i in sorted_idx])
-        ncart = cart_ao_loc[-1]
-        nsph = sph_ao_loc[-1]
-        self.cart2sph = block_c2s_diag(ncart, nsph, self.angular, l_ctr_counts)
-
-        if _mol.cart:
-            inv_idx = np.argsort(self.cart_ao_idx, kind='stable').astype(np.int32)
-            self.coeff = cupy.eye(ncart)[:,inv_idx]
-        else:
-            inv_idx = np.argsort(self.sph_ao_idx, kind='stable').astype(np.int32)
-            self.coeff = self.cart2sph[:, inv_idx]
+        self.cart2sph = block_c2s_diag(self.angular, l_ctr_counts)
         cput1 = log.timer_debug1('AO cart2sph coeff', *cput1)
 
         # pairing auxiliary basis with fake basis set
@@ -203,36 +192,22 @@ class VHFOpt(_vhf.VHFOpt):
         aux_l_ctr_offsets = np.append(0, np.cumsum(aux_l_ctr_counts))
 
         # contraction coefficient for auxiliary basis
-        cart_aux_loc = sorted_auxmol.ao_loc_nr(cart=True)
-        sph_aux_loc = sorted_auxmol.ao_loc_nr(cart=False)
+        cart_aux_loc = _sorted_auxmol.ao_loc_nr(cart=True)
+        sph_aux_loc = _sorted_auxmol.ao_loc_nr(cart=False)
         self.cart_aux_loc = [cart_aux_loc[cp] for cp in aux_l_ctr_offsets]
         self.sph_aux_loc = [sph_aux_loc[cp] for cp in aux_l_ctr_offsets]
         self.aux_angular = [l[0] for l in aux_uniq_l_ctr]
 
-        cart_aux_loc = self.auxmol.ao_loc_nr(cart=True)
-        sph_aux_loc = self.auxmol.ao_loc_nr(cart=False)
-        naux = sph_aux_loc[-1]
-        ao_idx = np.array_split(np.arange(naux), sph_aux_loc[1:-1])
-        self.sph_aux_idx = np.hstack([ao_idx[i] for i in sorted_aux_idx])
+        aux_loc = _auxmol.ao_loc_nr(cart=_auxmol.cart)
+        ao_idx = np.array_split(np.arange(_auxmol.nao), aux_loc[1:-1])
+        self.aux_ao_idx = np.hstack([ao_idx[i] for i in sorted_aux_idx])
 
         # cartesian aux index
-        naux = cart_aux_loc[-1]
-        ao_idx = np.array_split(np.arange(naux), cart_aux_loc[1:-1])
-        self.cart_aux_idx = np.hstack([ao_idx[i] for i in sorted_aux_idx])
-        ncart = cart_aux_loc[-1]
-        nsph = sph_aux_loc[-1]
-        self.aux_cart2sph = block_c2s_diag(ncart, nsph, self.aux_angular, aux_l_ctr_counts)
-
-        if _auxmol.cart:
-            inv_idx = np.argsort(self.cart_aux_idx, kind='stable').astype(np.int32)
-            self.aux_coeff = cupy.eye(ncart)[:,inv_idx]
-        else:
-            inv_idx = np.argsort(self.sph_aux_idx, kind='stable').astype(np.int32)
-            self.aux_coeff = self.aux_cart2sph[:, inv_idx]
+        self.aux_cart2sph = block_c2s_diag(self.aux_angular, aux_l_ctr_counts)
         aux_l_ctr_offsets += fake_l_ctr_offsets[-1]
         cput1 = log.timer_debug1('aux cart2sph coeff', *cput1)
 
-        ao_loc = sorted_mol.ao_loc_nr(cart=_mol.cart)
+        ao_loc = _sorted_mol.ao_loc_nr(cart=_mol.cart)
         self.ao_pairs_row, self.ao_pairs_col = get_ao_pairs(pair2bra, pair2ket, ao_loc)
         cderi_row = cupy.hstack(self.ao_pairs_row)
         cderi_col = cupy.hstack(self.ao_pairs_col)
@@ -268,7 +243,7 @@ class VHFOpt(_vhf.VHFOpt):
         bas_pair2shls = np.hstack(pair2bra + pair2ket).astype(np.int32).reshape(2,-1)
         bas_pairs_locs = np.append(0, np.cumsum([x.size for x in pair2bra])).astype(np.int32)
         log_qs = log_qs + aux_log_qs
-        ao_loc = tot_mol.ao_loc_nr(cart=True)
+        ao_loc = _tot_mol.ao_loc_nr(cart=True)
         ncptype = len(log_qs)
 
         self.bpcache = ctypes.POINTER(BasisProdCache)()
@@ -278,9 +253,9 @@ class VHFOpt(_vhf.VHFOpt):
             ao_loc.ctypes.data_as(ctypes.c_void_p),
             bas_pair2shls.ctypes.data_as(ctypes.c_void_p),
             bas_pairs_locs.ctypes.data_as(ctypes.c_void_p), ctypes.c_int(ncptype),
-            tot_mol._atm.ctypes.data_as(ctypes.c_void_p), ctypes.c_int(tot_mol.natm),
-            tot_mol._bas.ctypes.data_as(ctypes.c_void_p), ctypes.c_int(tot_mol.nbas),
-            tot_mol._env.ctypes.data_as(ctypes.c_void_p))
+            _tot_mol._atm.ctypes.data_as(ctypes.c_void_p), ctypes.c_int(_tot_mol.natm),
+            _tot_mol._bas.ctypes.data_as(ctypes.c_void_p), ctypes.c_int(_tot_mol.nbas),
+            _tot_mol._env.ctypes.data_as(ctypes.c_void_p))
 
         cput1 = log.timer_debug1('Initialize GPU cache', *cput1)
         self.bas_pairs_locs = bas_pairs_locs
@@ -294,25 +269,77 @@ class VHFOpt(_vhf.VHFOpt):
 
         if _mol.cart:
             self.ao_loc = self.cart_ao_loc
-            self.ao_idx = self.cart_ao_idx
         else:
             self.ao_loc = self.sph_ao_loc
-            self.ao_idx = self.sph_ao_idx
         if _auxmol.cart:
             self.aux_ao_loc = self.cart_aux_loc
-            self.aux_ao_idx = self.cart_aux_idx
         else:
             self.aux_ao_loc = self.sph_aux_loc
-            self.aux_ao_idx = self.sph_aux_idx
 
-        self.rev_ao_idx = np.argsort(self.ao_idx, kind='stable').astype(np.int32)
-        self.ao_idx = cupy.array(self.ao_idx)
-        self.cart_ao_idx = cupy.array(self.cart_ao_idx)
-        self.sph_ao_idx = cupy.array(self.sph_ao_idx)
-        self.aux_ao_idx = cupy.array(self.aux_ao_idx)
-        self.cart_aux_idx = cupy.array(self.cart_aux_idx)
-        self.sph_aux_idx = cupy.array(self.sph_aux_idx)
-        self.rev_ao_idx = cupy.array(self.rev_ao_idx)
+        self._sorted_mol = _sorted_mol
+        self._sorted_auxmol = _sorted_auxmol
+
+    def sort_orbitals(self, mat, axis=[], aux_axis=[]):
+        ''' Transform a matrix in AO into a matrix in sorted AO
+        '''
+        idx = self.ao_idx
+        aux_idx = self.aux_ao_idx
+        shape_ones = (1,) * mat.ndim
+        fancy_index = []
+        for dim, n in enumerate(mat.shape):
+            if dim in axis:
+                assert n == len(idx)
+                indices = idx
+            elif dim in aux_axis:
+                assert n == len(aux_idx)
+                indices = aux_idx
+            else:
+                indices = np.arange(n)
+            idx_shape = shape_ones[:dim] + (-1,) + shape_ones[dim+1:]
+            fancy_index.append(indices.reshape(idx_shape))
+        return mat[tuple(fancy_index)]
+
+    def unsort_orbitals(self, sorted_mat, axis=[], aux_axis=[]):
+        ''' Transform a matrix in sorted AO into a matrix in the original AO
+        '''
+        idx = self.ao_idx
+        aux_idx = self.aux_ao_idx
+        shape_ones = (1,) * sorted_mat.ndim
+        fancy_index = []
+        for dim, n in enumerate(sorted_mat.shape):
+            if dim in axis:
+                assert n == len(idx)
+                indices = idx
+            elif dim in aux_axis:
+                assert n == len(aux_idx)
+                indices = aux_idx
+            else:
+                indices = np.arange(n)
+            idx_shape = shape_ones[:dim] + (-1,) + shape_ones[dim+1:]
+            fancy_index.append(indices.reshape(idx_shape))
+        mat = cupy.empty_like(sorted_mat)
+        mat[tuple(fancy_index)] = sorted_mat
+        return mat
+    
+    @property
+    def coeff(self):
+        nao = self._mol_.nao
+        if self._mol_.cart:
+            coeff = cupy.eye(nao)
+            self._coeff = self.unsort_orbitals(coeff, axis=[1])
+        else:
+            self._coeff = self.unsort_orbitals(self.cart2sph, axis=[1])
+        return self._coeff
+
+    @property
+    def aux_coeff(self):
+        naux = self._auxmol_.nao
+        if self._auxmol_.cart:
+            coeff = cupy.eye(naux)
+            self._aux_coeff = self.unsort_orbitals(coeff, aux_axis=[1])
+        else:
+            self._aux_coeff = self.unsort_orbitals(self.aux_cart2sph, aux_axis=[1])
+        return self._aux_coeff
 
 def get_int3c2e_wjk(mol, auxmol, dm0_tag, thred=1e-12, omega=None, with_k=True):
     log = logger.new_logger(mol, mol.verbose)
@@ -351,7 +378,7 @@ def get_int3c2e_wjk(mol, auxmol, dm0_tag, thred=1e-12, omega=None, with_k=True):
             li = intopt.angular[cpi]
             lj = intopt.angular[cpj]
             int3c_blk = get_int3c2e_slice(intopt, cp_ij_id, cp_kl_id, omega=omega)
-            if not intopt._mol.cart:
+            if not intopt._mol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=1, ang=lj)
                 int3c_blk = cart2sph(int3c_blk, axis=2, ang=li)
             i0, i1 = intopt.ao_loc[cpi], intopt.ao_loc[cpi+1]
@@ -378,7 +405,7 @@ def get_int3c2e_ip_jk(intopt, cp_aux_id, ip_type, rhoj, rhok, dm, omega=None):
     '''
     fn = getattr(libgvhf, 'GINTbuild_int3c2e_' + ip_type + '_jk')
     if omega is None: omega = 0.0
-    nao = intopt.mol.nao
+    nao = intopt._sorted_mol.nao
     n_dm = 1
 
     cp_kl_id = cp_aux_id + len(intopt.log_qs)
@@ -451,19 +478,19 @@ def loop_int3c2e_general(intopt, ip_type='', omega=None, stream=None):
     if omega is None: omega = 0.0
     if stream is None: stream = cupy.cuda.get_current_stream()
 
-    nao = intopt.mol.nao
-    naux = intopt.auxmol.nao
+    nao = intopt._sorted_mol.nao
+    naux = intopt._sorted_auxmol.nao
     norb = nao + naux + 1
     ao_loc = intopt.ao_loc
     aux_ao_loc = intopt.aux_ao_loc
     comp = 3**order
 
-    lmax = intopt.mol._bas[:gto.ANG_OF].max()
-    aux_lmax = intopt.auxmol._bas[:gto.ANG_OF].max()
+    lmax = intopt._sorted_mol._bas[:gto.ANG_OF].max()
+    aux_lmax = intopt._sorted_auxmol._bas[:gto.ANG_OF].max()
     nroots = (lmax + aux_lmax + order)//2 + 1
     if nroots > NROOT_ON_GPU:
         from pyscf.gto.moleintor import getints, make_cintopt
-        pmol = intopt.tot_mol
+        pmol = intopt._tot_mol
         intor = pmol._add_suffix('int3c2e_' + ip_type)
         opt = make_cintopt(pmol._atm, pmol._bas, pmol._env, intor)
 
@@ -519,9 +546,9 @@ def loop_int3c2e_general(intopt, ip_type='', omega=None, stream=None):
                 int3c_cpu = getints(intor, pmol._atm, pmol._bas, pmol._env, shls_slice, cintopt=opt).transpose([0,3,2,1])
                 int3c_blk = cupy.asarray(int3c_cpu)
 
-            if not intopt._auxmol.cart:
+            if not intopt._auxmol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=1, ang=lk)
-            if not intopt._mol.cart:
+            if not intopt._mol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=2, ang=lj)
                 int3c_blk = cart2sph(int3c_blk, axis=3, ang=li)
 
@@ -615,20 +642,20 @@ def loop_aux_jk(intopt, ip_type='', omega=None, stream=None):
         yield aux_id, ints_slices
 
 def get_ao2atom(intopt, aoslices):
-    ao_idx = intopt.ao_idx
-    ao2atom = cupy.zeros([len(ao_idx), len(aoslices)])
+    nao = intopt._mol_.nao
+    ao2atom = cupy.zeros([nao, len(aoslices)])
     for ia, aoslice in enumerate(aoslices):
         _, _, p0, p1 = aoslice
         ao2atom[p0:p1,ia] = 1.0
-    return ao2atom[ao_idx,:]
+    return intopt.sort_orbitals(ao2atom, axis=[0])
 
 def get_aux2atom(intopt, auxslices):
-    aux_ao_idx = intopt.aux_ao_idx
-    aux2atom = cupy.zeros([len(aux_ao_idx), len(auxslices)])
+    naux = intopt._auxmol_.nao
+    aux2atom = cupy.zeros([naux, len(auxslices)])
     for ia, auxslice in enumerate(auxslices):
         _, _, p0, p1 = auxslice
         aux2atom[p0:p1,ia] = 1.0
-    return aux2atom[aux_ao_idx,:]
+    return intopt.sort_orbitals(aux2atom, aux_axis=[0])
 
 def get_j_int3c2e_pass1(intopt, dm0, sort_j=True):
     '''
@@ -636,22 +663,24 @@ def get_j_int3c2e_pass1(intopt, dm0, sort_j=True):
     '''
     n_dm = 1
 
-    naux = intopt.cart_aux_loc[-1]#len(intopt.cart_aux_idx)
-    rhoj = cupy.zeros([naux])
+    naux = intopt._sorted_auxmol.nao
+    
     coeff = intopt.coeff
     if dm0.ndim == 3:
         dm0 = dm0[0] + dm0[1]
     dm_cart = coeff @ dm0 @ coeff.T
-
+    
     num_cp_ij = [len(log_qs) for log_qs in intopt.log_qs]
     num_cp_kl = [len(log_qs) for log_qs in intopt.aux_log_qs]
 
     bins_locs_ij = np.append(0, np.cumsum(num_cp_ij)).astype(np.int32)
     bins_locs_kl = np.append(0, np.cumsum(num_cp_kl)).astype(np.int32)
-
+    
     ncp_ij = len(intopt.log_qs)
     ncp_kl = len(intopt.aux_log_qs)
     norb = dm_cart.shape[0]
+    
+    rhoj = cupy.zeros([naux])
     err = libgvhf.GINTbuild_j_int3c2e_pass1(
         intopt.bpcache,
         ctypes.cast(dm_cart.data.ptr, ctypes.c_void_p),
@@ -665,7 +694,7 @@ def get_j_int3c2e_pass1(intopt, dm0, sort_j=True):
         ctypes.c_int(ncp_kl))
     if err != 0:
         raise RuntimeError('CUDA error in get_j_pass1')
-
+    
     if sort_j:
         aux_coeff = intopt.aux_coeff
         rhoj = cupy.dot(rhoj, aux_coeff)
@@ -676,8 +705,8 @@ def get_j_int3c2e_pass2(intopt, rhoj):
     get vj pass2 for int3c2e
     '''
     n_dm = 1
-    norb = len(intopt.cart_ao_idx)
-    naux = len(intopt.cart_aux_idx)
+    norb = intopt._sorted_mol.nao
+    naux = intopt._sorted_auxmol.nao
     vj = cupy.zeros([norb, norb])
 
     num_cp_ij = [len(log_qs) for log_qs in intopt.log_qs]
@@ -688,9 +717,10 @@ def get_j_int3c2e_pass2(intopt, rhoj):
 
     ncp_ij = len(intopt.log_qs)
     ncp_kl = len(intopt.aux_log_qs)
-
-    aux_coeff = intopt.aux_coeff
-    rhoj = cupy.dot(aux_coeff, rhoj)
+    
+    rhoj = intopt.sort_orbitals(rhoj, aux_axis=[0])
+    if not intopt._auxmol_.cart:
+        rhoj = intopt.aux_cart2sph @ rhoj
 
     err = libgvhf.GINTbuild_j_int3c2e_pass2(
         intopt.bpcache,
@@ -706,8 +736,11 @@ def get_j_int3c2e_pass2(intopt, rhoj):
 
     if err != 0:
         raise RuntimeError('CUDA error in get_j_pass2')
-    coeff = intopt.coeff
-    vj = coeff.T @ vj @ coeff
+    
+    if not intopt._mol_.cart:
+        cart2sph = intopt.cart2sph
+        vj = cart2sph.T @ vj @ cart2sph
+    vj = intopt.unsort_orbitals(vj, axis=[0,1])
     vj = vj + vj.T
     return vj
 
@@ -719,7 +752,7 @@ def get_int3c2e_jk(mol, auxmol, dm0_tag, with_k=True, omega=None):
     intopt.build(1e-14, diag_block_with_triu=True, aosym=True, group_size=BLKSIZE, group_size_aux=BLKSIZE)
 
     if omega is None: omega = 0.0
-    naux = len(intopt.aux_ao_idx)
+    naux = auxmol.nao
     orbo = cupy.asarray(dm0_tag.occ_coeff, order='C')
     nocc = orbo.shape[1]
     rhoj = cupy.empty([naux])
@@ -736,7 +769,7 @@ def get_int3c2e_jk(mol, auxmol, dm0_tag, with_k=True, omega=None):
             li = intopt.angular[cpi]
             lj = intopt.angular[cpj]
             int3c_blk = get_int3c2e_slice(intopt, cp_ij_id, cp_kl_id, omega=omega)
-            if not intopt._mol.cart:
+            if not intopt._mol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=1, ang=lj)
                 int3c_blk = cart2sph(int3c_blk, axis=2, ang=li)
             i0, i1 = intopt.ao_loc[cpi], intopt.ao_loc[cpi+1]
@@ -863,8 +896,8 @@ def get_int3c2e_ip1_wjk(intopt, dm0_tag, with_k=True, omega=None):
     '''
     get wj and wk for int3c2e_ip1
     '''
-    nao = len(intopt.ao_idx)
-    naux = len(intopt.aux_ao_idx)
+    nao = intopt._mol_.nao
+    naux = intopt._auxmol_.nao
     orbo = cupy.asarray(dm0_tag.occ_coeff, order='C')
     nocc = orbo.shape[1]
 
@@ -903,7 +936,7 @@ def get_int3c2e_ip2_wjk(intopt, dm0_tag, with_k=True, omega=None):
     '''
     get wj and wk for int3c2e_ip2
     '''
-    naux = len(intopt.aux_ao_idx)
+    naux = intopt._auxmol_.nao
     orbo = cupy.asarray(dm0_tag.occ_coeff, order='C')
     nocc = orbo.shape[1]
     wj = cupy.zeros([naux,3])
@@ -918,12 +951,12 @@ def get_int3c2e_ipip1_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None):
     '''
     get hj and hk with int3c2e_ipip1
     '''
-    nao_sph = dm0_tag.shape[0]
+    nao = dm0_tag.shape[0]
     orbo = cupy.asarray(dm0_tag.occ_coeff, order='C')
-    hj = cupy.zeros([nao_sph,9])
+    hj = cupy.zeros([nao,9])
     hk = None
     if with_k:
-        hk = cupy.zeros([nao_sph,9])
+        hk = cupy.zeros([nao,9])
     for i0,i1,j0,j1,k0,k1,int3c_blk in loop_int3c2e_general(intopt, ip_type='ipip1', omega=omega):
         tmp = contract('xpji,ij->xpi', int3c_blk, dm0_tag[i0:i1,j0:j1])
         hj[i0:i1] += contract('xpi,p->ix', tmp, rhoj[k0:k1])
@@ -931,21 +964,21 @@ def get_int3c2e_ipip1_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None):
             rhok_tmp = contract('por,ir->pio', rhok[k0:k1], orbo[i0:i1])
             rhok_tmp = contract('pio,jo->pij', rhok_tmp, orbo[j0:j1])
             hk[i0:i1] += contract('xpji,pij->ix', int3c_blk, rhok_tmp)
-    hj = hj.reshape([nao_sph,3,3])
+    hj = hj.reshape([nao,3,3])
     if with_k:
-        hk = hk.reshape([nao_sph,3,3])
+        hk = hk.reshape([nao,3,3])
     return hj, hk
 
 def get_int3c2e_ipvip1_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None):
     '''
     # get hj and hk with int3c2e_ipvip1
     '''
-    nao_sph = dm0_tag.shape[0]
+    nao = dm0_tag.shape[0]
     orbo = cupy.asarray(dm0_tag.occ_coeff, order='C')
-    hj = cupy.zeros([nao_sph,nao_sph,9])
+    hj = cupy.zeros([nao,nao,9])
     hk = None
     if with_k:
-        hk = cupy.zeros([nao_sph,nao_sph,9])
+        hk = cupy.zeros([nao,nao,9])
     for i0,i1,j0,j1,k0,k1,int3c_blk in loop_int3c2e_general(intopt, ip_type='ipvip1', omega=omega):
         tmp = contract('xpji,ij->xpij', int3c_blk, dm0_tag[i0:i1,j0:j1])
         hj[i0:i1,j0:j1] += contract('xpij,p->ijx', tmp, rhoj[k0:k1])
@@ -953,22 +986,22 @@ def get_int3c2e_ipvip1_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None)
             rhok_tmp = contract('por,ir->pio', rhok[k0:k1], orbo[i0:i1])
             rhok_tmp = contract('pio,jo->pji', rhok_tmp, orbo[j0:j1])
             hk[i0:i1,j0:j1] += contract('xpji,pji->ijx', int3c_blk, rhok_tmp)
-    hj = hj.reshape([nao_sph,nao_sph,3,3])
+    hj = hj.reshape([nao,nao,3,3])
     if with_k:
-        hk = hk.reshape([nao_sph,nao_sph,3,3])
+        hk = hk.reshape([nao,nao,3,3])
     return hj, hk
 
 def get_int3c2e_ip1ip2_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None):
     '''
     # get hj and hk with int3c2e_ip1ip2
     '''
-    nao_sph = dm0_tag.shape[0]
-    naux_sph = rhok.shape[0]
+    nao = dm0_tag.shape[0]
+    naux = rhok.shape[0]
     orbo = cupy.asarray(dm0_tag.occ_coeff, order='C')
-    hj = cupy.zeros([nao_sph,naux_sph,9])
+    hj = cupy.zeros([nao,naux,9])
     hk = None
     if with_k:
-        hk = cupy.zeros([nao_sph,naux_sph,9])
+        hk = cupy.zeros([nao,naux,9])
     for i0,i1,j0,j1,k0,k1,int3c_blk in loop_int3c2e_general(intopt, ip_type='ip1ip2', omega=omega):
         tmp = contract('xpji,ij->xpi', int3c_blk, dm0_tag[i0:i1,j0:j1])
         hj[i0:i1,k0:k1] += contract('xpi,p->ipx', tmp, rhoj[k0:k1])
@@ -976,21 +1009,21 @@ def get_int3c2e_ip1ip2_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None)
             rhok_tmp = contract('por,ir->pio', rhok[k0:k1], orbo[i0:i1])
             rhok_tmp = contract('pio,jo->pij', rhok_tmp, orbo[j0:j1])
             hk[i0:i1,k0:k1] += contract('xpji,pij->ipx', int3c_blk, rhok_tmp)
-    hj = hj.reshape([nao_sph,naux_sph,3,3])
+    hj = hj.reshape([nao,naux,3,3])
     if with_k:
-        hk = hk.reshape([nao_sph,naux_sph,3,3])
+        hk = hk.reshape([nao,naux,3,3])
     return hj, hk
 
 def get_int3c2e_ipip2_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None):
     '''
     # get hj and hk with int3c2e_ipip2
     '''
-    naux_sph = rhok.shape[0]
+    naux = rhok.shape[0]
     orbo = cupy.asarray(dm0_tag.occ_coeff, order='C')
-    hj = cupy.zeros([naux_sph,9])
+    hj = cupy.zeros([naux,9])
     hk = None
     if with_k:
-        hk = cupy.zeros([naux_sph,9])
+        hk = cupy.zeros([naux,9])
     for i0,i1,j0,j1,k0,k1,int3c_blk in loop_int3c2e_general(intopt, ip_type='ipip2', omega=omega):
         tmp = contract('xpji,ij->xp', int3c_blk, dm0_tag[i0:i1,j0:j1])
         hj[k0:k1] += contract('xp,p->px', tmp, rhoj[k0:k1])
@@ -998,9 +1031,9 @@ def get_int3c2e_ipip2_hjk(intopt, rhoj, rhok, dm0_tag, with_k=True, omega=None):
             rhok_tmp = contract('por,jr->pjo', rhok[k0:k1], orbo[j0:j1])
             rhok_tmp = contract('pjo,io->pji', rhok_tmp, orbo[i0:i1])
             hk[k0:k1] += contract('xpji,pji->px', int3c_blk, rhok_tmp)
-    hj = hj.reshape([naux_sph,3,3])
+    hj = hj.reshape([naux,3,3])
     if with_k:
-        hk = hk.reshape([naux_sph,3,3])
+        hk = hk.reshape([naux,3,3])
     return hj, hk
 
 def get_hess_nuc_elec(mol, dm):
@@ -1172,9 +1205,9 @@ def get_int3c2e_ip(mol, auxmol=None, ip_type=1, auxbasis='weigend+etb', direct_s
             if err != 0:
                 raise RuntimeError("int3c2e_ip failed\n")
 
-            if not intopt._auxmol.cart:
+            if not intopt._auxmol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=1, ang=lk)
-            if not intopt._mol.cart:
+            if not intopt._mol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=2, ang=lj)
                 int3c_blk = cart2sph(int3c_blk, axis=3, ang=li)
 
@@ -1183,12 +1216,11 @@ def get_int3c2e_ip(mol, auxmol=None, ip_type=1, auxbasis='weigend+etb', direct_s
             k0, k1 = aux_ao_loc[aux_id], aux_ao_loc[aux_id+1]
 
             int3c[:, k0:k1, j0:j1, i0:i1] = int3c_blk
-    ao_idx = np.argsort(intopt.ao_idx)
-    aux_idx = np.argsort(intopt.aux_ao_idx)
-    int3c = int3c[cupy.ix_(np.arange(3), aux_idx, ao_idx, ao_idx)]
-
+    #ao_idx = np.argsort(intopt.ao_idx)
+    #aux_idx = np.argsort(intopt.aux_ao_idx)
+    #int3c = int3c[cupy.ix_(np.arange(3), aux_idx, ao_idx, ao_idx)]
+    int3c = intopt.unsort_orbitals(int3c, aux_axis=[1], axis=[2,3])
     return int3c.transpose([0,3,2,1])
-
 
 def get_int3c2e_general(mol, auxmol=None, ip_type='', auxbasis='weigend+etb', direct_scf_tol=1e-13, omega=None, stream=None):
     '''
@@ -1219,13 +1251,12 @@ def get_int3c2e_general(mol, auxmol=None, ip_type='', auxbasis='weigend+etb', di
     nroots = (lmax + aux_lmax + order)//2 + 1
     if nroots > NROOT_ON_GPU:
         from pyscf.gto.moleintor import getints, make_cintopt
-        mol = intopt.mol
-        pmol = intopt.tot_mol
+        pmol = intopt._tot_mol
         intor = pmol._add_suffix('int3c2e_' + ip_type)
         opt = make_cintopt(pmol._atm, pmol._bas, pmol._env, intor)
 
-    nao_cart = intopt.mol.nao
-    naux_cart = intopt.auxmol.nao
+    nao_cart = intopt._sorted_mol.nao
+    naux_cart = intopt._sorted_auxmol.nao
     norb_cart = nao_cart + naux_cart + 1
     ao_loc = intopt.ao_loc
     aux_ao_loc = intopt.aux_ao_loc
@@ -1281,9 +1312,9 @@ def get_int3c2e_general(mol, auxmol=None, ip_type='', auxbasis='weigend+etb', di
                 int3c_cpu = getints(intor, pmol._atm, pmol._bas, pmol._env, shls_slice, cintopt=opt).transpose([0,3,2,1])
                 int3c_blk = cupy.asarray(int3c_cpu)
 
-            if not intopt._auxmol.cart:
+            if not intopt._auxmol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=1, ang=lk)
-            if not intopt._mol.cart:
+            if not intopt._mol_.cart:
                 int3c_blk = cart2sph(int3c_blk, axis=2, ang=lj)
                 int3c_blk = cart2sph(int3c_blk, axis=3, ang=li)
 
@@ -1293,10 +1324,7 @@ def get_int3c2e_general(mol, auxmol=None, ip_type='', auxbasis='weigend+etb', di
 
             int3c[:, k0:k1, j0:j1, i0:i1] = int3c_blk
 
-    ao_idx = np.argsort(intopt.ao_idx)
-    aux_idx = np.argsort(intopt.aux_ao_idx)
-    int3c = int3c[cupy.ix_(np.arange(comp), aux_idx, ao_idx, ao_idx)]
-
+    int3c = intopt.unsort_orbitals(int3c, aux_axis=[1], axis=[2,3])
     return int3c.transpose([0,3,2,1])
 
 def get_dh1e(mol, dm0):
@@ -1352,8 +1380,8 @@ def get_int3c2e_slice(intopt, cp_ij_id, cp_aux_id, cart=False, aosym=None, out=N
     '''
     if stream is None: stream = cupy.cuda.get_current_stream()
     if omega is None: omega = 0.0
-    nao_cart = intopt.mol.nao
-    naux_cart = intopt.auxmol.nao
+    nao_cart = intopt._sorted_mol.nao
+    naux_cart = intopt._sorted_auxmol.nao
     norb_cart = nao_cart + naux_cart + 1
 
     cpi = intopt.cp_idx[cp_ij_id]
@@ -1381,7 +1409,7 @@ def get_int3c2e_slice(intopt, cp_ij_id, cp_aux_id, cart=False, aosym=None, out=N
     # if possible, write the data into the given allocated space
     # otherwise, need a temporary space for cart2sph
     '''
-    if out is None or (lk > 1 and not intopt._auxmol.cart):
+    if out is None or (lk > 1 and not intopt._auxmol_.cart):
         int3c_blk = cupy.zeros([nk,nj,ni], order='C')
         strides = np.array([1, ni, ni*nj, 1], dtype=np.int32)
     else:
@@ -1408,7 +1436,7 @@ def get_int3c2e_slice(intopt, cp_ij_id, cp_aux_id, cart=False, aosym=None, out=N
         raise RuntimeError('GINT_fill_int2e failed')
 
     # move this operation to j2c?
-    if lk > 1 and intopt._auxmol.cart == 0:
+    if lk > 1 and intopt._auxmol_.cart == 0:
         int3c_blk = cart2sph(int3c_blk, axis=0, ang=lk, out=out)
     return int3c_blk
 
@@ -1445,10 +1473,10 @@ def get_int3c2e(mol, auxmol=None, auxbasis='weigend+etb', direct_scf_tol=1e-13, 
         int3c[:, j0:j1, i0:i1] = int3c_slice
     row, col = np.tril_indices(nao)
     int3c[:, row, col] = int3c[:, col, row]
-    ao_idx = np.argsort(intopt.ao_idx)
-    aux_id = np.argsort(intopt.aux_ao_idx)
-    int3c = int3c[np.ix_(aux_id, ao_idx, ao_idx)]
-
+    #ao_idx = np.argsort(intopt.ao_idx)
+    #aux_id = np.argsort(intopt.aux_ao_idx)
+    #int3c = int3c[np.ix_(aux_id, ao_idx, ao_idx)]
+    int3c = intopt.unsort_orbitals(int3c, aux_axis=[0], axis=[1,2])
     return int3c.transpose([2,1,0])
 
 def sort_mol(mol0, cart=True, log=None):

--- a/gpu4pyscf/df/int3c2e.py
+++ b/gpu4pyscf/df/int3c2e.py
@@ -312,8 +312,8 @@ class VHFOpt(_vhf.VHFOpt):
     
     @property
     def coeff(self):
-        nao = self._mol_.nao
-        if self._mol_.cart:
+        nao = self.mol.nao
+        if self.mol.cart:
             coeff = cupy.eye(nao)
             self._coeff = self.unsort_orbitals(coeff, axis=[1])
         else:
@@ -322,8 +322,8 @@ class VHFOpt(_vhf.VHFOpt):
 
     @property
     def aux_coeff(self):
-        naux = self._auxmol_.nao
-        if self._auxmol_.cart:
+        naux = self.auxmol.nao
+        if self.auxmol.cart:
             coeff = cupy.eye(naux)
             self._aux_coeff = self.unsort_orbitals(coeff, aux_axis=[1])
         else:

--- a/gpu4pyscf/df/tests/test_df_jk.py
+++ b/gpu4pyscf/df/tests/test_df_jk.py
@@ -54,7 +54,7 @@ class KnownValues(unittest.TestCase):
         intopt = int3c2e.VHFOpt(mol, auxmol, 'int2e')
         intopt.build(1e-14, diag_block_with_triu=False, aosym=True)
         cupy.random.seed(np.asarray(1, dtype=np.uint64))
-        nao = intopt._mol_.nao
+        nao = intopt.mol.nao
         dm = cupy.random.rand(nao, nao)
         dm = dm + dm.T
 
@@ -73,7 +73,7 @@ class KnownValues(unittest.TestCase):
         intopt = int3c2e.VHFOpt(mol_sph, auxmol, 'int2e')
         intopt.build(1e-14, diag_block_with_triu=False, aosym=True)
         cupy.random.seed(np.asarray(1, dtype=np.uint64))
-        nao = intopt._mol_.nao
+        nao = intopt.mol.nao
         dm = cupy.random.rand(nao, nao)
         dm = dm + dm.T
         

--- a/gpu4pyscf/df/tests/test_df_jk.py
+++ b/gpu4pyscf/df/tests/test_df_jk.py
@@ -32,14 +32,20 @@ Cl -1.73 -1.0 -1.0''',
 bas='def2-tzvpp'
 
 def setUpModule():
-    global mol, auxmol
+    global mol, mol_sph, auxmol, auxmol_sph
     mol = pyscf.M(atom=atom, basis=bas, output='/dev/null', cart=True, verbose=1)
     auxmol = df.addons.make_auxmol(mol, auxbasis='sto3g')
 
+    mol_sph = pyscf.M(atom=atom, basis=bas, output='/dev/null', cart=False, verbose=1)
+    auxmol_sph = df.addons.make_auxmol(mol_sph, auxbasis='sto3g')
+
 def tearDownModule():
-    global mol, auxmol
+    global mol, mol_sph, auxmol, auxmol_sph
     mol.stdout.close()
-    del mol, auxmol
+    mol_sph.stdout.close()
+    auxmol.stdout.close()
+    auxmol_sph.stdout.close()
+    del mol, auxmol, mol_sph, auxmol_sph
 
 class KnownValues(unittest.TestCase):
 
@@ -48,10 +54,29 @@ class KnownValues(unittest.TestCase):
         intopt = int3c2e.VHFOpt(mol, auxmol, 'int2e')
         intopt.build(1e-14, diag_block_with_triu=False, aosym=True)
         cupy.random.seed(np.asarray(1, dtype=np.uint64))
-        nao = len(intopt.ao_idx)
+        nao = intopt._mol_.nao
         dm = cupy.random.rand(nao, nao)
         dm = dm + dm.T
 
+        # pass 1
+        rhoj_outcore = cupy.einsum('ijL,ij->L', int3c_gpu, dm)
+        rhoj_incore = 2.0*int3c2e.get_j_int3c2e_pass1(intopt, dm)
+        assert cupy.linalg.norm(rhoj_outcore - rhoj_incore) < 1e-8
+
+        # pass 2
+        vj_outcore = cupy.einsum('ijL,L->ij', int3c_gpu, rhoj_outcore)
+        vj_incore = int3c2e.get_j_int3c2e_pass2(intopt, rhoj_incore)
+        assert cupy.linalg.norm(vj_outcore - vj_incore) < 1e-5
+    
+    def test_vj_sph_incore(self):
+        int3c_gpu = int3c2e.get_int3c2e(mol_sph, auxmol, aosym=True, direct_scf_tol=1e-14)
+        intopt = int3c2e.VHFOpt(mol_sph, auxmol, 'int2e')
+        intopt.build(1e-14, diag_block_with_triu=False, aosym=True)
+        cupy.random.seed(np.asarray(1, dtype=np.uint64))
+        nao = intopt._mol_.nao
+        dm = cupy.random.rand(nao, nao)
+        dm = dm + dm.T
+        
         # pass 1
         rhoj_outcore = cupy.einsum('ijL,ij->L', int3c_gpu, dm)
         rhoj_incore = 2.0*int3c2e.get_j_int3c2e_pass1(intopt, dm)
@@ -72,7 +97,7 @@ class KnownValues(unittest.TestCase):
         vj0, _ = mf.get_jk(dm=dm, with_j=True, with_k=False, hermi=1)
         vj = df_jk.get_j(mf.with_df, dm)
         assert cupy.linalg.norm(vj - vj0) < 1e-4
-
+    
     def test_jk_hermi0(self):
         dfobj = DF(mol, 'sto3g').build()
         np.random.seed(3)

--- a/gpu4pyscf/df/tests/test_df_rks_grad.py
+++ b/gpu4pyscf/df/tests/test_df_rks_grad.py
@@ -117,17 +117,17 @@ def _vs_cpu(mol, grid_response=False, xc=xc0, disp=disp0, tol=1e-9):
     assert abs(g_analy - ref).max() < tol
 
 class KnownValues(unittest.TestCase):
-
+    
     def test_grad_with_grids_response(self):
         print("-----testing DF DFT gradient with grids response----")
         _check_grad(mol_sph, grid_response=True, xc='LDA', disp=None)
         _check_grad(mol_sph, grid_response=True, xc='B3LYP', disp=None)
         _check_grad(mol_sph, grid_response=True, xc='m06', disp=None, tol=1e-4)
-
+    
     def test_grad_lda(self):
         print("-----LDA testing-------")
         _vs_cpu(mol_sph, xc='LDA', disp=None)
-
+    
     def test_grad_gga(self):
         print('-----GGA testing-------')
         _vs_cpu(mol_sph, xc='PBE', disp=None)
@@ -147,7 +147,7 @@ class KnownValues(unittest.TestCase):
     def test_grad_nlc(self):
         print('--------nlc testing-------------')
         _vs_cpu(mol_sph, xc='HYB_MGGA_XC_WB97M_V', disp=None, tol=1e-7)
-
+    
     def test_grad_cart(self):
         print('------ Cart testing--------')
         _vs_cpu(mol_cart, xc='B3LYP', disp=None)
@@ -163,7 +163,7 @@ class KnownValues(unittest.TestCase):
     def test_grad_wb97m_d3bj(self):
         print('------ wB97m-d3bj --------')
         _vs_cpu(mol_sph, xc='wb97m-d3bj', tol=1e-8)
-
+    
 if __name__ == "__main__":
     print("Full Tests for DF Gradient")
     unittest.main()

--- a/gpu4pyscf/dft/numint.py
+++ b/gpu4pyscf/dft/numint.py
@@ -483,7 +483,7 @@ def nr_rks(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
         p1 = p0 + weight.size
         for i in range(nset):
             if mo_coeff is None:
-                rho_tot[i,:,p0:p1] = eval_rho(_sorted_mol, ao_mask, dms[i][np.ix_(idx,idx)], xctype=xctype, hermi=1, with_lapl=with_lapl)
+                rho_tot[i,:,p0:p1] = eval_rho(_sorted_mol, ao_mask, dms[i][idx[:,None],idx], xctype=xctype, hermi=1, with_lapl=with_lapl)
             else:
                 mo_coeff_mask = mo_coeff[idx,:]
                 rho_tot[i,:,p0:p1] = eval_rho2(_sorted_mol, ao_mask, mo_coeff_mask, mo_occ, None, xctype, with_lapl)
@@ -693,7 +693,7 @@ def nr_rks_group(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
         p1 = p0 + weight.size
         for i in range(nset):
             if mo_coeff is None:
-                rho_tot[i,:,p0:p1] = eval_rho(_sorted_mol, ao_mask, dms[i][np.ix_(idx,idx)], xctype=xctype, hermi=1, with_lapl=with_lapl)
+                rho_tot[i,:,p0:p1] = eval_rho(_sorted_mol, ao_mask, dms[i][idx[:,None],idx], xctype=xctype, hermi=1, with_lapl=with_lapl)
             else:
                 mo_coeff_mask = mo_coeff[idx,:]
                 rho_tot[i,:,p0:p1] = eval_rho2(_sorted_mol, ao_mask, mo_coeff_mask, mo_occ, None, xctype, with_lapl)
@@ -830,8 +830,8 @@ def nr_uks(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
         for i in range(nset):
             t0 = log.init_timer()
             if mo_coeff is None:
-                rho_a = eval_rho(_sorted_mol, ao_mask, dma[i][np.ix_(idx,idx)], xctype=xctype, hermi=1, with_lapl=with_lapl)
-                rho_b = eval_rho(_sorted_mol, ao_mask, dmb[i][np.ix_(idx,idx)], xctype=xctype, hermi=1, with_lapl=with_lapl)
+                rho_a = eval_rho(_sorted_mol, ao_mask, dma[i][idx[:,None],idx], xctype=xctype, hermi=1, with_lapl=with_lapl)
+                rho_b = eval_rho(_sorted_mol, ao_mask, dmb[i][idx[:,None],idx], xctype=xctype, hermi=1, with_lapl=with_lapl)
             else:
                 mo_coeff_mask = mo_coeff[:, idx,:]
                 rho_a = eval_rho2(_sorted_mol, ao_mask, mo_coeff_mask[0], mo_occ[0], None, xctype, with_lapl)
@@ -962,9 +962,9 @@ def nr_rks_fxc(ni, mol, grids, xc_code, dm0=None, dms=None, relativity=0, hermi=
     # AO basis -> gdftopt AO basis
     with_mocc = hasattr(dms, 'mo1')
     if with_mocc:
-        mo1 = opt.sort_orbitals(dms.mo1, axis=[1)
+        mo1 = opt.sort_orbitals(dms.mo1, axis=[1])
         occ_coeff = opt.sort_orbitals(dms.occ_coeff) * 2.0
-    dms = opt.sort_orbitals(dms.reshape(-1,nao0,nao0), axis=[1,2)
+    dms = opt.sort_orbitals(dms.reshape(-1,nao0,nao0), axis=[1,2])
     nset = len(dms)
     vmat = cupy.zeros((nset, nao, nao))
 
@@ -988,7 +988,7 @@ def nr_rks_fxc(ni, mol, grids, xc_code, dm0=None, dms=None, relativity=0, hermi=
             # slow version
             rho1 = []
             for i in range(nset):
-                rho_tmp = eval_rho(_sorted_mol, ao, dms[i][np.ix_(mask,mask)],
+                rho_tmp = eval_rho(_sorted_mol, ao, dms[i][mask[:,None],mask],
                                    xctype=xctype, hermi=hermi, with_lapl=with_lapl)
                 rho1.append(rho_tmp)
             rho1 = cupy.stack(rho1, axis=0)
@@ -1110,10 +1110,10 @@ def nr_uks_fxc(ni, mol, grids, xc_code, dm0=None, dms=None, relativity=0, hermi=
             rho1a = []
             rho1b = []
             for i in range(nset):
-                rho_tmp = eval_rho(_sorted_mol, ao, dma[i][np.ix_(mask,mask)],
+                rho_tmp = eval_rho(_sorted_mol, ao, dma[i][mask[:,None],mask],
                                    xctype=xctype, hermi=hermi, with_lapl=with_lapl)
                 rho1a.append(rho_tmp)
-                rho_tmp = eval_rho(_sorted_mol, ao, dmb[i][np.ix_(mask,mask)],
+                rho_tmp = eval_rho(_sorted_mol, ao, dmb[i][mask[:,None],mask],
                                    xctype=xctype, hermi=hermi, with_lapl=with_lapl)
                 rho1b.append(rho_tmp)
             rho1a = cupy.stack(rho1a, axis=0)
@@ -1227,9 +1227,8 @@ def nr_nlc_vxc(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     vvrho = []
     for ao, idx, weight, coords \
             in ni.block_loop(_sorted_mol, grids, nao, ao_deriv, max_memory=max_memory):
-        #rho = eval_rho(opt.mol, ao, dms[0][np.ix_(mask,mask)], xctype='GGA', hermi=1)
         if mo_coeff is None:
-            rho = eval_rho(_sorted_mol, ao, dms[0][np.ix_(idx,idx)], xctype='GGA', hermi=1, with_lapl=with_lapl)
+            rho = eval_rho(_sorted_mol, ao, dms[0][idx[:,None],idx], xctype='GGA', hermi=1, with_lapl=with_lapl)
         else:
             mo_coeff_mask = mo_coeff[idx,:]
             rho = eval_rho2(_sorted_mol, ao, mo_coeff_mask, mo_occ, None, 'GGA', with_lapl)

--- a/gpu4pyscf/dft/numint.py
+++ b/gpu4pyscf/dft/numint.py
@@ -963,7 +963,7 @@ def nr_rks_fxc(ni, mol, grids, xc_code, dm0=None, dms=None, relativity=0, hermi=
     with_mocc = hasattr(dms, 'mo1')
     if with_mocc:
         mo1 = opt.sort_orbitals(dms.mo1, axis=[1])
-        occ_coeff = opt.sort_orbitals(dms.occ_coeff) * 2.0
+        occ_coeff = opt.sort_orbitals(dms.occ_coeff, axis=[0]) * 2.0
     dms = opt.sort_orbitals(dms.reshape(-1,nao0,nao0), axis=[1,2])
     nset = len(dms)
     vmat = cupy.zeros((nset, nao, nao))

--- a/gpu4pyscf/grad/rhf.py
+++ b/gpu4pyscf/grad/rhf.py
@@ -256,8 +256,8 @@ def get_grad_hcore(mf_grad, mo_coeff=None, mo_occ=None):
     intopt = int3c2e.VHFOpt(mol, fakemol, 'int2e')
     intopt.build(1e-14, diag_block_with_triu=True, aosym=False,
                  group_size=int3c2e.BLKSIZE, group_size_aux=int3c2e.BLKSIZE)
-    orbo_sorted = orbo[intopt.ao_idx]
-    mo_coeff_sorted = mo_coeff[intopt.ao_idx]
+    orbo_sorted = intopt.sort_orbitals(orbo, axis=[0])
+    mo_coeff_sorted = intopt.sort_orbitals(mo_coeff, axis=[0])
     for i0,i1,j0,j1,k0,k1,int3c_blk in int3c2e.loop_int3c2e_general(intopt, ip_type='ip1'):
         dh1e[k0:k1,:,j0:j1,:] += contract('xkji,io->kxjo', int3c_blk, orbo_sorted[i0:i1])
         dh1e[k0:k1,:,i0:i1,:] += contract('xkji,jo->kxio', int3c_blk, orbo_sorted[j0:j1])

--- a/gpu4pyscf/grad/uks.py
+++ b/gpu4pyscf/grad/uks.py
@@ -139,9 +139,8 @@ def get_vxc(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     coeff = cupy.asarray(opt.coeff)
     nao, nao0 = coeff.shape
     dms = cupy.asarray(dms)
-    dms = take_last2d(dms, opt.ao_idx)
-    mo_coeff = mo_coeff[:, opt.ao_idx]
-
+    dms = opt.sort_orbitals(dms, axis=[1,2])
+    mo_coeff = opt.sort_orbitals(mo_coeff, axis=[1])
     nset = len(dms)
     vmat = cupy.zeros((nset,3,nao,nao))
     if xctype == 'LDA':
@@ -193,7 +192,7 @@ def get_vxc(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
             vtmp += rks_grad._tau_grad_dot_(ao_mask, wv[1,4])
             add_sparse(vmat[1], vtmp, idx)
 
-    vmat = take_last2d(vmat, opt.rev_ao_idx)
+    vmat = opt.unsort_orbitals(vmat, axis=[2,3])
     exc = None
 
     # - sign because nabla_X = -nabla_x
@@ -216,8 +215,7 @@ def get_vxc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     nao, nao0 = coeff.shape
     dms = cupy.asarray(dms)
     assert dms.ndim == 3 and dms.shape[0] == 2
-    #:dms = cupy.einsum('pi,nij,qj->npq', coeff, dms, coeff)
-    dms = sandwich_dot(dms.reshape(-1,nao0,nao0), coeff.T)
+    dms = opt.sort_orbitals(dms.reshape(-1,nao0,nao0), axis=[1,2])
 
     excsum = cupy.zeros((natm, 3))
     vmat = cupy.zeros((2,3,nao,nao))
@@ -304,9 +302,7 @@ def get_vxc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
                     excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms[1]) * 2
                     rho = vxc = None
 
-    #:vmat = cupy.einsum('pi,snpq,qj->snij', coeff, vmat, coeff)
-    vmat = sandwich_dot(vmat.reshape(6,nao,nao), coeff).reshape(2,3,nao0,nao0)
-
+    vmat = opt.unsort_orbitals(vmat, axis=[2,3])
     # - sign because nabla_X = -nabla_x
     return excsum, -vmat
 
@@ -326,8 +322,8 @@ def get_nlc_vxc(ni, mol, grids, xc_code, dms, mo_coeff, mo_occ, relativity=0, he
     _sorted_mol = opt._sorted_mol
     coeff = cupy.asarray(opt.coeff)
     nao, nao0 = coeff.shape
-    mo_coeff_0 = coeff @ mo_coeff[0]
-    mo_coeff_1 = coeff @ mo_coeff[1]
+    mo_coeff_0 = opt.sort_orbitals(mo_coeff[0], axis=[0])
+    mo_coeff_1 = opt.sort_orbitals(mo_coeff[1], axis=[0])
     nset = 1
     assert nset == 1
 
@@ -361,8 +357,7 @@ def get_nlc_vxc(ni, mol, grids, xc_code, dms, mo_coeff, mo_occ, relativity=0, he
         vmat_tmp = rks_grad._gga_grad_sum_(ao_mask, wv)
         add_sparse(vmat, vmat_tmp, mask)
 
-    rev_ao_idx = opt.rev_ao_idx
-    vmat = take_last2d(vmat, rev_ao_idx)
+    vmat = opt.unsort_orbitals(vmat, axis=[1,2])
     exc = None
     # - sign because nabla_X = -nabla_x
     return exc, -vmat

--- a/gpu4pyscf/gto/mole.py
+++ b/gpu4pyscf/gto/mole.py
@@ -86,7 +86,7 @@ def basis_seg_contraction(mol, allow_replica=False):
     pmol.output = mol.output
     pmol.verbose = mol.verbose
     pmol.stdout = mol.stdout
-    pmol.cart = True
+    pmol.cart = True #mol.cart
     pmol._bas = np.asarray(np.vstack(_bas), dtype=np.int32)
     pmol._env = _env
     return pmol

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -358,7 +358,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             wv = weight * vxc[0]
             aow = [numint._scale_ao(ao[i], wv) for i in range(1, 4)]
             _d1d2_dot_(ipip, mol, aow, ao[1:4], mask, ao_loc, False)
-            dm0_mask = dm0_sorted[mask, mask[:,None]]
+            dm0_mask = dm0_sorted[mask[:,None], mask]
 
             ao_dm_mask = contract('nig,ij->njg', ao_mask[:4], dm0_mask)
             ao_dm0 = numint._dot_ao_dm(mol, ao[0], dm0, mask, shls_slice, ao_loc)
@@ -396,7 +396,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             _d1d2_dot_(ipip, mol, aow, ao[1:4], mask, ao_loc, False)
             ao_dm0 = [numint._dot_ao_dm(mol, ao[i], dm0, mask, shls_slice, ao_loc) for i in range(4)]
             wf = weight * fxc
-            dm0_mask = dm0_sorted[mask, mask[:,None]]
+            dm0_mask = dm0_sorted[mask[:,None], mask]
             ao_dm_mask = contract('nig,ij->njg', ao_mask[:4], dm0_mask)
             vmat_dm_tmp = cupy.empty([3,3,nao_non0])
             for ia in range(_sorted_mol.natm):
@@ -441,7 +441,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             _d1d2_dot_(ipip, mol, [aow[0], aow[1], aow[2]], [ao[XX], ao[XY], ao[XZ]], mask, ao_loc, False)
             _d1d2_dot_(ipip, mol, [aow[1], aow[3], aow[4]], [ao[YX], ao[YY], ao[YZ]], mask, ao_loc, False)
             _d1d2_dot_(ipip, mol, [aow[2], aow[4], aow[5]], [ao[ZX], ao[ZY], ao[ZZ]], mask, ao_loc, False)
-            dm0_mask = dm0_sorted[mask, mask[:,None]]
+            dm0_mask = dm0_sorted[mask[:,None], mask]
             ao_dm0 = [numint._dot_ao_dm(mol, ao[i], dm0, mask, shls_slice, ao_loc) for i in range(4)]
             ao_dm_mask = contract('nig,ij->njg', ao_mask[:4], dm0_mask)
             wf = weight * fxc

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -146,7 +146,6 @@ def _get_vxc_diag(hessobj, mo_coeff, mo_occ, max_memory):
     mo_occ = cupy.asarray(mo_occ)
     mo_coeff = cupy.asarray(mo_coeff)
 
-    nao_sph = mo_coeff.shape[0]
     ni = mf._numint
     xctype = ni._xc_type(mf.xc)
     shls_slice = (0, mol.nbas)
@@ -157,8 +156,7 @@ def _get_vxc_diag(hessobj, mo_coeff, mo_occ, max_memory):
         ni.build(mol, grids.coords)
         opt = ni.gdftopt
     _sorted_mol = opt._sorted_mol
-    coeff = cupy.asarray(opt.coeff)
-    mo_coeff = coeff @ mo_coeff
+    mo_coeff = opt.sort_orbitals(mo_coeff, axis=[0])
     nao = mo_coeff.shape[0]
 
     vmat = cupy.zeros((6,nao,nao))
@@ -251,9 +249,8 @@ def _get_vxc_diag(hessobj, mo_coeff, mo_occ, max_memory):
                  1,3,4,
                  2,4,5]]
 
-    vmat = contract('npq,qj->npj', vmat, coeff)
-    vmat = contract('pi,npj->nij', coeff, vmat)
-    return vmat.reshape(3,3,nao_sph,nao_sph)
+    vmat = opt.unsort_orbitals(vmat, axis=[1,2])
+    return vmat.reshape(3,3,nao,nao)
 
 def _make_dR_rho1(ao, ao_dm0, atm_id, aoslices, xctype):
     p0, p1 = aoslices[atm_id][2:]
@@ -344,7 +341,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
     _sorted_mol = opt._sorted_mol
     coeff = cupy.asarray(opt.coeff)
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
-    dm0_sorted = take_last2d(dm0, opt.ao_idx)
+    dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
     vmat_dm = cupy.zeros((_sorted_mol.natm,3,3,nao))
     ipip = cupy.zeros((3,3,nao,nao))
     if xctype == 'LDA':
@@ -361,7 +358,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             wv = weight * vxc[0]
             aow = [numint._scale_ao(ao[i], wv) for i in range(1, 4)]
             _d1d2_dot_(ipip, mol, aow, ao[1:4], mask, ao_loc, False)
-            dm0_mask = dm0_sorted[numpy.ix_(mask, mask)]
+            dm0_mask = dm0_sorted[mask, mask[:,None]]
 
             ao_dm_mask = contract('nig,ij->njg', ao_mask[:4], dm0_mask)
             ao_dm0 = numint._dot_ao_dm(mol, ao[0], dm0, mask, shls_slice, ao_loc)
@@ -379,7 +376,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             ao_dm0 = aow = None
             t1 = log.timer_debug2('integration', *t1)
         for ia in range(_sorted_mol.natm):
-            vmat_dm[ia] = vmat_dm[ia][:,:,opt.rev_ao_idx]
+            vmat_dm[ia][:,:,opt._ao_idx] = vmat_dm[ia]
             p0, p1 = aoslices[ia][2:]
             vmat_dm[ia] += contract('xypq,pq->xyp', ipip[:,:,:,p0:p1], dm0[:,p0:p1])
     elif xctype == 'GGA':
@@ -399,7 +396,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             _d1d2_dot_(ipip, mol, aow, ao[1:4], mask, ao_loc, False)
             ao_dm0 = [numint._dot_ao_dm(mol, ao[i], dm0, mask, shls_slice, ao_loc) for i in range(4)]
             wf = weight * fxc
-            dm0_mask = dm0_sorted[numpy.ix_(mask, mask)]
+            dm0_mask = dm0_sorted[mask, mask[:,None]]
             ao_dm_mask = contract('nig,ij->njg', ao_mask[:4], dm0_mask)
             vmat_dm_tmp = cupy.empty([3,3,nao_non0])
             for ia in range(_sorted_mol.natm):
@@ -416,7 +413,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             ao_dm0 = aow = None
             t1 = log.timer_debug2('integration', *t1)
         for ia in range(_sorted_mol.natm):
-            vmat_dm[ia] = vmat_dm[ia][:,:,opt.rev_ao_idx]
+            vmat_dm[ia][:,:,opt._ao_idx] = vmat_dm[ia]
             p0, p1 = aoslices[ia][2:]
             vmat_dm[ia] += contract('xypq,pq->xyp', ipip[:,:,:,p0:p1], dm0[:,p0:p1])
             vmat_dm[ia] += contract('yxqp,pq->xyp', ipip[:,:,p0:p1], dm0[:,p0:p1])
@@ -444,7 +441,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             _d1d2_dot_(ipip, mol, [aow[0], aow[1], aow[2]], [ao[XX], ao[XY], ao[XZ]], mask, ao_loc, False)
             _d1d2_dot_(ipip, mol, [aow[1], aow[3], aow[4]], [ao[YX], ao[YY], ao[YZ]], mask, ao_loc, False)
             _d1d2_dot_(ipip, mol, [aow[2], aow[4], aow[5]], [ao[ZX], ao[ZY], ao[ZZ]], mask, ao_loc, False)
-            dm0_mask = dm0_sorted[numpy.ix_(mask, mask)]
+            dm0_mask = dm0_sorted[mask, mask[:,None]]
             ao_dm0 = [numint._dot_ao_dm(mol, ao[i], dm0, mask, shls_slice, ao_loc) for i in range(4)]
             ao_dm_mask = contract('nig,ij->njg', ao_mask[:4], dm0_mask)
             wf = weight * fxc
@@ -483,7 +480,7 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
                 vmat_dm[ia][:,:,mask] += vmat_dm_tmp
             t1 = log.timer_debug2('integration', *t1)
         for ia in range(_sorted_mol.natm):
-            vmat_dm[ia] = vmat_dm[ia][:,:,opt.rev_ao_idx]
+            vmat_dm[ia][:,:,opt._ao_idx] = vmat_dm[ia]
             p0, p1 = aoslices[ia][2:]
             vmat_dm[ia] += contract('xypq,pq->xyp', ipip[:,:,:,p0:p1], dm0[:,p0:p1])
             vmat_dm[ia] += contract('yxqp,pq->xyp', ipip[:,:,p0:p1], dm0[:,p0:p1])

--- a/gpu4pyscf/hessian/uks.py
+++ b/gpu4pyscf/hessian/uks.py
@@ -422,8 +422,8 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             _d1d2_dot_(ipipa, mol, aowa, ao[1:4], mask, ao_loc, False)
             aowb = [numint._scale_ao(ao[i], wv[1]) for i in range(1, 4)]
             _d1d2_dot_(ipipb, mol, aowb, ao[1:4], mask, ao_loc, False)
-            dm0a_mask = dm0a_sorted[mask, mask[:,None]]
-            dm0b_mask = dm0b_sorted[mask, mask[:,None]]
+            dm0a_mask = dm0a_sorted[mask[:,None], mask]
+            dm0b_mask = dm0b_sorted[mask[:,None], mask]
 
             ao_dma_mask = contract('nig,ij->njg', ao_mask[:4], dm0a_mask)
             ao_dmb_mask = contract('nig,ij->njg', ao_mask[:4], dm0b_mask)
@@ -475,8 +475,8 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             ao_dm0a = [numint._dot_ao_dm(mol, ao[i], dm0a, mask, shls_slice, ao_loc) for i in range(4)]
             ao_dm0b = [numint._dot_ao_dm(mol, ao[i], dm0b, mask, shls_slice, ao_loc) for i in range(4)]
             wf = weight * fxc
-            dm0a_mask = dm0a_sorted[mask, mask[:,None]]
-            dm0b_mask = dm0b_sorted[mask, mask[:,None]]
+            dm0a_mask = dm0a_sorted[mask[:,None], mask]
+            dm0b_mask = dm0b_sorted[mask[:,None], mask]
             ao_dma_mask = contract('nig,ij->njg', ao_mask[:4], dm0a_mask)
             ao_dmb_mask = contract('nig,ij->njg', ao_mask[:4], dm0b_mask)
             vmata_dm_tmp = cupy.empty([3,3,nao_non0])
@@ -545,8 +545,8 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             _d1d2_dot_(ipipb, mol, [aow[1], aow[3], aow[4]], [ao[YX], ao[YY], ao[YZ]], mask, ao_loc, False)
             _d1d2_dot_(ipipb, mol, [aow[2], aow[4], aow[5]], [ao[ZX], ao[ZY], ao[ZZ]], mask, ao_loc, False)
 
-            dm0a_mask = dm0a_sorted[mask, mask[:,None]]
-            dm0b_mask = dm0b_sorted[mask, mask[:,None]]
+            dm0a_mask = dm0a_sorted[mask[:,None], mask]
+            dm0b_mask = dm0b_sorted[mask[:,None], mask]
             ao_dm0a = [numint._dot_ao_dm(mol, ao[i], dm0a, mask, shls_slice, ao_loc) for i in range(4)]
             ao_dm0b = [numint._dot_ao_dm(mol, ao[i], dm0b, mask, shls_slice, ao_loc) for i in range(4)]
             ao_dma_mask = contract('nig,ij->njg', ao_mask[:4], dm0a_mask)

--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -228,7 +228,10 @@ def dist_matrix(x, y, out=None):
 
 def block_c2s_diag(angular, counts):
     '''
-    constract a cartesian to spherical transformation of n shells
+    Diagonal blocked cartesian to spherical transformation
+    Args: 
+        angular (list): angular momentum type, e.g. [0,1,2,3]
+        counts (list): count of each angular momentum
     '''
     if _data['c2s'] is None:
         c2s_data = cupy.concatenate([cupy.asarray(x.ravel()) for x in c2s_l])

--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -226,7 +226,7 @@ def dist_matrix(x, y, out=None):
         raise RuntimeError('failed in calculating distance matrix')
     return out
 
-def block_c2s_diag(ncart, nsph, angular, counts):
+def block_c2s_diag(angular, counts):
     '''
     constract a cartesian to spherical transformation of n shells
     '''
@@ -246,7 +246,8 @@ def block_c2s_diag(ncart, nsph, angular, counts):
         offsets += [c2s_offset[l]] * count
     rows = cupy.hstack(rows)
     cols = cupy.hstack(cols)
-
+    
+    ncart, nsph = int(rows[-1]), int(cols[-1])
     cart2sph = cupy.zeros([ncart, nsph])
     offsets = cupy.asarray(offsets, dtype='int32')
 

--- a/gpu4pyscf/mp/dfmp2.py
+++ b/gpu4pyscf/mp/dfmp2.py
@@ -100,8 +100,7 @@ class DFMP2(mp2.MP2):
         mo_coeff = cupy.asarray(mo_coeff, order='C')
         Lov = None
         with_df = self.with_df
-        ao_idx = with_df.intopt.ao_idx
-        mo_coeff = mo_coeff[ao_idx]
+        mo_coeff = with_df.intopt.sort_orbitals(mo_coeff, axis=[0])
         orbo = mo_coeff[:,:nocc]
         orbv = mo_coeff[:,nocc:]
         blksize = with_df.get_blksize()

--- a/gpu4pyscf/qmmm/chelpg.py
+++ b/gpu4pyscf/qmmm/chelpg.py
@@ -89,8 +89,6 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     intopt.cart_ao_idx = np.hstack([ao_idx[i] for i in sorted_idx])
     ncart = cart_ao_loc[-1]
     intopt.cart2sph = block_c2s_diag(intopt.angular, l_ctr_counts)
-    #inv_idx = np.argsort(intopt.sph_ao_idx, kind='stable').astype(np.int32)
-    #intopt.coeff = intopt.cart2sph[:, inv_idx]
 
     # pairing auxiliary basis with fake basis set
     fake_l_ctr_offsets = np.append(0, np.cumsum(fake_l_ctr_counts))
@@ -160,9 +158,9 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     intopt._sorted_mol = sorted_mol
     intopt._sorted_auxmol = sorted_auxmol
     if intopt.mol.cart:
-        intopt.ao_idx = intopt.cart_ao_idx
+        intopt._ao_idx = intopt.cart_ao_idx
     else:
-        intopt.ao_idx = intopt.sph_ao_idx
+        intopt._ao_idx = intopt.sph_ao_idx
 
 def eval_chelpg_layer_gpu(mf, deltaR=0.3, Rhead=2.8, ifqchem=True, Rvdw=modified_Bondi, verbose=None):
     """Cal chelpg charge

--- a/gpu4pyscf/qmmm/chelpg.py
+++ b/gpu4pyscf/qmmm/chelpg.py
@@ -38,7 +38,7 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     but without transformation for auxiliary basis.
     '''
     sorted_mol, sorted_idx, uniq_l_ctr, l_ctr_counts = int3c2e.sort_mol(
-        intopt._mol_)
+        intopt.mol)
     if group_size is not None:
         uniq_l_ctr, l_ctr_counts = int3c2e._split_l_ctr_groups(
             uniq_l_ctr, l_ctr_counts, group_size)
@@ -48,7 +48,7 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     _, _, fake_uniq_l_ctr, fake_l_ctr_counts = int3c2e.sort_mol(fake_mol)
 
     # sort auxiliary mol
-    sorted_auxmol, sorted_aux_idx, aux_uniq_l_ctr, aux_l_ctr_counts = int3c2e.sort_mol(
+    sorted_auxmol, _, aux_uniq_l_ctr, aux_l_ctr_counts = int3c2e.sort_mol(
         intopt._auxmol_)
     if group_size_aux is not None:
         aux_uniq_l_ctr, aux_l_ctr_counts = int3c2e._split_l_ctr_groups(
@@ -77,8 +77,8 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     intopt.sph_ao_loc = [sph_ao_loc[cp] for cp in l_ctr_offsets]
     intopt.angular = [l[0] for l in uniq_l_ctr]
 
-    cart_ao_loc = intopt._mol_.ao_loc_nr(cart=True)
-    sph_ao_loc = intopt._mol_.ao_loc_nr(cart=False)
+    cart_ao_loc = intopt.mol.ao_loc_nr(cart=True)
+    sph_ao_loc = intopt.mol.ao_loc_nr(cart=False)
     nao = sph_ao_loc[-1]
     ao_idx = np.array_split(np.arange(nao), sph_ao_loc[1:-1])
     intopt.sph_ao_idx = np.hstack([ao_idx[i] for i in sorted_idx])
@@ -88,7 +88,6 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     ao_idx = np.array_split(np.arange(nao), cart_ao_loc[1:-1])
     intopt.cart_ao_idx = np.hstack([ao_idx[i] for i in sorted_idx])
     ncart = cart_ao_loc[-1]
-    nsph = sph_ao_loc[-1]
     intopt.cart2sph = block_c2s_diag(intopt.angular, l_ctr_counts)
     #inv_idx = np.argsort(intopt.sph_ao_idx, kind='stable').astype(np.int32)
     #intopt.coeff = intopt.cart2sph[:, inv_idx]
@@ -109,7 +108,6 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     cart_aux_loc = intopt._auxmol_.ao_loc_nr(cart=True)
     sph_aux_loc = intopt._auxmol_.ao_loc_nr(cart=False)
     ncart = cart_aux_loc[-1]
-    nsph = sph_aux_loc[-1]
     # inv_idx = np.argsort(intopt.sph_aux_idx, kind='stable').astype(np.int32)
     aux_l_ctr_offsets += fake_l_ctr_offsets[-1]
 
@@ -161,7 +159,7 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
 
     intopt._sorted_mol = sorted_mol
     intopt._sorted_auxmol = sorted_auxmol
-    if intopt._mol_.cart:
+    if intopt.mol.cart:
         intopt.ao_idx = intopt.cart_ao_idx
     else:
         intopt.ao_idx = intopt.sph_ao_idx

--- a/gpu4pyscf/qmmm/chelpg.py
+++ b/gpu4pyscf/qmmm/chelpg.py
@@ -49,7 +49,7 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
 
     # sort auxiliary mol
     sorted_auxmol, _, aux_uniq_l_ctr, aux_l_ctr_counts = int3c2e.sort_mol(
-        intopt._auxmol_)
+        intopt.auxmol)
     if group_size_aux is not None:
         aux_uniq_l_ctr, aux_l_ctr_counts = int3c2e._split_l_ctr_groups(
             aux_uniq_l_ctr, aux_l_ctr_counts, group_size_aux)
@@ -105,8 +105,8 @@ def _build_VHFOpt(intopt, cutoff=1e-14, group_size=None,
     intopt.sph_aux_loc = [sph_aux_loc[cp] for cp in aux_l_ctr_offsets]
     intopt.aux_angular = [l[0] for l in aux_uniq_l_ctr]
 
-    cart_aux_loc = intopt._auxmol_.ao_loc_nr(cart=True)
-    sph_aux_loc = intopt._auxmol_.ao_loc_nr(cart=False)
+    cart_aux_loc = intopt.auxmol.ao_loc_nr(cart=True)
+    sph_aux_loc = intopt.auxmol.ao_loc_nr(cart=False)
     ncart = cart_aux_loc[-1]
     # inv_idx = np.argsort(intopt.sph_aux_idx, kind='stable').astype(np.int32)
     aux_l_ctr_offsets += fake_l_ctr_offsets[-1]
@@ -253,8 +253,8 @@ def eval_chelpg_layer_gpu(mf, deltaR=0.3, Rhead=2.8, ifqchem=True, Rvdw=modified
     for ibatch in range(0, ngrids, nbatch):
         max_grid = min(ibatch+nbatch, ngrids)
         num_grids = max_grid - ibatch
-        ptr = intopt._auxmol_._atm[:num_grids, gto.PTR_COORD]
-        intopt._auxmol_._env[np.vstack(
+        ptr = intopt.auxmol._atm[:num_grids, gto.PTR_COORD]
+        intopt.auxmol._env[np.vstack(
             (ptr, ptr+1, ptr+2)).T] = gridcoords[ibatch:max_grid]
         _build_VHFOpt(intopt, 1e-14, diag_block_with_triu=False, aosym=True)
         potential_real[ibatch:max_grid] -= 2.0 * \

--- a/gpu4pyscf/qmmm/pbc/itrf.py
+++ b/gpu4pyscf/qmmm/pbc/itrf.py
@@ -1026,7 +1026,8 @@ class QMMMGrad:
                 v = cp.zeros_like(g_qm)
                 for i0,i1,j0,j1,k0,k1,j3c in int3c2e.loop_int3c2e_general(intopt, ip_type='ip1'):
                     v[:,i0:i1,j0:j1] += contract('xkji,k->xij', j3c, charges[k0:k1])
-                g_qm += cupy_helper.take_last2d(v, intopt.rev_ao_idx)
+                v = intopt.unsort_orbitals(v, axis=[1,2])
+                g_qm += v #cupy_helper.take_last2d(v, intopt.rev_ao_idx)
             elif mm_mol.charge_model == 'point' and len(coords) != 0:
                 max_memory = self.max_memory - lib.current_memory()[0]
                 blksize = int(min(max_memory*1e6/8/nao**2/3, 200))
@@ -1079,7 +1080,7 @@ class QMMMGrad:
             intopt.build(self.base.direct_scf_tol, diag_block_with_triu=True, aosym=False, 
                          group_size=int3c2e.BLKSIZE, group_size_aux=int3c2e.BLKSIZE)
 
-            dm_ = cupy_helper.take_last2d(dm, intopt.sph_ao_idx)
+            dm_ = intopt.sort_orbitals(dm, axis=[0,1])
             for i0,i1,j0,j1,k0,k1,j3c in int3c2e.loop_int3c2e_general(intopt, ip_type='ip2'):
                 j3c = contract('xkji,k->xkji', j3c, charges[k0:k1])
                 g_[k0:k1] += contract('xkji,ij->kx', j3c, dm_[i0:i1,j0:j1])

--- a/gpu4pyscf/scf/int2c2e.py
+++ b/gpu4pyscf/scf/int2c2e.py
@@ -33,7 +33,7 @@ def get_int2c2e_sorted(mol, intopt=None, direct_scf_tol=1e-13, aosym=None, omega
     nao = mol.nao
     rows, cols = np.tril_indices(nao)
 
-    nao_cart = intopt.mol.nao
+    nao_cart = intopt._sorted_mol.nao
     norb_cart = nao_cart + 1
 
     int2c = cupy.zeros([nao_cart, nao_cart], order='F')
@@ -137,5 +137,5 @@ def get_int2c2e(mol, direct_scf_tol=1e-13):
     intopt = VHFOpt(mol, mol, 'int2e')
     intopt.build(direct_scf_tol, diag_block_with_triu=True, aosym=True)
     int2c = get_int2c2e_sorted(mol, intopt=intopt)
-    int2c = take_last2d(int2c, intopt.rev_ao_idx)
+    int2c = intopt.unsort_orbitals(int2c, axis=[0,1])
     return int2c

--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -243,11 +243,11 @@ def grad_qv(pcmobj, dm):
     dvj, _ = int3c2e.get_int3c2e_ip_jk(intopt, 0, 'ip1', q_sym, None, dm_cart)
     dq, _ = int3c2e.get_int3c2e_ip_jk(intopt, 0, 'ip2', q_sym, None, dm_cart)
 
-    cart_ao_idx = intopt.cart_ao_idx
-    rev_cart_ao_idx = numpy.argsort(cart_ao_idx)
-    dvj = dvj[:,rev_cart_ao_idx]
-
-    aoslice = intopt.mol.aoslice_by_atom()
+    if not mol.cart:
+        dvj = dvj @ intopt.cart2sph
+    dvj = intopt.unsort_orbitals(dvj, axis=[1])
+    
+    aoslice = intopt._mol_.aoslice_by_atom()
     dq = cupy.asarray([cupy.sum(dq[:,p0:p1], axis=1) for p0,p1 in gridslice])
     dvj= 2.0 * cupy.asarray([cupy.sum(dvj[:,p0:p1], axis=1) for p0,p1 in aoslice[:,2:]])
     de = dq + dvj

--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -247,7 +247,7 @@ def grad_qv(pcmobj, dm):
         dvj = dvj @ intopt.cart2sph
     dvj = intopt.unsort_orbitals(dvj, axis=[1])
     
-    aoslice = intopt._mol_.aoslice_by_atom()
+    aoslice = intopt.mol.aoslice_by_atom()
     dq = cupy.asarray([cupy.sum(dq[:,p0:p1], axis=1) for p0,p1 in gridslice])
     dvj= 2.0 * cupy.asarray([cupy.sum(dvj[:,p0:p1], axis=1) for p0,p1 in aoslice[:,2:]])
     de = dq + dvj

--- a/gpu4pyscf/solvent/hessian/pcm.py
+++ b/gpu4pyscf/solvent/hessian/pcm.py
@@ -105,7 +105,7 @@ def hess_qv(pcmobj, dm, verbose=None):
     rev_cart_ao_idx = numpy.argsort(cart_ao_idx)
     dvj = dvj[:,rev_cart_ao_idx]
 
-    aoslice = intopt.mol.aoslice_by_atom()
+    aoslice = intopt._mol_.aoslice_by_atom()
     dq = cupy.asarray([cupy.sum(dq[:,p0:p1], axis=1) for p0,p1 in gridslice])
     dvj= 2.0 * cupy.asarray([cupy.sum(dvj[:,p0:p1], axis=1) for p0,p1 in aoslice[:,2:]])
     de = dq + dvj

--- a/gpu4pyscf/solvent/hessian/pcm.py
+++ b/gpu4pyscf/solvent/hessian/pcm.py
@@ -105,7 +105,7 @@ def hess_qv(pcmobj, dm, verbose=None):
     rev_cart_ao_idx = numpy.argsort(cart_ao_idx)
     dvj = dvj[:,rev_cart_ao_idx]
 
-    aoslice = intopt._mol_.aoslice_by_atom()
+    aoslice = intopt.mol.aoslice_by_atom()
     dq = cupy.asarray([cupy.sum(dq[:,p0:p1], axis=1) for p0,p1 in gridslice])
     dvj= 2.0 * cupy.asarray([cupy.sum(dvj[:,p0:p1], axis=1) for p0,p1 in aoslice[:,2:]])
     de = dq + dvj

--- a/gpu4pyscf/solvent/tests/test_pcm_hessian.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_hessian.py
@@ -128,9 +128,19 @@ class KnownValues(unittest.TestCase):
         hess_gpu = hessobj.kernel()
         assert np.linalg.norm(hess_cpu - hess_gpu) < 1e-8
         '''
+        mol = gto.Mole()
+        mol.atom = '''
+O       0.0000000000    -0.0000000000     0.1174000000
+H      -0.7570000000    -0.0000000000    -0.4696000000
+H       0.7570000000     0.0000000000    -0.4696000000
+    '''
+        mol.basis = 'sto-3g'
+        mol.output = '/dev/null'
+        mol.build(verbose=0)
         mf = pyscf.dft.RKS(mol, xc='b3lyp').density_fit().PCM()
         mf.conv_tol = 1e-12
         mf.conv_tol_cpscf = 1e-7
+        mf.grids.atom_grid = (50,194)
         mf.kernel()
         hessobj = mf.Hessian()
         hess_cpu = hessobj.kernel()
@@ -148,9 +158,19 @@ class KnownValues(unittest.TestCase):
         e_cpu = mf.kernel()
         assert abs(e_cpu - e_gpu) < 1e-8
         '''
+        mol = gto.Mole()
+        mol.atom = '''
+O       0.0000000000    -0.0000000000     0.1174000000
+H      -0.7570000000    -0.0000000000    -0.4696000000
+H       0.7570000000     0.0000000000    -0.4696000000
+    '''
+        mol.basis = 'sto-3g'
+        mol.output = '/dev/null'
+        mol.build(verbose=0)
         mf = dft.RKS(mol, xc='b3lyp').density_fit().PCM()
         mf.conv_tol = 1e-12
         mf.conv_tol_cpscf = 1e-7
+        mf.grids.atom_grid = (50,194)
         mf.kernel()
         hessobj = mf.Hessian()
         hess_gpu = hessobj.kernel()

--- a/gpu4pyscf/tests/test_dft.py
+++ b/gpu4pyscf/tests/test_dft.py
@@ -132,12 +132,10 @@ class KnownValues(unittest.TestCase):
         assert np.abs(e_dft - -685.0578838805443) < 1e-7
 
         g = mf.nuc_grad_method().kernel()
-        print(np.abs(cupy.linalg.norm(g)))
-        assert np.abs(cupy.linalg.norm(g) - 0.16804945458657145) < 1e-5
+        assert np.abs(cupy.linalg.norm(g) - 0.16905807654571403) < 1e-5
 
         h = mf.Hessian().kernel()
-        print(np.abs(cupy.linalg.norm(h)))
-        assert np.abs(cupy.linalg.norm(h) - 3.741783814494321) < 1e-4
+        assert np.abs(cupy.linalg.norm(h) - 3.743840896534178) < 1e-4
 
     @pytest.mark.smoke
     def test_DFUKS_with_SMD(self):
@@ -152,12 +150,10 @@ class KnownValues(unittest.TestCase):
         assert np.abs(e_dft - -685.05788388063) < 1e-7
 
         g = mf.nuc_grad_method().kernel()
-        print(np.abs(cupy.linalg.norm(g)))
-        assert np.abs(cupy.linalg.norm(g) - 0.1680496465773684) < 1e-5
+        assert np.abs(cupy.linalg.norm(g) - 0.1690582751813457) < 1e-5
 
         h = mf.Hessian().kernel()
-        print(np.abs(cupy.linalg.norm(h)))
-        assert np.abs(cupy.linalg.norm(h) - 3.7417788481647563) < 1e-4
+        assert np.abs(cupy.linalg.norm(h) - 3.743858482519822) < 1e-4
 
 if __name__ == "__main__":
     print("Full Smoke Tests")

--- a/gpu4pyscf/tests/test_dft.py
+++ b/gpu4pyscf/tests/test_dft.py
@@ -132,6 +132,7 @@ class KnownValues(unittest.TestCase):
         assert np.abs(e_dft - -685.0578838805443) < 1e-7
 
         g = mf.nuc_grad_method().kernel()
+        print(np.abs(cupy.linalg.norm(g)))
         assert np.abs(cupy.linalg.norm(g) - 0.16804945458657145) < 1e-5
 
         h = mf.Hessian().kernel()
@@ -151,6 +152,7 @@ class KnownValues(unittest.TestCase):
         assert np.abs(e_dft - -685.05788388063) < 1e-7
 
         g = mf.nuc_grad_method().kernel()
+        print(np.abs(cupy.linalg.norm(g)))
         assert np.abs(cupy.linalg.norm(g) - 0.1680496465773684) < 1e-5
 
         h = mf.Hessian().kernel()

--- a/gpu4pyscf/tests/test_dft.py
+++ b/gpu4pyscf/tests/test_dft.py
@@ -13,12 +13,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import unittest
 import numpy as np
 import pyscf
 import pytest
 import cupy
+from gpu4pyscf.dft import rks, uks
 
-atom = '''
+def setUpModule():
+    global mol
+    atom = '''
 C                 -0.07551087    1.68127663   -0.10745193
 O                  1.33621755    1.87147409   -0.39326987
 C                  1.67074668    2.95729545    0.49387976
@@ -41,112 +45,118 @@ O                 -3.00083741    0.38730252   -2.10989934
 H                 -3.93210821    0.28874990   -1.89865997
 '''
 
-mol = pyscf.M(atom=atom, basis='def2-tzvpp', max_memory=32000, cart=0)
-mol.output = '/dev/null'
-mol.build()
-mol.verbose = 1
+    mol = pyscf.M(atom=atom, basis='def2-tzvpp', max_memory=32000, cart=0)
+    mol.output = '/dev/null'
+    mol.build()
+    mol.verbose = 1
 
-@pytest.mark.smoke
-def test_b3lyp_with_d3bj():
-    print('-------- DFRKS with D3(BJ) -------')
-    from gpu4pyscf.dft import rks
-    mf = rks.RKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
-    mf.grids.atom_grid = (99,590)
-    mf.conv_tol = 1e-10
-    mf.conv_tol_cpscf = 1e-8
-    mf.disp = 'd3bj'
-    e_dft = mf.kernel()
-    assert np.abs(e_dft - -685.0326965348272) < 1e-7
+def tearDownModule():
+    global mol
+    mol.stdout.close()
+    del mol
 
-    g = mf.nuc_grad_method().kernel()
-    assert np.abs(cupy.linalg.norm(g) - 0.17498362161082373) < 1e-5
+class KnownValues(unittest.TestCase):
+    @pytest.mark.smoke
+    def test_b3lyp_with_d3bj(self):
+        print('-------- DFRKS with D3(BJ) -------')
+        mf = rks.RKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-10
+        mf.conv_tol_cpscf = 1e-8
+        mf.disp = 'd3bj'
+        e_dft = mf.kernel()
+        assert np.abs(e_dft - -685.0326965348272) < 1e-7
 
-    h = mf.Hessian().kernel()
-    assert np.abs(cupy.linalg.norm(h) - 3.7684319231335377) < 1e-4
+        g = mf.nuc_grad_method().kernel()
+        assert np.abs(cupy.linalg.norm(g) - 0.17498362161082373) < 1e-5
 
-@pytest.mark.smoke
-def test_b3lyp_d3bj():
-    print('-------- DFRKS with D3(BJ) -------')
-    from gpu4pyscf.dft import rks
-    mf = rks.RKS(mol, xc='b3lyp-d3bj').density_fit(auxbasis='def2-tzvpp-jkfit')
-    mf.grids.atom_grid = (99,590)
-    mf.conv_tol = 1e-10
-    mf.conv_tol_cpscf = 1e-8
-    e_dft = mf.kernel()
-    assert np.abs(e_dft - -685.0326965348272) < 1e-7
+        h = mf.Hessian().kernel()
+        assert np.abs(cupy.linalg.norm(h) - 3.7684319231335377) < 1e-4
 
-    g = mf.nuc_grad_method().kernel()
-    assert np.abs(cupy.linalg.norm(g) - 0.17498362161082373) < 1e-5
+    @pytest.mark.smoke
+    def test_b3lyp_d3bj(self):
+        print('-------- DFRKS with D3(BJ) -------')
+        mf = rks.RKS(mol, xc='b3lyp-d3bj').density_fit(auxbasis='def2-tzvpp-jkfit')
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-10
+        mf.conv_tol_cpscf = 1e-8
+        e_dft = mf.kernel()
+        assert np.abs(e_dft - -685.0326965348272) < 1e-7
 
-    h = mf.Hessian().kernel()
-    assert np.abs(cupy.linalg.norm(h) - 3.7684319231335377) < 1e-4
+        g = mf.nuc_grad_method().kernel()
+        assert np.abs(cupy.linalg.norm(g) - 0.17498362161082373) < 1e-5
 
-@pytest.mark.smoke
-def test_DFUKS():
-    print('------- DFUKS with D3(BJ) -------')
-    from gpu4pyscf.dft import uks
-    mf = uks.UKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
-    mf.grids.atom_grid = (99,590)
-    mf.conv_tol = 1e-10
-    mf.conv_tol_cpscf = 1e-8
-    mf.disp = 'd3bj'
-    e_dft = mf.kernel()
-    assert np.abs(e_dft - -685.0326965349493) < 1e-7
+        h = mf.Hessian().kernel()
+        assert np.abs(cupy.linalg.norm(h) - 3.7684319231335377) < 1e-4
 
-    g = mf.nuc_grad_method().kernel()
-    assert np.abs(cupy.linalg.norm(g) - 0.17498264516108836) < 1e-5
+    @pytest.mark.smoke
+    def test_DFUKS(self):
+        print('------- DFUKS with D3(BJ) -------')
+        mf = uks.UKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-10
+        mf.conv_tol_cpscf = 1e-8
+        mf.disp = 'd3bj'
+        e_dft = mf.kernel()
+        assert np.abs(e_dft - -685.0326965349493) < 1e-7
 
-    h = mf.Hessian().kernel()
-    assert np.abs(cupy.linalg.norm(h) - 3.768429871470736) < 1e-4
+        g = mf.nuc_grad_method().kernel()
+        assert np.abs(cupy.linalg.norm(g) - 0.17498264516108836) < 1e-5
 
-@pytest.mark.smoke
-def test_RKS():
-    print('-------- RKS with D3(BJ) -------')
-    from gpu4pyscf.dft import rks
-    mf = rks.RKS(mol, xc='b3lyp')
-    mf.grids.atom_grid = (99,590)
-    mf.conv_tol = 1e-12
-    mf.disp = 'd3bj'
-    e_dft = mf.kernel()
-    assert np.abs(e_dft - -685.0325611822375) < 1e-7
+        h = mf.Hessian().kernel()
+        assert np.abs(cupy.linalg.norm(h) - 3.768429871470736) < 1e-4
 
-    g = mf.nuc_grad_method().kernel()
-    assert np.abs(cupy.linalg.norm(g) - 0.1750368231223345) < 1e-6
+    @pytest.mark.smoke
+    def test_RKS(self):
+        print('-------- RKS with D3(BJ) -------')
+        mf = rks.RKS(mol, xc='b3lyp')
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-12
+        mf.disp = 'd3bj'
+        e_dft = mf.kernel()
+        assert np.abs(e_dft - -685.0325611822375) < 1e-7
 
-@pytest.mark.smoke
-def test_DFRKS_with_SMD():
-    print('----- DFRKS with SMD -----')
-    from gpu4pyscf.dft import rks
-    mf = rks.RKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
-    mf = mf.SMD()
-    mf.grids.atom_grid = (99,590)
-    mf.conv_tol = 1e-10
-    mf.conv_tol_cpscf = 1e-8
-    mf.disp = 'd3bj'
-    e_dft = mf.kernel()
-    assert np.abs(e_dft - -685.0578838805443) < 1e-7
+        g = mf.nuc_grad_method().kernel()
+        assert np.abs(cupy.linalg.norm(g) - 0.1750368231223345) < 1e-6
 
-    g = mf.nuc_grad_method().kernel()
-    assert np.abs(cupy.linalg.norm(g) - 0.16804945458657145) < 1e-5
+    @pytest.mark.smoke
+    def test_DFRKS_with_SMD(self):
+        print('----- DFRKS with SMD -----')
+        mf = rks.RKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
+        mf = mf.SMD()
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-10
+        mf.conv_tol_cpscf = 1e-8
+        mf.disp = 'd3bj'
+        e_dft = mf.kernel()
+        assert np.abs(e_dft - -685.0578838805443) < 1e-7
 
-    h = mf.Hessian().kernel()
-    assert np.abs(cupy.linalg.norm(h) - 3.741783814494321) < 1e-4
+        g = mf.nuc_grad_method().kernel()
+        assert np.abs(cupy.linalg.norm(g) - 0.16804945458657145) < 1e-5
 
-@pytest.mark.smoke
-def test_DFUKS_with_SMD():
-    print('------- DFUKS with SMD ---------')
-    from gpu4pyscf.dft import uks
-    mf = uks.UKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
-    mf = mf.SMD()
-    mf.grids.atom_grid = (99,590)
-    mf.conv_tol = 1e-10
-    mf.conv_tol_cpscf = 1e-8
-    mf.disp = 'd3bj'
-    e_dft = mf.kernel()
-    assert np.abs(e_dft - -685.05788388063) < 1e-7
+        h = mf.Hessian().kernel()
+        print(np.abs(cupy.linalg.norm(h)))
+        assert np.abs(cupy.linalg.norm(h) - 3.741783814494321) < 1e-4
 
-    g = mf.nuc_grad_method().kernel()
-    assert np.abs(cupy.linalg.norm(g) - 0.1680496465773684) < 1e-5
+    @pytest.mark.smoke
+    def test_DFUKS_with_SMD(self):
+        print('------- DFUKS with SMD ---------')
+        mf = uks.UKS(mol, xc='b3lyp').density_fit(auxbasis='def2-tzvpp-jkfit')
+        mf = mf.SMD()
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-10
+        mf.conv_tol_cpscf = 1e-8
+        mf.disp = 'd3bj'
+        e_dft = mf.kernel()
+        assert np.abs(e_dft - -685.05788388063) < 1e-7
 
-    h = mf.Hessian().kernel()
-    assert np.abs(cupy.linalg.norm(h) - 3.7417788481647563) < 1e-4
+        g = mf.nuc_grad_method().kernel()
+        assert np.abs(cupy.linalg.norm(g) - 0.1680496465773684) < 1e-5
+
+        h = mf.Hessian().kernel()
+        print(np.abs(cupy.linalg.norm(h)))
+        assert np.abs(cupy.linalg.norm(h) - 3.7417788481647563) < 1e-4
+
+if __name__ == "__main__":
+    print("Full Smoke Tests")
+    unittest.main()


### PR DESCRIPTION
This PR tries to refactor two classes `_VHFOpt` and `_GDFTOpt`, and reduce the confusions in the conventions.
- Define `sort_orbitals` and `unsort_orbitals` for transforming between the original AO and sorted AO.
- Remove the usage of `ao_idx` and `aux_ao_idx` in other modules.
- `opt.mol` for the original mol. `opt._sorted_mol` for sorted mol. 