### PR TITLE
Update eval_ao for the compatibility with PySCF

### DIFF
--- a/gpu4pyscf/__config__.py
+++ b/gpu4pyscf/__config__.py
@@ -2,37 +2,16 @@ import cupy
 
 props = cupy.cuda.runtime.getDeviceProperties(0)
 GB = 1024*1024*1024
-# such as A100-80G
-if props['totalGlobalMem'] >= 64 * GB:
-    min_ao_blksize = 128
-    min_grid_blksize = 128*128
-    ao_aligned = 32
-    grid_aligned = 256
-    mem_fraction = 0.9
-    number_of_threads = 2048 * 108
-# such as V100-32G
-elif props['totalGlobalMem'] >= 32 * GB:
-    min_ao_blksize = 128
-    min_grid_blksize = 128*128
-    ao_aligned = 32
-    grid_aligned = 256
-    mem_fraction = 0.9
-    number_of_threads = 1024 * 80
-# such as A30-24GB
-elif props['totalGlobalMem'] >= 16 * GB:
-    min_ao_blksize = 128
-    min_grid_blksize = 128*128
-    ao_aligned = 32
-    grid_aligned = 256
-    mem_fraction = 0.9
-    number_of_threads = 1024 * 80
-# other gaming cards
-else:
+min_ao_blksize = 128
+min_grid_blksize = 128*128
+ao_aligned = 32
+grid_aligned = 256
+
+# Use smaller blksize for old gaming GPUs
+if props['totalGlobalMem'] < 16 * GB:
     min_ao_blksize = 64
     min_grid_blksize = 64*64
-    ao_aligned = 32
-    grid_aligned = 128
-    mem_fraction = 0.9
-    number_of_threads = 1024 * 80
 
+# Use 90% of the global memory for CuPy memory pool
+mem_fraction = 0.9
 cupy.get_default_memory_pool().set_limit(fraction=mem_fraction)

--- a/gpu4pyscf/dft/tests/test_ao_values.py
+++ b/gpu4pyscf/dft/tests/test_ao_values.py
@@ -54,37 +54,35 @@ class KnownValues(unittest.TestCase):
     def test_ao_sph_deriv0(self):
         coords = np.random.random((100,3))
         ao = mol_sph.eval_gto('GTOval_sph_deriv0', coords)
-        ao_cpu = cupy.asarray(ao.T)
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_sph, coords, deriv=0)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
-        ao_gpu = numint.eval_ao(mol_sph, coords, deriv=0)
-        assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
-
+        
     def test_ao_sph_deriv1(self):
         coords = np.random.random((100,3))
         ao = mol_sph.eval_gto('GTOval_sph_deriv1', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_sph, coords, deriv=1)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 
     def test_ao_sph_deriv2(self):
         coords = np.random.random((4,3))
         ao = mol_sph.eval_gto('GTOval_sph_deriv2', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_sph, coords, deriv=2)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 
     def test_ao_sph_deriv3(self):
         coords = np.random.random((100,3))
         ao = mol_sph.eval_gto('GTOval_sph_deriv3', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_sph, coords, deriv=3)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 
     def test_ao_sph_deriv4(self):
         coords = np.random.random((100,3))
         ao = mol_sph.eval_gto('GTOval_sph_deriv4', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_sph, coords, deriv=4)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 
@@ -92,28 +90,28 @@ class KnownValues(unittest.TestCase):
     def test_ao_cart_deriv0(self):
         coords = np.random.random((100,3))
         ao = mol_cart.eval_gto('GTOval_cart_deriv0', coords)
-        ao_cpu = cupy.asarray(ao.T)
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_cart, coords, deriv=0)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 
     def test_ao_cart_deriv1(self):
         coords = np.random.random((100,3))
         ao = mol_cart.eval_gto('GTOval_cart_deriv1', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_cart, coords, deriv=1)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 
     def test_ao_cart_deriv2(self):
         coords = np.random.random((100,3))
         ao = mol_cart.eval_gto('GTOval_cart_deriv2', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_cart, coords, deriv=2)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 
     def test_ao_cart_deriv3(self):
         coords = np.random.random((100,3))
         ao = mol_cart.eval_gto('GTOval_cart_deriv3', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ni = NumInt()
         ao_gpu = ni.eval_ao(mol_cart, coords, deriv=3)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
@@ -121,7 +119,7 @@ class KnownValues(unittest.TestCase):
     def test_ao_cart_deriv4(self):
         coords = np.random.random((100,3))
         ao = mol_cart.eval_gto('GTOval_cart_deriv4', coords)
-        ao_cpu = cupy.asarray(ao.transpose(0,2,1))
+        ao_cpu = cupy.asarray(ao)
         ao_gpu = numint.eval_ao(mol_cart, coords, deriv=4)
         assert cupy.linalg.norm(ao_cpu - ao_gpu) < 1e-8
 

--- a/gpu4pyscf/dft/tests/test_numint.py
+++ b/gpu4pyscf/dft/tests/test_numint.py
@@ -219,11 +219,10 @@ class KnownValues(unittest.TestCase):
         ni_gpu = NumInt()
         ni_cpu = pyscf_numint()
         for xctype in ('LDA', 'GGA', 'MGGA'):
-            print(xctype)
             deriv = 1
             if xctype == 'LDA':
                 deriv = 0
-            ao_gpu = ni_gpu.eval_ao(mol, grids_gpu.coords, deriv=deriv)
+            ao_gpu = ni_gpu.eval_ao(mol, grids_gpu.coords, deriv=deriv, transpose=False)
             ao_cpu = ni_cpu.eval_ao(mol, grids_cpu.coords, deriv=deriv)
             rho = ni_gpu.eval_rho(mol, ao_gpu, dm, xctype=xctype, hermi=0, with_lapl=False)
             ref = ni_cpu.eval_rho(mol, ao_cpu, dm, xctype=xctype, hermi=0, with_lapl=False)

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -352,7 +352,7 @@ def get_vxc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
         for atm_id, (coords, weight, weight1) in enumerate(grids_response_cc(grids)):
             ngrids = weight.size
             for p0, p1 in lib.prange(0,ngrids,block_size):
-                ao = numint.eval_ao(_sorted_mol, coords[p0:p1, :], ao_deriv, gdftopt=opt)
+                ao = numint.eval_ao(_sorted_mol, coords[p0:p1, :], ao_deriv, gdftopt=opt, transpose=False)
 
                 if xctype == 'LDA':
                     rho = numint.eval_rho(_sorted_mol, ao[0], dms,
@@ -403,7 +403,7 @@ def get_vxc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     #:vmat = cupy.einsum('pi,npq,qj->nij', coeff, vmat, coeff)
     vmat = sandwich_dot(vmat, coeff)
-    
+
     # - sign because nabla_X = -nabla_x
     return excsum, -vmat
 
@@ -418,7 +418,7 @@ def grids_response_cc(grids):
     atm_dist = gto.inter_distance(mol, atm_coords)
     atm_dist = cupy.asarray(atm_dist)
     atm_coords = cupy.asarray(atm_coords)
-    
+
     def _radii_adjust(mol, atomic_radii):
         charges = mol.atom_charges()
         if grids.radii_adjust == radi.treutler_atomic_radii_adjust:

--- a/gpu4pyscf/grad/uks.py
+++ b/gpu4pyscf/grad/uks.py
@@ -90,7 +90,7 @@ def get_veff(ks_grad, mol=None, dm=None, verbose=None):
             vxc_tmp[0] += vnlc
             vxc_tmp[1] += vnlc
     t0 = logger.timer(ks_grad, 'vxc', *t0)
-    
+
     mo_coeff_alpha = mf.mo_coeff[0]
     mo_coeff_beta = mf.mo_coeff[1]
     occ_coeff0 = cupy.asarray(mo_coeff_alpha[:, mf.mo_occ[0]>0.5], order='C')
@@ -237,7 +237,7 @@ def get_vxc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
         for atm_id, (coords, weight, weight1) in enumerate(rks_grad.grids_response_cc(grids)):
             ngrids = weight.size
             for p0, p1 in lib.prange(0,ngrids,block_size):
-                ao = numint.eval_ao(_sorted_mol, coords[p0:p1, :], ao_deriv, gdftopt=opt)
+                ao = numint.eval_ao(_sorted_mol, coords[p0:p1, :], ao_deriv, gdftopt=opt, transpose=False)
                 if xctype == 'LDA':
                     rho_a = numint.eval_rho(_sorted_mol, ao[0], dms[0],
                                         xctype=xctype, hermi=1, with_lapl=False)


### PR DESCRIPTION
- By default, `eval_ao` returns the same shape as the function in PySCF.
- Simplified `__config__.py`