### PR TITLE
Set default conv_tol_cpscf && refactor uhf class

### DIFF
--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -16,9 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import h5py
-import numpy as np
 import cupy
-import scipy.linalg
 from functools import reduce
 from pyscf import gto
 from pyscf import lib as pyscf_lib
@@ -354,7 +352,7 @@ class SCF(pyscf_lib.StreamObject):
     conv_tol_grad       = hf_cpu.SCF.conv_tol_grad
     max_cycle           = hf_cpu.SCF.max_cycle
     init_guess          = hf_cpu.SCF.init_guess
-    conv_tol_cpscf      = 1e-4
+    conv_tol_cpscf      = 1e-6   # TODO: reuse the default value in PySCF
 
     disp                = None
     DIIS                = diis.SCF_DIIS

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -449,7 +449,6 @@ class SCF(pyscf_lib.StreamObject):
     stability                = NotImplemented
     nuc_grad_method          = NotImplemented
     update_                  = NotImplemented
-    canonicalize             = NotImplemented
     istype                   = hf_cpu.SCF.istype
     to_rhf                   = NotImplemented
     to_uhf                   = NotImplemented

--- a/gpu4pyscf/scf/uhf.py
+++ b/gpu4pyscf/scf/uhf.py
@@ -18,15 +18,13 @@
 from functools import reduce
 import numpy as np
 import cupy
-from pyscf.scf import uhf
-from pyscf import lib as pyscf_lib
+from pyscf.scf import uhf as uhf_cpu
 from pyscf import __config__
 
 from gpu4pyscf.scf.hf import eigh, damping, level_shift
 from gpu4pyscf.scf import hf
 from gpu4pyscf.lib import logger
 from gpu4pyscf.lib.cupy_helper import tag_array
-from gpu4pyscf.scf import diis
 
 def make_rdm1(mo_coeff, mo_occ, **kwargs):
     '''One-particle density matrix in AO representation
@@ -205,6 +203,7 @@ class UHF(hf.SCF):
     @property
     def nelectron_alpha(self):
         return self.nelec[0]
+    
     @nelectron_alpha.setter
     def nelectron_alpha(self, x):
         logger.warn(self, 'WARN: Attribute .nelectron_alpha is deprecated. '
@@ -215,10 +214,8 @@ class UHF(hf.SCF):
     def dump_flags(self, verbose=None):
         return
 
-    get_jk = hf._get_jk
-    _eigh = staticmethod(eigh)
     get_fock = get_fock
-    get_occ = uhf.get_occ
+    get_occ = uhf_cpu.get_occ
 
     def get_grad(self, mo_coeff, mo_occ, fock=None):
         if fock is None:
@@ -226,47 +223,27 @@ class UHF(hf.SCF):
             fock = self.get_hcore(self.mol) + self.get_veff(self.mol, dm1)
         return get_grad(mo_coeff, mo_occ, fock)
 
-    make_asym_dm       = NotImplemented
+    make_asym_dm             = NotImplemented
     make_rdm2                = NotImplemented
     energy_elec              = energy_elec
-    get_init_guess           = hf.return_cupy_array(uhf.UHF.get_init_guess)
-    init_guess_by_minao      = uhf.UHF.init_guess_by_minao
-    init_guess_by_atom       = uhf.UHF.init_guess_by_atom
-    init_guess_by_huckel     = uhf.UHF.init_guess_by_huckel
-    init_guess_by_mod_huckel = uhf.UHF.init_guess_by_mod_huckel
-    init_guess_by_1e         = uhf.UHF.init_guess_by_1e
-    init_guess_by_chkfile    = uhf.UHF.init_guess_by_chkfile
-    _finalize          = uhf.UHF._finalize
+    get_init_guess           = hf.return_cupy_array(uhf_cpu.UHF.get_init_guess)
+    init_guess_by_minao      = uhf_cpu.UHF.init_guess_by_minao
+    init_guess_by_atom       = uhf_cpu.UHF.init_guess_by_atom
+    init_guess_by_huckel     = uhf_cpu.UHF.init_guess_by_huckel
+    init_guess_by_mod_huckel = uhf_cpu.UHF.init_guess_by_mod_huckel
+    init_guess_by_1e         = uhf_cpu.UHF.init_guess_by_1e
+    init_guess_by_chkfile    = uhf_cpu.UHF.init_guess_by_chkfile
+    _finalize                = uhf_cpu.UHF._finalize
 
-    conv_tol_cpscf = 1e-4
-    DIIS = diis.SCF_DIIS
-    #get_jk = _get_jk
-
-    get_hcore = hf.RHF.get_hcore
-    get_ovlp = hf.RHF.get_ovlp
-    get_init_guess = hf.return_cupy_array(uhf.UHF.get_init_guess)
-    density_fit = hf.RHF.density_fit
-    energy_tot = hf.RHF.energy_tot
-    energy_elec = energy_elec
-    canonicalize = canonicalize
-
-    make_rdm2 = NotImplemented
-    x2c = x2c1e = sfx2c1e = NotImplemented
-    to_rhf = NotImplemented
-    to_uhf = NotImplemented
-    to_ghf = NotImplemented
-    to_rks = NotImplemented
-    to_uks = NotImplemented
-    to_gks = NotImplemented
-    to_ks = NotImplemented
     # TODO: Enable followings after testing
-    analyze = NotImplemented
-    stability = NotImplemented
-    mulliken_pop = NotImplemented
-    mulliken_spin_pop = NotImplemented
-    mulliken_meta = NotImplemented
-    mulliken_meta_spin = NotImplemented
-    det_ovlp = NotImplemented
+    analyze                 = NotImplemented
+    stability               = NotImplemented
+    mulliken_spin_pop       = NotImplemented
+    mulliken_meta_spin      = NotImplemented
+    det_ovlp                = NotImplemented
+
+    density_fit             = hf.RHF.density_fit
+    newton                  = hf.RHF.newton
 
     def make_rdm1(self, mo_coeff=None, mo_occ=None, **kwargs):
         if mo_coeff is None:
@@ -297,9 +274,6 @@ class UHF(hf.SCF):
             vhf += cupy.asarray(vhf_last)
         return vhf
 
-    scf = hf.scf
-    kernel = pyscf_lib.alias(scf, alias_name='kernel')
-
     def spin_square(self, mo_coeff=None, s=None):
         if mo_coeff is None:
             mo_coeff = (self.mo_coeff[0][:,self.mo_occ[0]>0],
@@ -312,12 +286,8 @@ class UHF(hf.SCF):
         from gpu4pyscf.grad import uhf
         return uhf.Gradients(self)
 
-    def newton(self):
-        from gpu4pyscf.scf.soscf import newton
-        return newton(self)
-
     def to_cpu(self):
         from gpu4pyscf.lib import utils
-        mf = uhf.UHF(self.mol)
+        mf = uhf_cpu.UHF(self.mol)
         utils.to_cpu(self, mf)
         return mf

--- a/gpu4pyscf/scf/uhf.py
+++ b/gpu4pyscf/scf/uhf.py
@@ -226,6 +226,8 @@ class UHF(hf.SCF):
     make_asym_dm             = NotImplemented
     make_rdm2                = NotImplemented
     energy_elec              = energy_elec
+    canonicalize             = canonicalize
+    
     get_init_guess           = hf.return_cupy_array(uhf_cpu.UHF.get_init_guess)
     init_guess_by_minao      = uhf_cpu.UHF.init_guess_by_minao
     init_guess_by_atom       = uhf_cpu.UHF.init_guess_by_atom

--- a/gpu4pyscf/tests/test_dft.py
+++ b/gpu4pyscf/tests/test_dft.py
@@ -112,6 +112,7 @@ class KnownValues(unittest.TestCase):
         mf = rks.RKS(mol, xc='b3lyp')
         mf.grids.atom_grid = (99,590)
         mf.conv_tol = 1e-12
+        mf.conv_tol_cpscf = 1e-8
         mf.disp = 'd3bj'
         e_dft = mf.kernel()
         assert np.abs(e_dft - -685.0325611822375) < 1e-7
@@ -128,6 +129,7 @@ class KnownValues(unittest.TestCase):
         mf = uks.UKS(mol, xc='b3lyp')
         mf.grids.atom_grid = (99,590)
         mf.conv_tol = 1e-12
+        mf.conv_tol_cpscf = 1e-8
         mf.disp = 'd3bj'
         e_dft = mf.kernel()
         assert np.abs(e_dft - -685.0325611822375) < 1e-7


### PR DESCRIPTION
- Set conv_tol_cpscf = 1e-6
- Remove duplicated definitions of attributes in UHF class.