### PR TITLE
Analytical PCM 2nd derivative

### DIFF
--- a/gpu4pyscf/gto/int3c1e_ipip.py
+++ b/gpu4pyscf/gto/int3c1e_ipip.py
@@ -1,0 +1,410 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ctypes
+import cupy as cp
+import numpy as np
+from pyscf import lib
+from pyscf.gto import ATOM_OF
+from pyscf.lib import c_null_ptr
+from gpu4pyscf.lib.cupy_helper import load_library, cart2sph, get_avail_mem
+from gpu4pyscf.gto.int3c1e import VHFOpt
+
+libgint = load_library('libgint')
+
+def get_int3c1e_ipip1_charge_contracted(mol, grids, charge_exponents, charges, intopt):
+    omega = mol.omega
+    assert omega >= 0.0, "Short-range one electron integrals with GPU acceleration is not implemented."
+
+    grids = cp.asarray(grids, order='C')
+    if charge_exponents is not None:
+        charge_exponents = cp.asarray(charge_exponents, order='C')
+
+    assert charges.ndim == 1 and charges.shape[0] == grids.shape[0]
+    charges = cp.asarray(charges).astype(np.float64)
+
+    charges = charges.reshape([-1, 1], order='C')
+    grids = cp.concatenate([grids, charges], axis=1)
+
+    int1e_charge_contracted = cp.empty([3, 3, mol.nao, mol.nao], order='C')
+    for cp_ij_id, _ in enumerate(intopt.log_qs):
+        cpi = intopt.cp_idx[cp_ij_id]
+        cpj = intopt.cp_jdx[cp_ij_id]
+        li = intopt.angular[cpi]
+        lj = intopt.angular[cpj]
+
+        stream = cp.cuda.get_current_stream()
+
+        log_q_ij = intopt.log_qs[cp_ij_id]
+
+        nbins = 1
+        bins_locs_ij = np.array([0, len(log_q_ij)], dtype=np.int32)
+
+        i0, i1 = intopt.cart_ao_loc[cpi], intopt.cart_ao_loc[cpi+1]
+        j0, j1 = intopt.cart_ao_loc[cpj], intopt.cart_ao_loc[cpj+1]
+        ni = i1 - i0
+        nj = j1 - j0
+
+        ao_offsets = np.array([i0, j0], dtype=np.int32)
+        strides = np.array([ni, ni*nj], dtype=np.int32)
+
+        charge_exponents_pointer = c_null_ptr()
+        if charge_exponents is not None:
+            charge_exponents_pointer = charge_exponents.data.ptr
+
+        ngrids = grids.shape[0]
+        # n_charge_sum_per_thread = 1 # means every thread processes one pair and one grid
+        # n_charge_sum_per_thread = ngrids # or larger number gaurantees one thread processes one pair and all grid points
+        n_charge_sum_per_thread = 10
+
+        int1e_angular_slice = cp.zeros([3, 3, j1-j0, i1-i0], order='C')
+
+        err = libgint.GINTfill_int3c1e_ipip1_charge_contracted(
+            ctypes.cast(stream.ptr, ctypes.c_void_p),
+            intopt.bpcache,
+            ctypes.cast(grids.data.ptr, ctypes.c_void_p),
+            ctypes.cast(charge_exponents_pointer, ctypes.c_void_p),
+            ctypes.c_int(ngrids),
+            ctypes.cast(int1e_angular_slice.data.ptr, ctypes.c_void_p),
+            strides.ctypes.data_as(ctypes.c_void_p),
+            ao_offsets.ctypes.data_as(ctypes.c_void_p),
+            bins_locs_ij.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(nbins),
+            ctypes.c_int(cp_ij_id),
+            ctypes.c_double(omega),
+            ctypes.c_int(n_charge_sum_per_thread))
+
+        if err != 0:
+            raise RuntimeError('GINTfill_int3c1e_charge_contracted failed')
+
+        int1e_angular_slice[1,0] = int1e_angular_slice[0,1]
+        int1e_angular_slice[2,0] = int1e_angular_slice[0,2]
+        int1e_angular_slice[2,1] = int1e_angular_slice[1,2]
+
+        i0, i1 = intopt.ao_loc[cpi], intopt.ao_loc[cpi+1]
+        j0, j1 = intopt.ao_loc[cpj], intopt.ao_loc[cpj+1]
+        if not mol.cart:
+            int1e_angular_slice = cart2sph(int1e_angular_slice, axis=2, ang=lj)
+            int1e_angular_slice = cart2sph(int1e_angular_slice, axis=3, ang=li)
+
+        int1e_charge_contracted[:, :, i0:i1, j0:j1] = int1e_angular_slice.transpose(0,1,3,2)
+
+    return intopt.unsort_orbitals(int1e_charge_contracted, axis=[2,3])
+
+def get_int3c1e_ipvip1_charge_contracted(mol, grids, charge_exponents, charges, intopt):
+    omega = mol.omega
+    assert omega >= 0.0, "Short-range one electron integrals with GPU acceleration is not implemented."
+
+    grids = cp.asarray(grids, order='C')
+    if charge_exponents is not None:
+        charge_exponents = cp.asarray(charge_exponents, order='C')
+
+    assert charges.ndim == 1 and charges.shape[0] == grids.shape[0]
+    charges = cp.asarray(charges).astype(np.float64)
+
+    charges = charges.reshape([-1, 1], order='C')
+    grids = cp.concatenate([grids, charges], axis=1)
+
+    int1e_charge_contracted = cp.empty([3, 3, mol.nao, mol.nao], order='C')
+    for cp_ij_id, _ in enumerate(intopt.log_qs):
+        cpi = intopt.cp_idx[cp_ij_id]
+        cpj = intopt.cp_jdx[cp_ij_id]
+        li = intopt.angular[cpi]
+        lj = intopt.angular[cpj]
+
+        stream = cp.cuda.get_current_stream()
+
+        log_q_ij = intopt.log_qs[cp_ij_id]
+
+        nbins = 1
+        bins_locs_ij = np.array([0, len(log_q_ij)], dtype=np.int32)
+
+        i0, i1 = intopt.cart_ao_loc[cpi], intopt.cart_ao_loc[cpi+1]
+        j0, j1 = intopt.cart_ao_loc[cpj], intopt.cart_ao_loc[cpj+1]
+        ni = i1 - i0
+        nj = j1 - j0
+
+        ao_offsets = np.array([i0, j0], dtype=np.int32)
+        strides = np.array([ni, ni*nj], dtype=np.int32)
+
+        charge_exponents_pointer = c_null_ptr()
+        if charge_exponents is not None:
+            charge_exponents_pointer = charge_exponents.data.ptr
+
+        ngrids = grids.shape[0]
+        # n_charge_sum_per_thread = 1 # means every thread processes one pair and one grid
+        # n_charge_sum_per_thread = ngrids # or larger number gaurantees one thread processes one pair and all grid points
+        n_charge_sum_per_thread = 10
+
+        int1e_angular_slice = cp.zeros([3, 3, j1-j0, i1-i0], order='C')
+
+        err = libgint.GINTfill_int3c1e_ipvip1_charge_contracted(
+            ctypes.cast(stream.ptr, ctypes.c_void_p),
+            intopt.bpcache,
+            ctypes.cast(grids.data.ptr, ctypes.c_void_p),
+            ctypes.cast(charge_exponents_pointer, ctypes.c_void_p),
+            ctypes.c_int(ngrids),
+            ctypes.cast(int1e_angular_slice.data.ptr, ctypes.c_void_p),
+            strides.ctypes.data_as(ctypes.c_void_p),
+            ao_offsets.ctypes.data_as(ctypes.c_void_p),
+            bins_locs_ij.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(nbins),
+            ctypes.c_int(cp_ij_id),
+            ctypes.c_double(omega),
+            ctypes.c_int(n_charge_sum_per_thread))
+
+        if err != 0:
+            raise RuntimeError('GINTfill_int3c1e_charge_contracted failed')
+
+        i0, i1 = intopt.ao_loc[cpi], intopt.ao_loc[cpi+1]
+        j0, j1 = intopt.ao_loc[cpj], intopt.ao_loc[cpj+1]
+        if not mol.cart:
+            int1e_angular_slice = cart2sph(int1e_angular_slice, axis=2, ang=lj)
+            int1e_angular_slice = cart2sph(int1e_angular_slice, axis=3, ang=li)
+
+        int1e_charge_contracted[:, :, i0:i1, j0:j1] = int1e_angular_slice.transpose(0,1,3,2)
+
+    return intopt.unsort_orbitals(int1e_charge_contracted, axis=[2,3])
+
+def get_int3c1e_ip1ip2_charge_contracted(mol, grids, charge_exponents, charges, intopt):
+    omega = mol.omega
+    assert omega >= 0.0, "Short-range one electron integrals with GPU acceleration is not implemented."
+
+    grids = cp.asarray(grids, order='C')
+    if charge_exponents is not None:
+        charge_exponents = cp.asarray(charge_exponents, order='C')
+
+    assert charges.ndim == 1 and charges.shape[0] == grids.shape[0]
+    charges = cp.asarray(charges).astype(np.float64)
+
+    charges = charges.reshape([-1, 1], order='C')
+    grids = cp.concatenate([grids, charges], axis=1)
+
+    int1e_charge_contracted = cp.empty([3, 3, mol.nao, mol.nao], order='C')
+    for cp_ij_id, _ in enumerate(intopt.log_qs):
+        cpi = intopt.cp_idx[cp_ij_id]
+        cpj = intopt.cp_jdx[cp_ij_id]
+        li = intopt.angular[cpi]
+        lj = intopt.angular[cpj]
+
+        stream = cp.cuda.get_current_stream()
+
+        log_q_ij = intopt.log_qs[cp_ij_id]
+
+        nbins = 1
+        bins_locs_ij = np.array([0, len(log_q_ij)], dtype=np.int32)
+
+        i0, i1 = intopt.cart_ao_loc[cpi], intopt.cart_ao_loc[cpi+1]
+        j0, j1 = intopt.cart_ao_loc[cpj], intopt.cart_ao_loc[cpj+1]
+        ni = i1 - i0
+        nj = j1 - j0
+
+        ao_offsets = np.array([i0, j0], dtype=np.int32)
+        strides = np.array([ni, ni*nj], dtype=np.int32)
+
+        charge_exponents_pointer = c_null_ptr()
+        if charge_exponents is not None:
+            charge_exponents_pointer = charge_exponents.data.ptr
+
+        ngrids = grids.shape[0]
+        # n_charge_sum_per_thread = 1 # means every thread processes one pair and one grid
+        # n_charge_sum_per_thread = ngrids # or larger number gaurantees one thread processes one pair and all grid points
+        n_charge_sum_per_thread = 10
+
+        int1e_angular_slice = cp.zeros([3, 3, j1-j0, i1-i0], order='C')
+
+        err = libgint.GINTfill_int3c1e_ip1ip2_charge_contracted(
+            ctypes.cast(stream.ptr, ctypes.c_void_p),
+            intopt.bpcache,
+            ctypes.cast(grids.data.ptr, ctypes.c_void_p),
+            ctypes.cast(charge_exponents_pointer, ctypes.c_void_p),
+            ctypes.c_int(ngrids),
+            ctypes.cast(int1e_angular_slice.data.ptr, ctypes.c_void_p),
+            strides.ctypes.data_as(ctypes.c_void_p),
+            ao_offsets.ctypes.data_as(ctypes.c_void_p),
+            bins_locs_ij.ctypes.data_as(ctypes.c_void_p),
+            ctypes.c_int(nbins),
+            ctypes.c_int(cp_ij_id),
+            ctypes.c_double(omega),
+            ctypes.c_int(n_charge_sum_per_thread))
+
+        if err != 0:
+            raise RuntimeError('GINTfill_int3c1e_charge_contracted failed')
+
+        i0, i1 = intopt.ao_loc[cpi], intopt.ao_loc[cpi+1]
+        j0, j1 = intopt.ao_loc[cpj], intopt.ao_loc[cpj+1]
+        if not mol.cart:
+            int1e_angular_slice = cart2sph(int1e_angular_slice, axis=2, ang=lj)
+            int1e_angular_slice = cart2sph(int1e_angular_slice, axis=3, ang=li)
+
+        int1e_charge_contracted[:, :, i0:i1, j0:j1] = int1e_angular_slice.transpose(0,1,3,2)
+
+    return intopt.unsort_orbitals(int1e_charge_contracted, axis=[2,3])
+
+def get_int3c1e_ipip2_density_contracted(mol, grids, charge_exponents, dm, intopt):
+    omega = mol.omega
+    assert omega >= 0.0, "Short-range one electron integrals with GPU acceleration is not implemented."
+
+    nao_cart = intopt._sorted_mol.nao
+    ngrids = grids.shape[0]
+
+    grids = cp.asarray(grids, order='C')
+    if charge_exponents is not None:
+        charge_exponents = cp.asarray(charge_exponents, order='C')
+
+    dm = cp.asarray(dm)
+    assert dm.ndim == 2
+    assert dm.shape[0] == dm.shape[1] and dm.shape[0] == mol.nao
+
+    dm = intopt.sort_orbitals(dm, [0,1])
+    if not mol.cart:
+        cart2sph_transformation_matrix = intopt.cart2sph
+        # TODO: This part is inefficient (O(N^3)), should be changed to the O(N^2) algorithm
+        dm = cart2sph_transformation_matrix @ dm @ cart2sph_transformation_matrix.T
+    dm = dm.flatten(order='F') # Column major order matches (i + j * n_ao) access pattern in the C function
+
+    dm = cp.asnumpy(dm)
+
+    ao_loc_sorted_order = intopt._sorted_mol.ao_loc_nr(cart = True)
+    l_ij = intopt.l_ij.T.flatten()
+    bas_coords = intopt._sorted_mol.atom_coords()[intopt._sorted_mol._bas[:, ATOM_OF]].flatten()
+
+    n_total_hermite_density = intopt.density_offset[-1]
+    dm_pair_ordered = np.empty(n_total_hermite_density)
+    libgint.GINTinit_J_density_rys_preprocess(dm.ctypes.data_as(ctypes.c_void_p),
+                                              dm_pair_ordered.ctypes.data_as(ctypes.c_void_p),
+                                              ctypes.c_int(1), ctypes.c_int(nao_cart),
+                                              ctypes.c_int(len(intopt.bas_pairs_locs) - 1),
+                                              intopt.bas_pair2shls.ctypes.data_as(ctypes.c_void_p),
+                                              intopt.bas_pairs_locs.ctypes.data_as(ctypes.c_void_p),
+                                              l_ij.ctypes.data_as(ctypes.c_void_p),
+                                              intopt.density_offset.ctypes.data_as(ctypes.c_void_p),
+                                              ao_loc_sorted_order.ctypes.data_as(ctypes.c_void_p),
+                                              bas_coords.ctypes.data_as(ctypes.c_void_p),
+                                              ctypes.c_bool(False))
+
+    dm_pair_ordered = cp.asarray(dm_pair_ordered)
+
+    n_threads_per_block_1d = 16
+    n_max_blocks_per_grid_1d = 65535
+    n_max_threads_1d = n_threads_per_block_1d * n_max_blocks_per_grid_1d
+    n_grid_split = int(np.ceil(ngrids / n_max_threads_1d))
+    if (n_grid_split > 100):
+        print(f"Grid dimension = {ngrids} is too large, more than 100 kernels for one electron integral will be launched.")
+    ngrids_per_split = (ngrids + n_grid_split - 1) // n_grid_split
+
+    int3c_density_contracted = cp.zeros([3, 3, ngrids], order='C')
+
+    for p0, p1 in lib.prange(0, ngrids, ngrids_per_split):
+        for cp_ij_id, _ in enumerate(intopt.log_qs):
+            stream = cp.cuda.get_current_stream()
+
+            log_q_ij = intopt.log_qs[cp_ij_id]
+
+            nbins = 1
+            bins_locs_ij = np.array([0, len(log_q_ij)], dtype=np.int32)
+
+            charge_exponents_pointer = c_null_ptr()
+            if charge_exponents is not None:
+                exponents_slice = charge_exponents[p0:p1]
+                charge_exponents_pointer = exponents_slice.data.ptr
+            grids_slice = grids[p0:p1]
+
+            # n_pair_sum_per_thread = 1 # means every thread processes one pair and one grid
+            # n_pair_sum_per_thread = nao_cart # or larger number gaurantees one thread processes one grid and all pairs of the same type
+            n_pair_sum_per_thread = nao_cart
+
+            err = libgint.GINTfill_int3c1e_ipip2_density_contracted(
+                ctypes.cast(stream.ptr, ctypes.c_void_p),
+                intopt.bpcache,
+                ctypes.cast(grids_slice.data.ptr, ctypes.c_void_p),
+                ctypes.cast(charge_exponents_pointer, ctypes.c_void_p),
+                ctypes.c_int(p1-p0),
+                ctypes.cast(dm_pair_ordered.data.ptr, ctypes.c_void_p),
+                intopt.density_offset.ctypes.data_as(ctypes.c_void_p),
+                ctypes.cast(int3c_density_contracted[:, p0:p1].data.ptr, ctypes.c_void_p),
+                bins_locs_ij.ctypes.data_as(ctypes.c_void_p),
+                ctypes.c_int(nbins),
+                ctypes.c_int(cp_ij_id),
+                ctypes.c_double(omega),
+                ctypes.c_int(n_pair_sum_per_thread))
+
+            if err != 0:
+                raise RuntimeError('GINTfill_int3c1e_density_contracted failed')
+
+    int3c_density_contracted[1,0] = int3c_density_contracted[0,1]
+    int3c_density_contracted[2,0] = int3c_density_contracted[0,2]
+    int3c_density_contracted[2,1] = int3c_density_contracted[1,2]
+
+    return int3c_density_contracted
+
+def int1e_grids_ipip1(mol, grids, charge_exponents=None, charges=None, direct_scf_tol=1e-13, intopt=None):
+    assert grids is not None
+    assert charges is not None
+
+    if intopt is None:
+        intopt = VHFOpt(mol)
+        intopt.build(direct_scf_tol, aosym=False)
+    else:
+        assert isinstance(intopt, VHFOpt), \
+            f"Please make sure intopt is a {VHFOpt.__module__}.{VHFOpt.__name__} object."
+        assert hasattr(intopt, "density_offset"), "Please call build() function for VHFOpt object first."
+        assert not intopt.aosym
+
+    return get_int3c1e_ipip1_charge_contracted(mol, grids, charge_exponents, charges, intopt)
+
+def int1e_grids_ipvip1(mol, grids, charge_exponents=None, charges=None, direct_scf_tol=1e-13, intopt=None):
+    assert grids is not None
+    assert charges is not None
+
+    if intopt is None:
+        intopt = VHFOpt(mol)
+        intopt.build(direct_scf_tol, aosym=False)
+    else:
+        assert isinstance(intopt, VHFOpt), \
+            f"Please make sure intopt is a {VHFOpt.__module__}.{VHFOpt.__name__} object."
+        assert hasattr(intopt, "density_offset"), "Please call build() function for VHFOpt object first."
+        assert not intopt.aosym
+
+    return get_int3c1e_ipvip1_charge_contracted(mol, grids, charge_exponents, charges, intopt)
+
+def int1e_grids_ip1ip2(mol, grids, charge_exponents=None, charges=None, direct_scf_tol=1e-13, intopt=None):
+    assert grids is not None
+    assert charges is not None
+
+    if intopt is None:
+        intopt = VHFOpt(mol)
+        intopt.build(direct_scf_tol, aosym=False)
+    else:
+        assert isinstance(intopt, VHFOpt), \
+            f"Please make sure intopt is a {VHFOpt.__module__}.{VHFOpt.__name__} object."
+        assert hasattr(intopt, "density_offset"), "Please call build() function for VHFOpt object first."
+        assert not intopt.aosym
+
+    return get_int3c1e_ip1ip2_charge_contracted(mol, grids, charge_exponents, charges, intopt)
+
+def int1e_grids_ipip2(mol, grids, charge_exponents=None, dm=None, direct_scf_tol=1e-13, intopt=None):
+    assert grids is not None
+    assert dm is not None
+
+    if intopt is None:
+        intopt = VHFOpt(mol)
+        intopt.build(direct_scf_tol, aosym=False)
+    else:
+        assert isinstance(intopt, VHFOpt), \
+            f"Please make sure intopt is a {VHFOpt.__module__}.{VHFOpt.__name__} object."
+        assert hasattr(intopt, "density_offset"), "Please call build() function for VHFOpt object first."
+        assert not intopt.aosym
+
+    return get_int3c1e_ipip2_density_contracted(mol, grids, charge_exponents, dm, intopt)

--- a/gpu4pyscf/gto/int3c1e_ipip.py
+++ b/gpu4pyscf/gto/int3c1e_ipip.py
@@ -66,7 +66,7 @@ def get_int3c1e_ipip1_charge_contracted(mol, grids, charge_exponents, charges, i
         ngrids = grids.shape[0]
         # n_charge_sum_per_thread = 1 # means every thread processes one pair and one grid
         # n_charge_sum_per_thread = ngrids # or larger number gaurantees one thread processes one pair and all grid points
-        n_charge_sum_per_thread = 10
+        n_charge_sum_per_thread = 100 # This number roughly optimize kernel performance on a large system
 
         int1e_angular_slice = cp.zeros([3, 3, j1-j0, i1-i0], order='C')
 
@@ -145,7 +145,7 @@ def get_int3c1e_ipvip1_charge_contracted(mol, grids, charge_exponents, charges, 
         ngrids = grids.shape[0]
         # n_charge_sum_per_thread = 1 # means every thread processes one pair and one grid
         # n_charge_sum_per_thread = ngrids # or larger number gaurantees one thread processes one pair and all grid points
-        n_charge_sum_per_thread = 10
+        n_charge_sum_per_thread = 100 # This number roughly optimize kernel performance on a large system
 
         int1e_angular_slice = cp.zeros([3, 3, j1-j0, i1-i0], order='C')
 
@@ -220,7 +220,7 @@ def get_int3c1e_ip1ip2_charge_contracted(mol, grids, charge_exponents, charges, 
         ngrids = grids.shape[0]
         # n_charge_sum_per_thread = 1 # means every thread processes one pair and one grid
         # n_charge_sum_per_thread = ngrids # or larger number gaurantees one thread processes one pair and all grid points
-        n_charge_sum_per_thread = 10
+        n_charge_sum_per_thread = 100 # This number roughly optimize kernel performance on a large system
 
         int1e_angular_slice = cp.zeros([3, 3, j1-j0, i1-i0], order='C')
 

--- a/gpu4pyscf/gto/tests/test_int1e_grids_ip.py
+++ b/gpu4pyscf/gto/tests/test_int1e_grids_ip.py
@@ -364,5 +364,5 @@ class KnownValues(unittest.TestCase):
         cp.testing.assert_allclose(ref_int1e_dA, test_int1e_dA, atol = integral_threshold)
 
 if __name__ == "__main__":
-    print("Full Tests for One Electron Coulomb Integrals")
+    print("Full Tests for One Electron Coulomb Integrals 1st Derivative")
     unittest.main()

--- a/gpu4pyscf/gto/tests/test_int1e_grids_ipip.py
+++ b/gpu4pyscf/gto/tests/test_int1e_grids_ipip.py
@@ -1,0 +1,480 @@
+# Copyright 2024 The GPU4PySCF Authors. All Rights Reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import numpy as np
+import cupy as cp
+import pyscf
+from pyscf import lib, gto, df
+from gpu4pyscf.gto.int3c1e_ipip import int1e_grids_ipip1, int1e_grids_ipvip1, int1e_grids_ip1ip2, int1e_grids_ipip2
+
+def setUpModule():
+    global mol_sph, mol_cart, grid_points, integral_threshold, density_contraction_threshold, charge_contraction_threshold
+    atom = '''
+O	0.0000	0.7375	-0.0528
+O	0.0000	-0.7375	-0.1528
+H	0.8190	0.8170	0.4220
+H	-0.8190	-0.8170	0.4220
+'''
+    bas='def2-qzvpp'
+
+    mol_sph = pyscf.M(atom=atom, basis=bas, max_memory=32000)
+    mol_sph.output = '/dev/null'
+    mol_sph.verbose = 0
+    mol_sph.build()
+
+    mol_cart = pyscf.M(atom=atom, basis=bas, max_memory=32000, cart=True)
+    mol_cart.output = '/dev/null'
+    mol_cart.verbose = 0
+    mol_cart.build()
+
+    xs = np.arange(-2.01, 2.0, 0.5)
+    ys = np.arange(-2.02, 2.0, 0.5)
+    zs = np.arange(-2.03, 2.0, 0.5)
+    grid_points = lib.cartesian_prod([xs, ys, zs])
+
+    # All of the following thresholds bound the max value of the corresponding matrix / tensor.
+    integral_threshold = 1e-12
+    density_contraction_threshold = 1e-10
+    charge_contraction_threshold = 1e-12
+
+def tearDownModule():
+    global mol_sph, mol_cart, grid_points
+    mol_sph.stdout.close()
+    mol_cart.stdout.close()
+    del mol_sph, mol_cart, grid_points
+
+class KnownValues(unittest.TestCase):
+    '''
+    Values are compared to PySCF CPU intor() function
+    '''
+    def test_int1e_grids_ipip1_charge_contracted_cart(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        mol = mol_cart
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ipip1 = mol._add_suffix('int3c2e_ipip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdA = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdA = ref_int1e_dAdA.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdA = int1e_grids_ipip1(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdA, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdA, test_int1e_dAdA, atol = integral_threshold)
+
+    def test_int1e_grids_ipip1_charge_contracted_sph(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ipip1 = mol._add_suffix('int3c2e_ipip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdA = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdA = ref_int1e_dAdA.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdA = int1e_grids_ipip1(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdA, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdA, test_int1e_dAdA, atol = integral_threshold)
+
+    def test_int1e_grids_ipip1_charge_contracted_gaussian_charge(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ipip1 = mol._add_suffix('int3c2e_ipip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdA = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdA = ref_int1e_dAdA.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdA = int1e_grids_ipip1(mol, grid_points, charges = charges, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dAdA, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdA, test_int1e_dAdA, atol = integral_threshold)
+
+    def test_int1e_grids_ipip1_charge_contracted_omega(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ipip1 = mol._add_suffix('int3c2e_ipip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdA = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdA = ref_int1e_dAdA.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdA = int1e_grids_ipip1(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdA, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdA, test_int1e_dAdA, atol = integral_threshold)
+
+    def test_int1e_grids_ipip1_charge_contracted_gaussian_charge_omega(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ipip1 = mol._add_suffix('int3c2e_ipip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdA = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdA = ref_int1e_dAdA.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdA = int1e_grids_ipip1(mol, grid_points, charges = charges, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dAdA, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdA, test_int1e_dAdA, atol = integral_threshold)
+
+    # ^ ipip1    v ipvip1
+
+    def test_int1e_grids_ipvip1_charge_contracted_cart(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        mol = mol_cart
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ipvip1 = mol._add_suffix('int3c2e_ipvip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipvip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipvip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdB = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdB = ref_int1e_dAdB.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdB = int1e_grids_ipvip1(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdB, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdB, test_int1e_dAdB, atol = integral_threshold)
+
+    def test_int1e_grids_ipvip1_charge_contracted_sph(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ipvip1 = mol._add_suffix('int3c2e_ipvip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipvip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipvip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdB = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdB = ref_int1e_dAdB.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdB = int1e_grids_ipvip1(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdB, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdB, test_int1e_dAdB, atol = integral_threshold)
+
+    def test_int1e_grids_ipvip1_charge_contracted_gaussian_charge(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ipvip1 = mol._add_suffix('int3c2e_ipvip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipvip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipvip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdB = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdB = ref_int1e_dAdB.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdB = int1e_grids_ipvip1(mol, grid_points, charges = charges, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dAdB, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdB, test_int1e_dAdB, atol = integral_threshold)
+
+    def test_int1e_grids_ipvip1_charge_contracted_omega(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ipvip1 = mol._add_suffix('int3c2e_ipvip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipvip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipvip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdB = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdB = ref_int1e_dAdB.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdB = int1e_grids_ipvip1(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdB, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdB, test_int1e_dAdB, atol = integral_threshold)
+
+    def test_int1e_grids_ipvip1_charge_contracted_gaussian_charge_omega(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ipvip1 = mol._add_suffix('int3c2e_ipvip1')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipvip1)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipvip1, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdB = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdB = ref_int1e_dAdB.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdB = int1e_grids_ipvip1(mol, grid_points, charges = charges, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dAdB, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdB, test_int1e_dAdB, atol = integral_threshold)
+
+    # ^ ipvip1    v ip1ip2
+
+    def test_int1e_grids_ip1ip2_charge_contracted_cart(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        mol = mol_cart
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdC = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdC = ref_int1e_dAdC.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdC = int1e_grids_ip1ip2(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdC, test_int1e_dAdC, atol = integral_threshold)
+
+    def test_int1e_grids_ip1ip2_charge_contracted_sph(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdC = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdC = ref_int1e_dAdC.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdC = int1e_grids_ip1ip2(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdC, test_int1e_dAdC, atol = integral_threshold)
+
+    def test_int1e_grids_ip1ip2_charge_contracted_gaussian_charge(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdC = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdC = ref_int1e_dAdC.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdC = int1e_grids_ip1ip2(mol, grid_points, charges = charges, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dAdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdC, test_int1e_dAdC, atol = integral_threshold)
+
+    def test_int1e_grids_ip1ip2_charge_contracted_omega(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdC = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdC = ref_int1e_dAdC.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdC = int1e_grids_ip1ip2(mol, grid_points, charges = charges)
+
+        assert isinstance(test_int1e_dAdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdC, test_int1e_dAdC, atol = integral_threshold)
+
+    def test_int1e_grids_ip1ip2_charge_contracted_gaussian_charge_omega(self):
+        np.random.seed(12345)
+        charges = np.random.uniform(-2.0, 2.0, grid_points.shape[0])
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        ref_int1e_dAdC = np.einsum('dijq,q->dij', v_nj, charges)
+        ref_int1e_dAdC = ref_int1e_dAdC.reshape(3, 3, mol.nao, mol.nao)
+
+        test_int1e_dAdC = int1e_grids_ip1ip2(mol, grid_points, charges = charges, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dAdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dAdC, test_int1e_dAdC, atol = integral_threshold)
+
+    # ^ ip1ip2    v ipip2
+
+    def test_int1e_grids_ipip2_charge_contracted_cart(self):
+        np.random.seed(12345)
+        dm = np.random.uniform(-2.0, 2.0, (mol_cart.nao, mol_cart.nao))
+
+        mol = mol_cart
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        # Note: we cannot compute ipip2 (dCdC) directly due to numerical problems,
+        #       pyscf treat a point charge as a sharp Gaussian, and we cannot take 2nd derivative of it.
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        v_nj = -v_nj - v_nj.transpose(0, 2, 1, 3) # dCdC = -dAdC - dBdC
+        ref_int1e_dCdC = np.einsum('dijq,ij->dq', v_nj, dm)
+        ref_int1e_dCdC = ref_int1e_dCdC.reshape(3, 3, grid_points.shape[0])
+
+        test_int1e_dCdC = int1e_grids_ipip2(mol, grid_points, dm = dm)
+
+        assert isinstance(test_int1e_dCdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dCdC, test_int1e_dCdC, atol = integral_threshold)
+
+    def test_int1e_grids_ipip2_charge_contracted_sph(self):
+        np.random.seed(12345)
+        dm = np.random.uniform(-2.0, 2.0, (mol_sph.nao, mol_sph.nao))
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        # Note: we cannot compute ipip2 (dCdC) directly due to numerical problems,
+        #       pyscf treat a point charge as a sharp Gaussian, and we cannot take 2nd derivative of it.
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        v_nj = -v_nj - v_nj.transpose(0, 2, 1, 3) # dCdC = -dAdC - dBdC
+        ref_int1e_dCdC = np.einsum('dijq,ij->dq', v_nj, dm)
+        ref_int1e_dCdC = ref_int1e_dCdC.reshape(3, 3, grid_points.shape[0])
+
+        test_int1e_dCdC = int1e_grids_ipip2(mol, grid_points, dm = dm)
+
+        assert isinstance(test_int1e_dCdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dCdC, test_int1e_dCdC, atol = integral_threshold)
+
+    def test_int1e_grids_ipip2_charge_contracted_gaussian_charge(self):
+        np.random.seed(12345)
+        dm = np.random.uniform(-2.0, 2.0, (mol_sph.nao, mol_sph.nao))
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        mol = mol_sph
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ipip2 = mol._add_suffix('int3c2e_ipip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipip2, aosym='s1', cintopt=cintopt)
+        ref_int1e_dCdC = np.einsum('dijq,ij->dq', v_nj, dm)
+        ref_int1e_dCdC = ref_int1e_dCdC.reshape(3, 3, grid_points.shape[0])
+
+        test_int1e_dCdC = int1e_grids_ipip2(mol, grid_points, dm = dm, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dCdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dCdC, test_int1e_dCdC, atol = integral_threshold)
+
+    def test_int1e_grids_ipip2_charge_contracted_omega(self):
+        np.random.seed(12345)
+        dm = np.random.uniform(-2.0, 2.0, (mol_sph.nao, mol_sph.nao))
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points)
+
+        # Note: we cannot compute ipip2 (dCdC) directly due to numerical problems,
+        #       pyscf treat a point charge as a sharp Gaussian, and we cannot take 2nd derivative of it.
+        int3c2e_ip1ip2 = mol._add_suffix('int3c2e_ip1ip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ip1ip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ip1ip2, aosym='s1', cintopt=cintopt)
+        v_nj = -v_nj - v_nj.transpose(0, 2, 1, 3) # dCdC = -dAdC - dBdC
+        ref_int1e_dCdC = np.einsum('dijq,ij->dq', v_nj, dm)
+        ref_int1e_dCdC = ref_int1e_dCdC.reshape(3, 3, grid_points.shape[0])
+
+        test_int1e_dCdC = int1e_grids_ipip2(mol, grid_points, dm = dm)
+
+        assert isinstance(test_int1e_dCdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dCdC, test_int1e_dCdC, atol = integral_threshold)
+
+    def test_int1e_grids_ipip2_charge_contracted_gaussian_charge_omega(self):
+        np.random.seed(12345)
+        dm = np.random.uniform(-2.0, 2.0, (mol_sph.nao, mol_sph.nao))
+        charge_exponents = np.random.uniform(0.5, 1.0, grid_points.shape[0])
+
+        omega = 0.8
+        mol_sph_omega = mol_sph.copy()
+        mol_sph_omega.set_range_coulomb(omega)
+
+        mol = mol_sph_omega
+        fakemol = gto.fakemol_for_charges(grid_points, expnt=charge_exponents)
+
+        int3c2e_ipip2 = mol._add_suffix('int3c2e_ipip2')
+        cintopt = gto.moleintor.make_cintopt(mol._atm, mol._bas, mol._env, int3c2e_ipip2)
+        v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e_ipip2, aosym='s1', cintopt=cintopt)
+        ref_int1e_dCdC = np.einsum('dijq,ij->dq', v_nj, dm)
+        ref_int1e_dCdC = ref_int1e_dCdC.reshape(3, 3, grid_points.shape[0])
+
+        test_int1e_dCdC = int1e_grids_ipip2(mol, grid_points, dm = dm, charge_exponents = charge_exponents)
+
+        assert isinstance(test_int1e_dCdC, cp.ndarray)
+        cp.testing.assert_allclose(ref_int1e_dCdC, test_int1e_dCdC, atol = integral_threshold)
+
+if __name__ == "__main__":
+    print("Full Tests for One Electron Coulomb Integrals 2nd Derivative")
+    unittest.main()

--- a/gpu4pyscf/lib/gint/CMakeLists.txt
+++ b/gpu4pyscf/lib/gint/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(gint SHARED
   nr_fill_ao_ints.cu
   nr_fill_ao_int3c1e.cu
   nr_fill_ao_int3c1e_ip.cu
+  nr_fill_ao_int3c1e_ipip.cu
   nr_fill_ao_int3c2e.cu
   nr_fill_ao_int3c2e_ip1.cu
   nr_fill_ao_int3c2e_ip2.cu

--- a/gpu4pyscf/lib/gint/g3c1e_ipip.cu
+++ b/gpu4pyscf/lib/gint/g3c1e_ipip.cu
@@ -1,0 +1,635 @@
+/*
+ * Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gint.h"
+
+template <int NROOTS>
+__device__
+static void GINTwrite_int3c1e_ipip1_charge_contracted(const double* g, double* local_output, const double minus_two_a, const double prefactor, const int i_l, const int j_l)
+{
+    const int *idx = c_idx;
+    const int *idy = c_idx + TOT_NF;
+    const int *idz = c_idx + TOT_NF * 2;
+
+    const int g_size = NROOTS * (i_l + 2 + 1) * (j_l + 1);
+    const double* __restrict__ gx = g;
+    const double* __restrict__ gy = g + g_size;
+    const double* __restrict__ gz = g + g_size * 2;
+
+    const int n_density_elements_i = (i_l + 1) * (i_l + 2) / 2;
+    const int n_density_elements_j = (j_l + 1) * (j_l + 2) / 2;
+    const int n_density_elements_ij = n_density_elements_i * n_density_elements_j;
+    for (int j = 0; j < n_density_elements_j; j++) {
+        for (int i = 0; i < n_density_elements_i; i++) {
+            const int loc_j = c_l_locs[j_l] + j;
+            const int loc_i = c_l_locs[i_l] + i;
+            const int ix = idx[loc_i];
+            const int iy = idy[loc_i];
+            const int iz = idz[loc_i];
+            const int jx = idx[loc_j];
+            const int jy = idy[loc_j];
+            const int jz = idz[loc_j];
+            const int gx_offset = ix + jx * (i_l + 2 + 1);
+            const int gy_offset = iy + jy * (i_l + 2 + 1);
+            const int gz_offset = iz + jz * (i_l + 2 + 1);
+
+            double d2eri_dAxdAx = 0;
+            double d2eri_dAxdAy = 0;
+            double d2eri_dAxdAz = 0;
+            double d2eri_dAydAy = 0;
+            double d2eri_dAydAz = 0;
+            double d2eri_dAzdAz = 0;
+#pragma unroll
+            for (int i_root = 0; i_root < NROOTS; i_root++) {
+                const double gx_minus_2 = (ix >= 2 ? gx[(gx_offset - 2) * NROOTS + i_root] : 0);
+                const double gy_minus_2 = (iy >= 2 ? gy[(gy_offset - 2) * NROOTS + i_root] : 0);
+                const double gz_minus_2 = (iz >= 2 ? gz[(gz_offset - 2) * NROOTS + i_root] : 0);
+                const double gx_minus_1 = (ix >= 1 ? gx[(gx_offset - 1) * NROOTS + i_root] : 0);
+                const double gy_minus_1 = (iy >= 1 ? gy[(gy_offset - 1) * NROOTS + i_root] : 0);
+                const double gz_minus_1 = (iz >= 1 ? gz[(gz_offset - 1) * NROOTS + i_root] : 0);
+                const double gx_0 = gx[gx_offset * NROOTS + i_root];
+                const double gy_0 = gy[gy_offset * NROOTS + i_root];
+                const double gz_0 = gz[gz_offset * NROOTS + i_root];
+                const double gx_1 = gx[(gx_offset + 1) * NROOTS + i_root];
+                const double gy_1 = gy[(gy_offset + 1) * NROOTS + i_root];
+                const double gz_1 = gz[(gz_offset + 1) * NROOTS + i_root];
+                const double gx_2 = gx[(gx_offset + 2) * NROOTS + i_root];
+                const double gy_2 = gy[(gy_offset + 2) * NROOTS + i_root];
+                const double gz_2 = gz[(gz_offset + 2) * NROOTS + i_root];
+                const double dgx_dAx = ix * gx_minus_1 + minus_two_a * gx_1;
+                const double dgy_dAy = iy * gy_minus_1 + minus_two_a * gy_1;
+                const double dgz_dAz = iz * gz_minus_1 + minus_two_a * gz_1;
+                const double d2gx_dAx2 = ix * (ix - 1) * gx_minus_2 + minus_two_a * (2 * ix + 1) * gx_0 + minus_two_a * minus_two_a * gx_2;
+                const double d2gy_dAy2 = iy * (iy - 1) * gy_minus_2 + minus_two_a * (2 * iy + 1) * gy_0 + minus_two_a * minus_two_a * gy_2;
+                const double d2gz_dAz2 = iz * (iz - 1) * gz_minus_2 + minus_two_a * (2 * iz + 1) * gz_0 + minus_two_a * minus_two_a * gz_2;
+                d2eri_dAxdAx += d2gx_dAx2 * gy_0 * gz_0;
+                d2eri_dAxdAy += dgx_dAx * dgy_dAy * gz_0;
+                d2eri_dAxdAz += dgx_dAx * gy_0 * dgz_dAz;
+                d2eri_dAydAy += gx_0 * d2gy_dAy2 * gz_0;
+                d2eri_dAydAz += gx_0 * dgy_dAy * dgz_dAz;
+                d2eri_dAzdAz += gx_0 * gy_0 * d2gz_dAz2;
+            }
+            local_output[i + j * n_density_elements_i + 0 * n_density_elements_ij] += d2eri_dAxdAx * prefactor;
+            local_output[i + j * n_density_elements_i + 1 * n_density_elements_ij] += d2eri_dAxdAy * prefactor;
+            local_output[i + j * n_density_elements_i + 2 * n_density_elements_ij] += d2eri_dAxdAz * prefactor;
+            local_output[i + j * n_density_elements_i + 3 * n_density_elements_ij] += d2eri_dAydAy * prefactor;
+            local_output[i + j * n_density_elements_i + 4 * n_density_elements_ij] += d2eri_dAydAz * prefactor;
+            local_output[i + j * n_density_elements_i + 5 * n_density_elements_ij] += d2eri_dAzdAz * prefactor;
+        }
+    }
+}
+
+template <int NROOTS, int GSIZE_INT3C_1E>
+__global__
+static void GINTfill_int3c1e_ipip1_charge_contracted_kernel_general(double* output, const BasisProdOffsets offsets, const int i_l, const int j_l, const int nprim_ij,
+                                                                    const int stride_j, const int stride_ij, const int ao_offsets_i, const int ao_offsets_j,
+                                                                    const double omega, const double* grid_points, const double* charge_exponents)
+{
+    const int ntasks_ij = offsets.ntasks_ij;
+    const int ngrids = offsets.ntasks_kl;
+    const int task_ij = blockIdx.x * blockDim.x + threadIdx.x;
+    if (task_ij >= ntasks_ij) {
+        return;
+    }
+
+    const int bas_ij = offsets.bas_ij + task_ij;
+    const int prim_ij = offsets.primitive_ij + task_ij * nprim_ij;
+    const int* bas_pair2bra = c_bpcache.bas_pair2bra;
+    const int* bas_pair2ket = c_bpcache.bas_pair2ket;
+    const int ish = bas_pair2bra[bas_ij];
+    const int jsh = bas_pair2ket[bas_ij];
+    const double* __restrict__ a_exponents = c_bpcache.a1;
+
+    constexpr int l_sum_max = (NROOTS - 1) * 2 + 1;
+    constexpr int l_i_max_density_elements = (l_sum_max + 1) / 2;
+    constexpr int l_j_max_density_elements = l_sum_max - l_i_max_density_elements;
+    double output_cache[(l_i_max_density_elements + 1) * (l_i_max_density_elements + 2) / 2
+                        * (l_j_max_density_elements + 1) * (l_j_max_density_elements + 2) / 2
+                        * 6] { 0.0 };
+
+    for (int task_grid = blockIdx.y * blockDim.y + threadIdx.y; task_grid < ngrids; task_grid += gridDim.y * blockDim.y) {
+        const double* grid_point = grid_points + task_grid * 4;
+        const double charge = grid_point[3];
+        const double charge_exponent = (charge_exponents != NULL) ? charge_exponents[task_grid] : 0.0;
+
+        double g[GSIZE_INT3C_1E];
+
+        for (int ij = prim_ij; ij < prim_ij+nprim_ij; ++ij) {
+            GINT_g1e<NROOTS>(g, grid_point, ish, jsh, ij, i_l + 2, j_l, charge_exponent, omega);
+            const double minus_two_a = -2.0 * a_exponents[ij];
+            GINTwrite_int3c1e_ipip1_charge_contracted<NROOTS>(g, output_cache, minus_two_a, charge, i_l, j_l);
+        }
+    }
+
+    const int* ao_loc = c_bpcache.ao_loc;
+
+    const int i0 = ao_loc[ish] - ao_offsets_i;
+    const int j0 = ao_loc[jsh] - ao_offsets_j;
+    const int n_density_elements_i = (i_l + 1) * (i_l + 2) / 2;
+    const int n_density_elements_j = (j_l + 1) * (j_l + 2) / 2;
+    const int n_density_elements_ij = n_density_elements_i * n_density_elements_j;
+    for (int j = 0; j < n_density_elements_j; j++) {
+        for (int i = 0; i < n_density_elements_i; i++) {
+            const double d2eri_dAxdAx = output_cache[i + j * n_density_elements_i + 0 * n_density_elements_ij];
+            const double d2eri_dAxdAy = output_cache[i + j * n_density_elements_i + 1 * n_density_elements_ij];
+            const double d2eri_dAxdAz = output_cache[i + j * n_density_elements_i + 2 * n_density_elements_ij];
+            const double d2eri_dAydAy = output_cache[i + j * n_density_elements_i + 3 * n_density_elements_ij];
+            const double d2eri_dAydAz = output_cache[i + j * n_density_elements_i + 4 * n_density_elements_ij];
+            const double d2eri_dAzdAz = output_cache[i + j * n_density_elements_i + 5 * n_density_elements_ij];
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 0 * stride_ij), d2eri_dAxdAx);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 1 * stride_ij), d2eri_dAxdAy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 2 * stride_ij), d2eri_dAxdAz);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 4 * stride_ij), d2eri_dAydAy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 5 * stride_ij), d2eri_dAydAz);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 8 * stride_ij), d2eri_dAzdAz);
+        }
+    }
+}
+
+template <int NROOTS>
+__device__
+static void GINTwrite_int3c1e_ipvip1_charge_contracted(const double* g, double* local_output, const double minus_two_a, const double minus_two_b, const double prefactor, const int i_l, const int j_l)
+{
+    const int *idx = c_idx;
+    const int *idy = c_idx + TOT_NF;
+    const int *idz = c_idx + TOT_NF * 2;
+
+    const int g_size = NROOTS * (i_l + 1 + 1) * (j_l + 1 + 1);
+    const double* __restrict__ gx = g;
+    const double* __restrict__ gy = g + g_size;
+    const double* __restrict__ gz = g + g_size * 2;
+
+    const int n_density_elements_i = (i_l + 1) * (i_l + 2) / 2;
+    const int n_density_elements_j = (j_l + 1) * (j_l + 2) / 2;
+    const int n_density_elements_ij = n_density_elements_i * n_density_elements_j;
+    for (int j = 0; j < n_density_elements_j; j++) {
+        for (int i = 0; i < n_density_elements_i; i++) {
+            const int loc_j = c_l_locs[j_l] + j;
+            const int loc_i = c_l_locs[i_l] + i;
+            const int ix = idx[loc_i];
+            const int iy = idy[loc_i];
+            const int iz = idz[loc_i];
+            const int jx = idx[loc_j];
+            const int jy = idy[loc_j];
+            const int jz = idz[loc_j];
+            const int j_offset = i_l + 1 + 1;
+
+            double d2eri_dAxdBx = 0;
+            double d2eri_dAxdBy = 0;
+            double d2eri_dAxdBz = 0;
+            double d2eri_dAydBx = 0;
+            double d2eri_dAydBy = 0;
+            double d2eri_dAydBz = 0;
+            double d2eri_dAzdBx = 0;
+            double d2eri_dAzdBy = 0;
+            double d2eri_dAzdBz = 0;
+#pragma unroll
+            for (int i_root = 0; i_root < NROOTS; i_root++) {
+                const double gx_i_minus_1_j_minus_1 = ix * jx * (ix >= 1 && jx >= 1 ? gx[(ix - 1 + (jx - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gy_i_minus_1_j_minus_1 = iy * jy * (iy >= 1 && jy >= 1 ? gy[(iy - 1 + (jy - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gz_i_minus_1_j_minus_1 = iz * jz * (iz >= 1 && jz >= 1 ? gz[(iz - 1 + (jz - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gx_i_minus_1_j_1 = ix * minus_two_b * (ix >= 1 ? gx[(ix - 1 + (jx + 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gy_i_minus_1_j_1 = iy * minus_two_b * (iy >= 1 ? gy[(iy - 1 + (jy + 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gz_i_minus_1_j_1 = iz * minus_two_b * (iz >= 1 ? gz[(iz - 1 + (jz + 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gx_i_1_j_minus_1 = jx * minus_two_a * (jx >= 1 ? gx[(ix + 1 + (jx - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gy_i_1_j_minus_1 = jy * minus_two_a * (jy >= 1 ? gy[(iy + 1 + (jy - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gz_i_1_j_minus_1 = jz * minus_two_a * (jz >= 1 ? gz[(iz + 1 + (jz - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gx_i_1_j_1 = minus_two_a * minus_two_b * gx[(ix + 1 + (jx + 1) * j_offset) * NROOTS + i_root];
+                const double gy_i_1_j_1 = minus_two_a * minus_two_b * gy[(iy + 1 + (jy + 1) * j_offset) * NROOTS + i_root];
+                const double gz_i_1_j_1 = minus_two_a * minus_two_b * gz[(iz + 1 + (jz + 1) * j_offset) * NROOTS + i_root];
+                const double gx_0 = gx[(ix + jx * j_offset) * NROOTS + i_root];
+                const double gy_0 = gy[(iy + jy * j_offset) * NROOTS + i_root];
+                const double gz_0 = gz[(iz + jz * j_offset) * NROOTS + i_root];
+                const double gx_i_1_j_0 = minus_two_a * gx[(ix + 1 + jx * j_offset) * NROOTS + i_root];
+                const double gy_i_1_j_0 = minus_two_a * gy[(iy + 1 + jy * j_offset) * NROOTS + i_root];
+                const double gz_i_1_j_0 = minus_two_a * gz[(iz + 1 + jz * j_offset) * NROOTS + i_root];
+                const double gx_i_minus_1_j_0 = ix * (ix >= 1 ? gx[(ix - 1 + jx * j_offset) * NROOTS + i_root] : 0);
+                const double gy_i_minus_1_j_0 = iy * (iy >= 1 ? gy[(iy - 1 + jy * j_offset) * NROOTS + i_root] : 0);
+                const double gz_i_minus_1_j_0 = iz * (iz >= 1 ? gz[(iz - 1 + jz * j_offset) * NROOTS + i_root] : 0);
+                const double gx_i_0_j_1 = minus_two_b * gx[(ix + (jx + 1) * j_offset) * NROOTS + i_root];
+                const double gy_i_0_j_1 = minus_two_b * gy[(iy + (jy + 1) * j_offset) * NROOTS + i_root];
+                const double gz_i_0_j_1 = minus_two_b * gz[(iz + (jz + 1) * j_offset) * NROOTS + i_root];
+                const double gx_i_0_j_minus_1 = jx * (jx >= 1 ? gx[(ix + (jx - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gy_i_0_j_minus_1 = jy * (jy >= 1 ? gy[(iy + (jy - 1) * j_offset) * NROOTS + i_root] : 0);
+                const double gz_i_0_j_minus_1 = jz * (jz >= 1 ? gz[(iz + (jz - 1) * j_offset) * NROOTS + i_root] : 0);
+
+                d2eri_dAxdBx += (gx_i_minus_1_j_minus_1 + gx_i_minus_1_j_1 + gx_i_1_j_minus_1 + gx_i_1_j_1) * gy_0 * gz_0;
+                d2eri_dAxdBy += (gx_i_minus_1_j_0 + gx_i_1_j_0) * (gy_i_0_j_minus_1 + gy_i_0_j_1) * gz_0;
+                d2eri_dAxdBz += (gx_i_minus_1_j_0 + gx_i_1_j_0) * gy_0 * (gz_i_0_j_minus_1 + gz_i_0_j_1);
+                d2eri_dAydBx += (gx_i_0_j_minus_1 + gx_i_0_j_1) * (gy_i_minus_1_j_0 + gy_i_1_j_0) * gz_0;
+                d2eri_dAydBy += gx_0 * (gy_i_minus_1_j_minus_1 + gy_i_minus_1_j_1 + gy_i_1_j_minus_1 + gy_i_1_j_1) * gz_0;
+                d2eri_dAydBz += gx_0 * (gy_i_minus_1_j_0 + gy_i_1_j_0) * (gz_i_0_j_minus_1 + gz_i_0_j_1);
+                d2eri_dAzdBx += (gx_i_0_j_minus_1 + gx_i_0_j_1) * gy_0 * (gz_i_minus_1_j_0 + gz_i_1_j_0);
+                d2eri_dAzdBy += gx_0 * (gy_i_0_j_minus_1 + gy_i_0_j_1) * (gz_i_minus_1_j_0 + gz_i_1_j_0);
+                d2eri_dAzdBz += gx_0 * gy_0 * (gz_i_minus_1_j_minus_1 + gz_i_minus_1_j_1 + gz_i_1_j_minus_1 + gz_i_1_j_1);
+            }
+            local_output[i + j * n_density_elements_i + 0 * n_density_elements_ij] += d2eri_dAxdBx * prefactor;
+            local_output[i + j * n_density_elements_i + 1 * n_density_elements_ij] += d2eri_dAxdBy * prefactor;
+            local_output[i + j * n_density_elements_i + 2 * n_density_elements_ij] += d2eri_dAxdBz * prefactor;
+            local_output[i + j * n_density_elements_i + 3 * n_density_elements_ij] += d2eri_dAydBx * prefactor;
+            local_output[i + j * n_density_elements_i + 4 * n_density_elements_ij] += d2eri_dAydBy * prefactor;
+            local_output[i + j * n_density_elements_i + 5 * n_density_elements_ij] += d2eri_dAydBz * prefactor;
+            local_output[i + j * n_density_elements_i + 6 * n_density_elements_ij] += d2eri_dAzdBx * prefactor;
+            local_output[i + j * n_density_elements_i + 7 * n_density_elements_ij] += d2eri_dAzdBy * prefactor;
+            local_output[i + j * n_density_elements_i + 8 * n_density_elements_ij] += d2eri_dAzdBz * prefactor;
+        }
+    }
+}
+
+template <int NROOTS, int GSIZE_INT3C_1E>
+__global__
+static void GINTfill_int3c1e_ipvip1_charge_contracted_kernel_general(double* output, const BasisProdOffsets offsets, const int i_l, const int j_l, const int nprim_ij,
+                                                                     const int stride_j, const int stride_ij, const int ao_offsets_i, const int ao_offsets_j,
+                                                                     const double omega, const double* grid_points, const double* charge_exponents)
+{
+    const int ntasks_ij = offsets.ntasks_ij;
+    const int ngrids = offsets.ntasks_kl;
+    const int task_ij = blockIdx.x * blockDim.x + threadIdx.x;
+    if (task_ij >= ntasks_ij) {
+        return;
+    }
+
+    const int bas_ij = offsets.bas_ij + task_ij;
+    const int prim_ij = offsets.primitive_ij + task_ij * nprim_ij;
+    const int* bas_pair2bra = c_bpcache.bas_pair2bra;
+    const int* bas_pair2ket = c_bpcache.bas_pair2ket;
+    const int ish = bas_pair2bra[bas_ij];
+    const int jsh = bas_pair2ket[bas_ij];
+    const double* __restrict__ a_exponents = c_bpcache.a1;
+    const double* __restrict__ b_exponents = c_bpcache.a2;
+
+    constexpr int l_sum_max = (NROOTS - 1) * 2 + 1;
+    constexpr int l_i_max_density_elements = (l_sum_max + 1) / 2;
+    constexpr int l_j_max_density_elements = l_sum_max - l_i_max_density_elements;
+    double output_cache[(l_i_max_density_elements + 1) * (l_i_max_density_elements + 2) / 2
+                        * (l_j_max_density_elements + 1) * (l_j_max_density_elements + 2) / 2
+                        * 9] { 0.0 };
+
+    for (int task_grid = blockIdx.y * blockDim.y + threadIdx.y; task_grid < ngrids; task_grid += gridDim.y * blockDim.y) {
+        const double* grid_point = grid_points + task_grid * 4;
+        const double charge = grid_point[3];
+        const double charge_exponent = (charge_exponents != NULL) ? charge_exponents[task_grid] : 0.0;
+
+        double g[GSIZE_INT3C_1E];
+
+        for (int ij = prim_ij; ij < prim_ij+nprim_ij; ++ij) {
+            GINT_g1e<NROOTS>(g, grid_point, ish, jsh, ij, i_l + 1, j_l + 1, charge_exponent, omega);
+            const double minus_two_a = -2.0 * a_exponents[ij];
+            const double minus_two_b = -2.0 * b_exponents[ij];
+            GINTwrite_int3c1e_ipvip1_charge_contracted<NROOTS>(g, output_cache, minus_two_a, minus_two_b, charge, i_l, j_l);
+        }
+    }
+
+    const int* ao_loc = c_bpcache.ao_loc;
+
+    const int i0 = ao_loc[ish] - ao_offsets_i;
+    const int j0 = ao_loc[jsh] - ao_offsets_j;
+    const int n_density_elements_i = (i_l + 1) * (i_l + 2) / 2;
+    const int n_density_elements_j = (j_l + 1) * (j_l + 2) / 2;
+    const int n_density_elements_ij = n_density_elements_i * n_density_elements_j;
+    for (int j = 0; j < n_density_elements_j; j++) {
+        for (int i = 0; i < n_density_elements_i; i++) {
+            const double d2eri_dAxdBx = output_cache[i + j * n_density_elements_i + 0 * n_density_elements_ij];
+            const double d2eri_dAxdBy = output_cache[i + j * n_density_elements_i + 1 * n_density_elements_ij];
+            const double d2eri_dAxdBz = output_cache[i + j * n_density_elements_i + 2 * n_density_elements_ij];
+            const double d2eri_dAydBx = output_cache[i + j * n_density_elements_i + 3 * n_density_elements_ij];
+            const double d2eri_dAydBy = output_cache[i + j * n_density_elements_i + 4 * n_density_elements_ij];
+            const double d2eri_dAydBz = output_cache[i + j * n_density_elements_i + 5 * n_density_elements_ij];
+            const double d2eri_dAzdBx = output_cache[i + j * n_density_elements_i + 6 * n_density_elements_ij];
+            const double d2eri_dAzdBy = output_cache[i + j * n_density_elements_i + 7 * n_density_elements_ij];
+            const double d2eri_dAzdBz = output_cache[i + j * n_density_elements_i + 8 * n_density_elements_ij];
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 0 * stride_ij), d2eri_dAxdBx);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 1 * stride_ij), d2eri_dAxdBy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 2 * stride_ij), d2eri_dAxdBz);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 3 * stride_ij), d2eri_dAydBx);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 4 * stride_ij), d2eri_dAydBy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 5 * stride_ij), d2eri_dAydBz);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 6 * stride_ij), d2eri_dAzdBx);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 7 * stride_ij), d2eri_dAzdBy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 8 * stride_ij), d2eri_dAzdBz);
+        }
+    }
+}
+
+template <int NROOTS>
+__device__
+static void GINTwrite_int3c1e_ip1ip2_charge_contracted(const double* g, double* local_output, const double minus_two_a, const double* u2, const double* AC, const double prefactor, const int i_l, const int j_l)
+{
+    const int *idx = c_idx;
+    const int *idy = c_idx + TOT_NF;
+    const int *idz = c_idx + TOT_NF * 2;
+
+    const int g_size = NROOTS * (i_l + 2 + 1) * (j_l + 1);
+    const double* __restrict__ gx = g;
+    const double* __restrict__ gy = g + g_size;
+    const double* __restrict__ gz = g + g_size * 2;
+
+    const double ACx = AC[0];
+    const double ACy = AC[1];
+    const double ACz = AC[2];
+
+    const int n_density_elements_i = (i_l + 1) * (i_l + 2) / 2;
+    const int n_density_elements_j = (j_l + 1) * (j_l + 2) / 2;
+    const int n_density_elements_ij = n_density_elements_i * n_density_elements_j;
+    for (int j = 0; j < n_density_elements_j; j++) {
+        for (int i = 0; i < n_density_elements_i; i++) {
+            const int loc_j = c_l_locs[j_l] + j;
+            const int loc_i = c_l_locs[i_l] + i;
+            const int ix = idx[loc_i];
+            const int iy = idy[loc_i];
+            const int iz = idz[loc_i];
+            const int jx = idx[loc_j];
+            const int jy = idy[loc_j];
+            const int jz = idz[loc_j];
+            const int gx_offset = ix + jx * (i_l + 2 + 1);
+            const int gy_offset = iy + jy * (i_l + 2 + 1);
+            const int gz_offset = iz + jz * (i_l + 2 + 1);
+
+            double d2eri_dAxdCx = 0;
+            double d2eri_dAxdCy = 0;
+            double d2eri_dAxdCz = 0;
+            double d2eri_dAydCx = 0;
+            double d2eri_dAydCy = 0;
+            double d2eri_dAydCz = 0;
+            double d2eri_dAzdCx = 0;
+            double d2eri_dAzdCy = 0;
+            double d2eri_dAzdCz = 0;
+#pragma unroll
+            for (int i_root = 0; i_root < NROOTS; i_root++) {
+                const double gx_minus_1 = (ix >= 1 ? gx[(gx_offset - 1) * NROOTS + i_root] : 0);
+                const double gy_minus_1 = (iy >= 1 ? gy[(gy_offset - 1) * NROOTS + i_root] : 0);
+                const double gz_minus_1 = (iz >= 1 ? gz[(gz_offset - 1) * NROOTS + i_root] : 0);
+                const double gx_0 = gx[gx_offset * NROOTS + i_root];
+                const double gy_0 = gy[gy_offset * NROOTS + i_root];
+                const double gz_0 = gz[gz_offset * NROOTS + i_root];
+                const double gx_1 = gx[(gx_offset + 1) * NROOTS + i_root];
+                const double gy_1 = gy[(gy_offset + 1) * NROOTS + i_root];
+                const double gz_1 = gz[(gz_offset + 1) * NROOTS + i_root];
+                const double gx_2 = gx[(gx_offset + 2) * NROOTS + i_root];
+                const double gy_2 = gy[(gy_offset + 2) * NROOTS + i_root];
+                const double gz_2 = gz[(gz_offset + 2) * NROOTS + i_root];
+
+                const double two_u2 = 2.0 * u2[i_root];
+                const double dgx_dAx = ix * gx_minus_1 + minus_two_a * gx_1;
+                const double dgy_dAy = iy * gy_minus_1 + minus_two_a * gy_1;
+                const double dgz_dAz = iz * gz_minus_1 + minus_two_a * gz_1;
+                const double dgx_dCx = two_u2 * (ACx * gx_0 + gx_1);
+                const double dgy_dCy = two_u2 * (ACy * gy_0 + gy_1);
+                const double dgz_dCz = two_u2 * (ACz * gz_0 + gz_1);
+                const double d2gx_dAxdCx = two_u2 * (ix * ACx * gx_minus_1 + ix * gx_0 + minus_two_a * ACx * gx_1 + minus_two_a * gx_2);
+                const double d2gy_dAydCy = two_u2 * (iy * ACy * gy_minus_1 + iy * gy_0 + minus_two_a * ACy * gy_1 + minus_two_a * gy_2);
+                const double d2gz_dAzdCz = two_u2 * (iz * ACz * gz_minus_1 + iz * gz_0 + minus_two_a * ACz * gz_1 + minus_two_a * gz_2);
+
+                d2eri_dAxdCx += - d2gx_dAxdCx * gy_0 * gz_0;
+                d2eri_dAxdCy += - dgx_dAx * dgy_dCy * gz_0;
+                d2eri_dAxdCz += - dgx_dAx * gy_0 * dgz_dCz;
+                d2eri_dAydCx += - dgx_dCx * dgy_dAy * gz_0;
+                d2eri_dAydCy += - gx_0 * d2gy_dAydCy * gz_0;
+                d2eri_dAydCz += - gx_0 * dgy_dAy * dgz_dCz;
+                d2eri_dAzdCx += - dgx_dCx * gy_0 * dgz_dAz;
+                d2eri_dAzdCy += - gx_0 * dgy_dCy * dgz_dAz;
+                d2eri_dAzdCz += - gx_0 * gy_0 * d2gz_dAzdCz;
+            }
+            local_output[i + j * n_density_elements_i + 0 * n_density_elements_ij] += d2eri_dAxdCx * prefactor;
+            local_output[i + j * n_density_elements_i + 1 * n_density_elements_ij] += d2eri_dAxdCy * prefactor;
+            local_output[i + j * n_density_elements_i + 2 * n_density_elements_ij] += d2eri_dAxdCz * prefactor;
+            local_output[i + j * n_density_elements_i + 3 * n_density_elements_ij] += d2eri_dAydCx * prefactor;
+            local_output[i + j * n_density_elements_i + 4 * n_density_elements_ij] += d2eri_dAydCy * prefactor;
+            local_output[i + j * n_density_elements_i + 5 * n_density_elements_ij] += d2eri_dAydCz * prefactor;
+            local_output[i + j * n_density_elements_i + 6 * n_density_elements_ij] += d2eri_dAzdCx * prefactor;
+            local_output[i + j * n_density_elements_i + 7 * n_density_elements_ij] += d2eri_dAzdCy * prefactor;
+            local_output[i + j * n_density_elements_i + 8 * n_density_elements_ij] += d2eri_dAzdCz * prefactor;
+        }
+    }
+}
+
+template <int NROOTS, int GSIZE_INT3C_1E>
+__global__
+static void GINTfill_int3c1e_ip1ip2_charge_contracted_kernel_general(double* output, const BasisProdOffsets offsets, const int i_l, const int j_l, const int nprim_ij,
+                                                                     const int stride_j, const int stride_ij, const int ao_offsets_i, const int ao_offsets_j,
+                                                                     const double omega, const double* grid_points, const double* charge_exponents)
+{
+    const int ntasks_ij = offsets.ntasks_ij;
+    const int ngrids = offsets.ntasks_kl;
+    const int task_ij = blockIdx.x * blockDim.x + threadIdx.x;
+    if (task_ij >= ntasks_ij) {
+        return;
+    }
+
+    const int bas_ij = offsets.bas_ij + task_ij;
+    const int prim_ij = offsets.primitive_ij + task_ij * nprim_ij;
+    const int* bas_pair2bra = c_bpcache.bas_pair2bra;
+    const int* bas_pair2ket = c_bpcache.bas_pair2ket;
+    const int ish = bas_pair2bra[bas_ij];
+    const int jsh = bas_pair2ket[bas_ij];
+    const double* __restrict__ a_exponents = c_bpcache.a1;
+
+    const int nbas = c_bpcache.nbas;
+    const double* __restrict__ bas_x = c_bpcache.bas_coords;
+    const double* __restrict__ bas_y = bas_x + nbas;
+    const double* __restrict__ bas_z = bas_y + nbas;
+    const double Ax = bas_x[ish];
+    const double Ay = bas_y[ish];
+    const double Az = bas_z[ish];
+
+    constexpr int l_sum_max = (NROOTS - 1) * 2 + 1;
+    constexpr int l_i_max_density_elements = (l_sum_max + 1) / 2;
+    constexpr int l_j_max_density_elements = l_sum_max - l_i_max_density_elements;
+    double output_cache[(l_i_max_density_elements + 1) * (l_i_max_density_elements + 2) / 2
+                        * (l_j_max_density_elements + 1) * (l_j_max_density_elements + 2) / 2
+                        * 9] { 0.0 };
+
+    for (int task_grid = blockIdx.y * blockDim.y + threadIdx.y; task_grid < ngrids; task_grid += gridDim.y * blockDim.y) {
+        const double* grid_point = grid_points + task_grid * 4;
+        const double Cx = grid_point[0];
+        const double Cy = grid_point[1];
+        const double Cz = grid_point[2];
+        const double charge = grid_point[3];
+        const double charge_exponent = (charge_exponents != NULL) ? charge_exponents[task_grid] : 0.0;
+
+        const double AC[3] { Ax - Cx, Ay - Cy, Az - Cz };
+
+        double g[GSIZE_INT3C_1E];
+        double u2[NROOTS];
+
+        for (int ij = prim_ij; ij < prim_ij+nprim_ij; ++ij) {
+            GINT_g1e_save_u2<NROOTS>(g, u2, grid_point, ish, jsh, ij, i_l + 2, j_l, charge_exponent, omega);
+            const double minus_two_a = -2.0 * a_exponents[ij];
+            GINTwrite_int3c1e_ip1ip2_charge_contracted<NROOTS>(g, output_cache, minus_two_a, u2, AC, charge, i_l, j_l);
+        }
+    }
+
+    const int* ao_loc = c_bpcache.ao_loc;
+
+    const int i0 = ao_loc[ish] - ao_offsets_i;
+    const int j0 = ao_loc[jsh] - ao_offsets_j;
+    const int n_density_elements_i = (i_l + 1) * (i_l + 2) / 2;
+    const int n_density_elements_j = (j_l + 1) * (j_l + 2) / 2;
+    const int n_density_elements_ij = n_density_elements_i * n_density_elements_j;
+    for (int j = 0; j < n_density_elements_j; j++) {
+        for (int i = 0; i < n_density_elements_i; i++) {
+            const double d2eri_dAxdCx = output_cache[i + j * n_density_elements_i + 0 * n_density_elements_ij];
+            const double d2eri_dAxdCy = output_cache[i + j * n_density_elements_i + 1 * n_density_elements_ij];
+            const double d2eri_dAxdCz = output_cache[i + j * n_density_elements_i + 2 * n_density_elements_ij];
+            const double d2eri_dAydCx = output_cache[i + j * n_density_elements_i + 3 * n_density_elements_ij];
+            const double d2eri_dAydCy = output_cache[i + j * n_density_elements_i + 4 * n_density_elements_ij];
+            const double d2eri_dAydCz = output_cache[i + j * n_density_elements_i + 5 * n_density_elements_ij];
+            const double d2eri_dAzdCx = output_cache[i + j * n_density_elements_i + 6 * n_density_elements_ij];
+            const double d2eri_dAzdCy = output_cache[i + j * n_density_elements_i + 7 * n_density_elements_ij];
+            const double d2eri_dAzdCz = output_cache[i + j * n_density_elements_i + 8 * n_density_elements_ij];
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 0 * stride_ij), d2eri_dAxdCx);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 1 * stride_ij), d2eri_dAxdCy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 2 * stride_ij), d2eri_dAxdCz);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 3 * stride_ij), d2eri_dAydCx);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 4 * stride_ij), d2eri_dAydCy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 5 * stride_ij), d2eri_dAydCz);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 6 * stride_ij), d2eri_dAzdCx);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 7 * stride_ij), d2eri_dAzdCy);
+            atomicAdd(output + ((i + i0) + (j + j0) * stride_j + 8 * stride_ij), d2eri_dAzdCz);
+        }
+    }
+}
+
+template <int L_SUM>
+__global__
+static void GINTfill_int3c1e_ipip2_density_contracted_kernel_general(double* output, const double* density, const HermiteDensityOffsets hermite_density_offsets,
+                                                                     const BasisProdOffsets offsets, const int nprim_ij,
+                                                                     const double omega, const double* grid_points, const double* charge_exponents)
+{
+    constexpr int NROOTS = (L_SUM + 2) / 2 + 1;
+
+    const int ntasks_ij = offsets.ntasks_ij;
+    const int ngrids = offsets.ntasks_kl;
+    const int task_grid = blockIdx.y * blockDim.y + threadIdx.y;
+    if (task_grid >= ngrids) {
+        return;
+    }
+
+    const double* grid_point = grid_points + task_grid * 3;
+    const double Cx = grid_point[0];
+    const double Cy = grid_point[1];
+    const double Cz = grid_point[2];
+    const double charge_exponent = (charge_exponents != NULL) ? charge_exponents[task_grid] : 0.0;
+
+    double d2eri_dCxdCx_pair_sum = 0.0;
+    double d2eri_dCxdCy_pair_sum = 0.0;
+    double d2eri_dCxdCz_pair_sum = 0.0;
+    double d2eri_dCydCy_pair_sum = 0.0;
+    double d2eri_dCydCz_pair_sum = 0.0;
+    double d2eri_dCzdCz_pair_sum = 0.0;
+    for (int task_ij = blockIdx.x * blockDim.x + threadIdx.x; task_ij < ntasks_ij; task_ij += gridDim.x * blockDim.x) {
+
+        const int bas_ij = offsets.bas_ij + task_ij;
+        const int prim_ij = offsets.primitive_ij + task_ij * nprim_ij;
+        const int* bas_pair2bra = c_bpcache.bas_pair2bra;
+        // const int* bas_pair2ket = c_bpcache.bas_pair2ket;
+        const int ish = bas_pair2bra[bas_ij];
+        // const int jsh = bas_pair2ket[bas_ij];
+        const int nbas = c_bpcache.nbas;
+        const double* __restrict__ bas_x = c_bpcache.bas_coords;
+        const double* __restrict__ bas_y = bas_x + nbas;
+        const double* __restrict__ bas_z = bas_y + nbas;
+        const double Ax = bas_x[ish];
+        const double Ay = bas_y[ish];
+        const double Az = bas_z[ish];
+
+        const double ACx = Ax - Cx;
+        const double ACy = Ay - Cy;
+        const double ACz = Az - Cz;
+
+        double D_hermite[(L_SUM + 1) * (L_SUM + 2) * (L_SUM + 3) / 6];
+#pragma unroll
+        for (int i_t = 0; i_t < (L_SUM + 1) * (L_SUM + 2) * (L_SUM + 3) / 6; i_t++) {
+            D_hermite[i_t] = density[bas_ij - hermite_density_offsets.pair_offset_of_angular_pair + hermite_density_offsets.density_offset_of_angular_pair + i_t * hermite_density_offsets.n_pair_of_angular_pair];
+        }
+
+        double d2eri_dCxdCx = 0.0;
+        double d2eri_dCxdCy = 0.0;
+        double d2eri_dCxdCz = 0.0;
+        double d2eri_dCydCy = 0.0;
+        double d2eri_dCydCz = 0.0;
+        double d2eri_dCzdCz = 0.0;
+        for (int ij = prim_ij; ij < prim_ij+nprim_ij; ++ij) {
+            double g[NROOTS * (L_SUM + 2 + 1) * 3];
+            double u2[NROOTS];
+            GINT_g1e_without_hrr_save_u2<L_SUM + 2>(g, u2, Cx, Cy, Cz, ish, ij, charge_exponent, omega);
+
+            const double* __restrict__ gx = g;
+            const double* __restrict__ gy = g + NROOTS * (L_SUM + 2 + 1);
+            const double* __restrict__ gz = g + NROOTS * (L_SUM + 2 + 1) * 2;
+
+#pragma unroll
+            for (int i_x = 0, i_t = 0; i_x <= L_SUM; i_x++) {
+#pragma unroll
+                for (int i_y = 0; i_x + i_y <= L_SUM; i_y++) {
+#pragma unroll
+                    for (int i_z = 0; i_x + i_y + i_z <= L_SUM; i_z++, i_t++) {
+                        double d2eri_dCxdCx_per_hermite = 0.0;
+                        double d2eri_dCxdCy_per_hermite = 0.0;
+                        double d2eri_dCxdCz_per_hermite = 0.0;
+                        double d2eri_dCydCy_per_hermite = 0.0;
+                        double d2eri_dCydCz_per_hermite = 0.0;
+                        double d2eri_dCzdCz_per_hermite = 0.0;
+#pragma unroll
+                        for (int i_root = 0; i_root < NROOTS; i_root++) {
+                            const double gx_0 = gx[i_root + NROOTS * i_x];
+                            const double gy_0 = gy[i_root + NROOTS * i_y];
+                            const double gz_0 = gz[i_root + NROOTS * i_z];
+                            const double gx_1 = gx[i_root + NROOTS * (i_x + 1)];
+                            const double gy_1 = gy[i_root + NROOTS * (i_y + 1)];
+                            const double gz_1 = gz[i_root + NROOTS * (i_z + 1)];
+                            const double gx_2 = gx[i_root + NROOTS * (i_x + 2)];
+                            const double gy_2 = gy[i_root + NROOTS * (i_y + 2)];
+                            const double gz_2 = gz[i_root + NROOTS * (i_z + 2)];
+                            const double two_u2 = 2.0 * u2[i_root];
+                            const double dgx_dCx = two_u2 * (gx_1 + ACx * gx_0);
+                            const double dgy_dCy = two_u2 * (gy_1 + ACy * gy_0);
+                            const double dgz_dCz = two_u2 * (gz_1 + ACz * gz_0);
+                            const double d2gx_dCx2 = two_u2 * (-gx_0 + two_u2 * (gx_2 + ACx * gx_1 * 2 + ACx * ACx * gx_0));
+                            const double d2gy_dCy2 = two_u2 * (-gy_0 + two_u2 * (gy_2 + ACy * gy_1 * 2 + ACy * ACy * gy_0));
+                            const double d2gz_dCz2 = two_u2 * (-gz_0 + two_u2 * (gz_2 + ACz * gz_1 * 2 + ACz * ACz * gz_0));
+                            d2eri_dCxdCx_per_hermite += d2gx_dCx2 * gy_0 * gz_0;
+                            d2eri_dCxdCy_per_hermite += dgx_dCx * dgy_dCy * gz_0;
+                            d2eri_dCxdCz_per_hermite += dgx_dCx * gy_0 * dgz_dCz;
+                            d2eri_dCydCy_per_hermite += gx_0 * d2gy_dCy2 * gz_0;
+                            d2eri_dCydCz_per_hermite += gx_0 * dgy_dCy * dgz_dCz;
+                            d2eri_dCzdCz_per_hermite += gx_0 * gy_0 * d2gz_dCz2;
+                        }
+                        const double D_t = D_hermite[i_t];
+                        d2eri_dCxdCx += d2eri_dCxdCx_per_hermite * D_t;
+                        d2eri_dCxdCy += d2eri_dCxdCy_per_hermite * D_t;
+                        d2eri_dCxdCz += d2eri_dCxdCz_per_hermite * D_t;
+                        d2eri_dCydCy += d2eri_dCydCy_per_hermite * D_t;
+                        d2eri_dCydCz += d2eri_dCydCz_per_hermite * D_t;
+                        d2eri_dCzdCz += d2eri_dCzdCz_per_hermite * D_t;
+                    }
+                }
+            }
+        }
+        d2eri_dCxdCx_pair_sum += d2eri_dCxdCx;
+        d2eri_dCxdCy_pair_sum += d2eri_dCxdCy;
+        d2eri_dCxdCz_pair_sum += d2eri_dCxdCz;
+        d2eri_dCydCy_pair_sum += d2eri_dCydCy;
+        d2eri_dCydCz_pair_sum += d2eri_dCydCz;
+        d2eri_dCzdCz_pair_sum += d2eri_dCzdCz;
+    }
+    atomicAdd(output + task_grid + ngrids * 0, d2eri_dCxdCx_pair_sum);
+    atomicAdd(output + task_grid + ngrids * 1, d2eri_dCxdCy_pair_sum);
+    atomicAdd(output + task_grid + ngrids * 2, d2eri_dCxdCz_pair_sum);
+    atomicAdd(output + task_grid + ngrids * 4, d2eri_dCydCy_pair_sum);
+    atomicAdd(output + task_grid + ngrids * 5, d2eri_dCydCz_pair_sum);
+    atomicAdd(output + task_grid + ngrids * 8, d2eri_dCzdCz_pair_sum);
+}

--- a/gpu4pyscf/lib/gint/nr_fill_ao_int3c1e_ipip.cu
+++ b/gpu4pyscf/lib/gint/nr_fill_ao_int3c1e_ipip.cu
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <cuda_runtime.h>
+
+#include "gint.h"
+#include "gint1e.h"
+#include "cuda_alloc.cuh"
+#include "cint2e.cuh"
+
+#include "rys_roots.cu"
+#include "g1e.cu"
+#include "g3c1e_ipip.cu"
+
+static int GINTfill_int3c1e_ipip1_charge_contracted_tasks(double* output, const BasisProdOffsets offsets, const int i_l, const int j_l, const int nprim_ij,
+                                                          const int stride_j, const int stride_ij, const int ao_offsets_i, const int ao_offsets_j,
+                                                          const double omega, const double* grid_points, const double* charge_exponents,
+                                                          const int n_charge_sum_per_thread, const cudaStream_t stream)
+{
+    const int ntasks_ij = offsets.ntasks_ij;
+    const int ngrids = (offsets.ntasks_kl + n_charge_sum_per_thread - 1) / n_charge_sum_per_thread;
+
+    const dim3 threads(THREADSX, THREADSY);
+    const dim3 blocks((ntasks_ij+THREADSX-1)/THREADSX, (ngrids+THREADSY-1)/THREADSY);
+    const int nrys_roots = (i_l + j_l + 2) / 2 + 1;
+    switch (nrys_roots) {
+    case 2: GINTfill_int3c1e_ipip1_charge_contracted_kernel_general<2, GSIZE5_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 3: GINTfill_int3c1e_ipip1_charge_contracted_kernel_general<3, GSIZE6_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 4: GINTfill_int3c1e_ipip1_charge_contracted_kernel_general<4, GSIZE4_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 5: GINTfill_int3c1e_ipip1_charge_contracted_kernel_general<5, GSIZE5_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 6: GINTfill_int3c1e_ipip1_charge_contracted_kernel_general<6, GSIZE6_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    default:
+        fprintf(stderr, "nrys_roots = %d out of range\n", nrys_roots);
+        return 1;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in %s: %s\n", __func__, cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+static int GINTfill_int3c1e_ipvip1_charge_contracted_tasks(double* output, const BasisProdOffsets offsets, const int i_l, const int j_l, const int nprim_ij,
+                                                           const int stride_j, const int stride_ij, const int ao_offsets_i, const int ao_offsets_j,
+                                                           const double omega, const double* grid_points, const double* charge_exponents,
+                                                           const int n_charge_sum_per_thread, const cudaStream_t stream)
+{
+    const int ntasks_ij = offsets.ntasks_ij;
+    const int ngrids = (offsets.ntasks_kl + n_charge_sum_per_thread - 1) / n_charge_sum_per_thread;
+
+    const dim3 threads(THREADSX, THREADSY);
+    const dim3 blocks((ntasks_ij+THREADSX-1)/THREADSX, (ngrids+THREADSY-1)/THREADSY);
+    const int nrys_roots = (i_l + j_l + 2) / 2 + 1;
+    switch (nrys_roots) {
+    case 2: GINTfill_int3c1e_ipvip1_charge_contracted_kernel_general<2, GSIZE5_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 3: GINTfill_int3c1e_ipvip1_charge_contracted_kernel_general<3, GSIZE6_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 4: GINTfill_int3c1e_ipvip1_charge_contracted_kernel_general<4, GSIZE4_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 5: GINTfill_int3c1e_ipvip1_charge_contracted_kernel_general<5, GSIZE5_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 6: GINTfill_int3c1e_ipvip1_charge_contracted_kernel_general<6, GSIZE6_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    default:
+        fprintf(stderr, "nrys_roots = %d out of range\n", nrys_roots);
+        return 1;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in %s: %s\n", __func__, cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+static int GINTfill_int3c1e_ip1ip2_charge_contracted_tasks(double* output, const BasisProdOffsets offsets, const int i_l, const int j_l, const int nprim_ij,
+                                                           const int stride_j, const int stride_ij, const int ao_offsets_i, const int ao_offsets_j,
+                                                           const double omega, const double* grid_points, const double* charge_exponents,
+                                                           const int n_charge_sum_per_thread, const cudaStream_t stream)
+{
+    const int ntasks_ij = offsets.ntasks_ij;
+    const int ngrids = (offsets.ntasks_kl + n_charge_sum_per_thread - 1) / n_charge_sum_per_thread;
+
+    const dim3 threads(THREADSX, THREADSY);
+    const dim3 blocks((ntasks_ij+THREADSX-1)/THREADSX, (ngrids+THREADSY-1)/THREADSY);
+    const int nrys_roots = (i_l + j_l + 2) / 2 + 1;
+    switch (nrys_roots) {
+    case 2: GINTfill_int3c1e_ip1ip2_charge_contracted_kernel_general<2, GSIZE5_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 3: GINTfill_int3c1e_ip1ip2_charge_contracted_kernel_general<3, GSIZE6_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 4: GINTfill_int3c1e_ip1ip2_charge_contracted_kernel_general<4, GSIZE4_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 5: GINTfill_int3c1e_ip1ip2_charge_contracted_kernel_general<5, GSIZE5_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    case 6: GINTfill_int3c1e_ip1ip2_charge_contracted_kernel_general<6, GSIZE6_INT3C_1E> <<<blocks, threads, 0, stream>>>(output, offsets, i_l, j_l, nprim_ij, stride_j, stride_ij, ao_offsets_i, ao_offsets_j, omega, grid_points, charge_exponents); break;
+    default:
+        fprintf(stderr, "nrys_roots = %d out of range\n", nrys_roots);
+        return 1;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in %s: %s\n", __func__, cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+static int GINTfill_int3c1e_ipip2_density_contracted_tasks(double* output, const double* density, const HermiteDensityOffsets hermite_density_offsets,
+                                                           const BasisProdOffsets offsets, const int i_l, const int j_l, const int nprim_ij,
+                                                           const double omega, const double* grid_points, const double* charge_exponents,
+                                                           const int n_pair_sum_per_thread, const cudaStream_t stream)
+{
+    const int ntasks_ij = (offsets.ntasks_ij + n_pair_sum_per_thread - 1) / n_pair_sum_per_thread;
+    const int ngrids = offsets.ntasks_kl;
+
+    const dim3 threads(THREADSX, THREADSY);
+    const dim3 blocks((ntasks_ij+THREADSX-1)/THREADSX, (ngrids+THREADSY-1)/THREADSY);
+    switch (i_l + j_l) {
+    case  0: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 0> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  1: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 1> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  2: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 2> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  3: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 3> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  4: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 4> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  5: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 5> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  6: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 6> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  7: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 7> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    case  8: GINTfill_int3c1e_ipip2_density_contracted_kernel_general< 8> <<<blocks, threads, 0, stream>>>(output, density, hermite_density_offsets, offsets, nprim_ij, omega, grid_points, charge_exponents); break;
+    // Up to g + g = 8 now
+    default:
+        fprintf(stderr, "i_l + j_l = %d out of range\n", i_l + j_l);
+        return 1;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in %s: %s\n", __func__, cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+extern "C" {
+int GINTfill_int3c1e_ipip1_charge_contracted(const cudaStream_t stream, const BasisProdCache* bpcache,
+                                             const double* grid_points, const double* charge_exponents, const int ngrids,
+                                             double* integral_charge_contracted,
+                                             const int* strides, const int* ao_offsets,
+                                             const int* bins_locs_ij, const int nbins,
+                                             const int cp_ij_id, const double omega, const int n_charge_sum_per_thread)
+{
+    const ContractionProdType *cp_ij = bpcache->cptype + cp_ij_id;
+    const int i_l = cp_ij->l_bra;
+    const int j_l = cp_ij->l_ket;
+    const int nrys_roots = (i_l + j_l + 2) / 2 + 1;
+    const int nprim_ij = cp_ij->nprim_12;
+
+    if (nrys_roots > MAX_NROOTS_INT3C_1E + 2) {
+        fprintf(stderr, "nrys_roots = %d too high\n", nrys_roots);
+        return 2;
+    }
+
+    checkCudaErrors(cudaMemcpyToSymbol(c_bpcache, bpcache, sizeof(BasisProdCache)));
+
+    const int* bas_pairs_locs = bpcache->bas_pairs_locs;
+    const int* primitive_pairs_locs = bpcache->primitive_pairs_locs;
+    for (int ij_bin = 0; ij_bin < nbins; ij_bin++) {
+        const int bas_ij0 = bins_locs_ij[ij_bin];
+        const int bas_ij1 = bins_locs_ij[ij_bin + 1];
+        const int ntasks_ij = bas_ij1 - bas_ij0;
+        if (ntasks_ij <= 0) {
+            continue;
+        }
+
+        BasisProdOffsets offsets;
+        offsets.ntasks_ij = ntasks_ij;
+        offsets.ntasks_kl = ngrids;
+        offsets.bas_ij = bas_pairs_locs[cp_ij_id] + bas_ij0;
+        offsets.bas_kl = -1;
+        offsets.primitive_ij = primitive_pairs_locs[cp_ij_id] + bas_ij0 * nprim_ij;
+        offsets.primitive_kl = -1;
+
+        const int err = GINTfill_int3c1e_ipip1_charge_contracted_tasks(integral_charge_contracted, offsets, i_l, j_l, nprim_ij,
+                                                                       strides[0], strides[1], ao_offsets[0], ao_offsets[1],
+                                                                       omega, grid_points, charge_exponents, n_charge_sum_per_thread, stream);
+
+        if (err != 0) {
+            return err;
+        }
+    }
+
+    return 0;
+}
+
+int GINTfill_int3c1e_ipvip1_charge_contracted(const cudaStream_t stream, const BasisProdCache* bpcache,
+                                              const double* grid_points, const double* charge_exponents, const int ngrids,
+                                              double* integral_charge_contracted,
+                                              const int* strides, const int* ao_offsets,
+                                              const int* bins_locs_ij, const int nbins,
+                                              const int cp_ij_id, const double omega, const int n_charge_sum_per_thread)
+{
+    const ContractionProdType *cp_ij = bpcache->cptype + cp_ij_id;
+    const int i_l = cp_ij->l_bra;
+    const int j_l = cp_ij->l_ket;
+    const int nrys_roots = (i_l + j_l + 2) / 2 + 1;
+    const int nprim_ij = cp_ij->nprim_12;
+
+    if (nrys_roots > MAX_NROOTS_INT3C_1E + 2) {
+        fprintf(stderr, "nrys_roots = %d too high\n", nrys_roots);
+        return 2;
+    }
+
+    checkCudaErrors(cudaMemcpyToSymbol(c_bpcache, bpcache, sizeof(BasisProdCache)));
+
+    const int* bas_pairs_locs = bpcache->bas_pairs_locs;
+    const int* primitive_pairs_locs = bpcache->primitive_pairs_locs;
+    for (int ij_bin = 0; ij_bin < nbins; ij_bin++) {
+        const int bas_ij0 = bins_locs_ij[ij_bin];
+        const int bas_ij1 = bins_locs_ij[ij_bin + 1];
+        const int ntasks_ij = bas_ij1 - bas_ij0;
+        if (ntasks_ij <= 0) {
+            continue;
+        }
+
+        BasisProdOffsets offsets;
+        offsets.ntasks_ij = ntasks_ij;
+        offsets.ntasks_kl = ngrids;
+        offsets.bas_ij = bas_pairs_locs[cp_ij_id] + bas_ij0;
+        offsets.bas_kl = -1;
+        offsets.primitive_ij = primitive_pairs_locs[cp_ij_id] + bas_ij0 * nprim_ij;
+        offsets.primitive_kl = -1;
+
+        const int err = GINTfill_int3c1e_ipvip1_charge_contracted_tasks(integral_charge_contracted, offsets, i_l, j_l, nprim_ij,
+                                                                        strides[0], strides[1], ao_offsets[0], ao_offsets[1],
+                                                                        omega, grid_points, charge_exponents, n_charge_sum_per_thread, stream);
+
+        if (err != 0) {
+            return err;
+        }
+    }
+
+    return 0;
+}
+
+int GINTfill_int3c1e_ip1ip2_charge_contracted(const cudaStream_t stream, const BasisProdCache* bpcache,
+                                              const double* grid_points, const double* charge_exponents, const int ngrids,
+                                              double* integral_charge_contracted,
+                                              const int* strides, const int* ao_offsets,
+                                              const int* bins_locs_ij, const int nbins,
+                                              const int cp_ij_id, const double omega, const int n_charge_sum_per_thread)
+{
+    const ContractionProdType *cp_ij = bpcache->cptype + cp_ij_id;
+    const int i_l = cp_ij->l_bra;
+    const int j_l = cp_ij->l_ket;
+    const int nrys_roots = (i_l + j_l + 2) / 2 + 1;
+    const int nprim_ij = cp_ij->nprim_12;
+
+    if (nrys_roots > MAX_NROOTS_INT3C_1E + 2) {
+        fprintf(stderr, "nrys_roots = %d too high\n", nrys_roots);
+        return 2;
+    }
+
+    checkCudaErrors(cudaMemcpyToSymbol(c_bpcache, bpcache, sizeof(BasisProdCache)));
+
+    const int* bas_pairs_locs = bpcache->bas_pairs_locs;
+    const int* primitive_pairs_locs = bpcache->primitive_pairs_locs;
+    for (int ij_bin = 0; ij_bin < nbins; ij_bin++) {
+        const int bas_ij0 = bins_locs_ij[ij_bin];
+        const int bas_ij1 = bins_locs_ij[ij_bin + 1];
+        const int ntasks_ij = bas_ij1 - bas_ij0;
+        if (ntasks_ij <= 0) {
+            continue;
+        }
+
+        BasisProdOffsets offsets;
+        offsets.ntasks_ij = ntasks_ij;
+        offsets.ntasks_kl = ngrids;
+        offsets.bas_ij = bas_pairs_locs[cp_ij_id] + bas_ij0;
+        offsets.bas_kl = -1;
+        offsets.primitive_ij = primitive_pairs_locs[cp_ij_id] + bas_ij0 * nprim_ij;
+        offsets.primitive_kl = -1;
+
+        const int err = GINTfill_int3c1e_ip1ip2_charge_contracted_tasks(integral_charge_contracted, offsets, i_l, j_l, nprim_ij,
+                                                                        strides[0], strides[1], ao_offsets[0], ao_offsets[1],
+                                                                        omega, grid_points, charge_exponents, n_charge_sum_per_thread, stream);
+
+        if (err != 0) {
+            return err;
+        }
+    }
+
+    return 0;
+}
+
+int GINTfill_int3c1e_ipip2_density_contracted(const cudaStream_t stream, const BasisProdCache* bpcache,
+                                              const double* grid_points, const double* charge_exponents, const int ngrids,
+                                              const double* dm_pair_ordered, const int* density_offset,
+                                              double* integral_density_contracted,
+                                              const int* bins_locs_ij, const int nbins,
+                                              const int cp_ij_id, const double omega, const int n_pair_sum_per_thread)
+{
+    const ContractionProdType *cp_ij = bpcache->cptype + cp_ij_id;
+    const int i_l = cp_ij->l_bra;
+    const int j_l = cp_ij->l_ket;
+    const int nrys_roots = (i_l + j_l + 2) / 2 + 1;
+    const int nprim_ij = cp_ij->nprim_12;
+
+    if (nrys_roots > MAX_NROOTS_INT3C_1E + 2) {
+        fprintf(stderr, "nrys_roots = %d too high\n", nrys_roots);
+        return 2;
+    }
+
+    checkCudaErrors(cudaMemcpyToSymbol(c_bpcache, bpcache, sizeof(BasisProdCache)));
+
+    const int* bas_pairs_locs = bpcache->bas_pairs_locs;
+    const int* primitive_pairs_locs = bpcache->primitive_pairs_locs;
+    for (int ij_bin = 0; ij_bin < nbins; ij_bin++) {
+        const int bas_ij0 = bins_locs_ij[ij_bin];
+        const int bas_ij1 = bins_locs_ij[ij_bin + 1];
+        const int ntasks_ij = bas_ij1 - bas_ij0;
+        if (ntasks_ij <= 0) {
+            continue;
+        }
+
+        BasisProdOffsets offsets;
+        offsets.ntasks_ij = ntasks_ij;
+        offsets.ntasks_kl = ngrids;
+        offsets.bas_ij = bas_pairs_locs[cp_ij_id] + bas_ij0;
+        offsets.bas_kl = -1;
+        offsets.primitive_ij = primitive_pairs_locs[cp_ij_id] + bas_ij0 * nprim_ij;
+        offsets.primitive_kl = -1;
+
+        HermiteDensityOffsets hermite_density_offsets;
+        hermite_density_offsets.density_offset_of_angular_pair = density_offset[cp_ij_id];
+        hermite_density_offsets.pair_offset_of_angular_pair = bas_pairs_locs[cp_ij_id];
+        hermite_density_offsets.n_pair_of_angular_pair = bas_pairs_locs[cp_ij_id + 1] - bas_pairs_locs[cp_ij_id];
+
+        const int err = GINTfill_int3c1e_ipip2_density_contracted_tasks(integral_density_contracted, dm_pair_ordered, hermite_density_offsets,
+                                                                        offsets, i_l, j_l, nprim_ij,
+                                                                        omega, grid_points, charge_exponents, n_pair_sum_per_thread, stream);
+
+        if (err != 0) {
+            return err;
+        }
+    }
+
+    return 0;
+}
+}

--- a/gpu4pyscf/lib/solvent/pcm.cu
+++ b/gpu4pyscf/lib/solvent/pcm.cu
@@ -153,7 +153,7 @@ static void _pcm_d2D_d2S(double *matrix_d2D, double *matrix_d2S,
     const double dy = coords[3*i+1] - coords[3*j+1];
     const double dz = coords[3*i+2] - coords[3*j+2];
     const double rij = norm3d(dx, dy, dz);
-    const double rij_1 = 1.0 / rij;
+    const double rij_1 = (i != j) ? (1.0 / rij) : 0.0; // This guarantees that if i == j, all matrix elements = 0
     const double rij_2 = rij_1 * rij_1;
     const double rij_3 = rij_2 * rij_1;
     const double rij_4 = rij_2 * rij_2;
@@ -171,27 +171,15 @@ static void _pcm_d2D_d2S(double *matrix_d2D, double *matrix_d2S,
     const double S_xyz_diagonal_prefactor = two_eij_over_sqrt_pi_exp_minus_eij2_rij2 * rij_2 - rij_3 * erf_eij_rij;
 
     const int n2 = n * n;
-    if (i == j) {
-        matrix_d2S[i*n + j         ] = 0.0;
-        matrix_d2S[i*n + j + n2    ] = 0.0;
-        matrix_d2S[i*n + j + n2 * 2] = 0.0;
-        matrix_d2S[i*n + j + n2 * 3] = 0.0;
-        matrix_d2S[i*n + j + n2 * 4] = 0.0;
-        matrix_d2S[i*n + j + n2 * 5] = 0.0;
-        matrix_d2S[i*n + j + n2 * 6] = 0.0;
-        matrix_d2S[i*n + j + n2 * 7] = 0.0;
-        matrix_d2S[i*n + j + n2 * 8] = 0.0;
-    } else {
-        matrix_d2S[i*n + j         ] = dx * dx * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
-        matrix_d2S[i*n + j + n2    ] = dx * dy * S_direct_product_prefactor;
-        matrix_d2S[i*n + j + n2 * 2] = dx * dz * S_direct_product_prefactor;
-        matrix_d2S[i*n + j + n2 * 3] = dy * dx * S_direct_product_prefactor;
-        matrix_d2S[i*n + j + n2 * 4] = dy * dy * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
-        matrix_d2S[i*n + j + n2 * 5] = dy * dz * S_direct_product_prefactor;
-        matrix_d2S[i*n + j + n2 * 6] = dz * dx * S_direct_product_prefactor;
-        matrix_d2S[i*n + j + n2 * 7] = dz * dy * S_direct_product_prefactor;
-        matrix_d2S[i*n + j + n2 * 8] = dz * dz * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
-    }
+    matrix_d2S[i*n + j         ] = dx * dx * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
+    matrix_d2S[i*n + j + n2    ] = dx * dy * S_direct_product_prefactor;
+    matrix_d2S[i*n + j + n2 * 2] = dx * dz * S_direct_product_prefactor;
+    matrix_d2S[i*n + j + n2 * 3] = dy * dx * S_direct_product_prefactor;
+    matrix_d2S[i*n + j + n2 * 4] = dy * dy * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
+    matrix_d2S[i*n + j + n2 * 5] = dy * dz * S_direct_product_prefactor;
+    matrix_d2S[i*n + j + n2 * 6] = dz * dx * S_direct_product_prefactor;
+    matrix_d2S[i*n + j + n2 * 7] = dz * dy * S_direct_product_prefactor;
+    matrix_d2S[i*n + j + n2 * 8] = dz * dz * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
 
     if (matrix_d2D != NULL) {
         const double nxj = norm_vec[3*j];
@@ -205,27 +193,15 @@ static void _pcm_d2D_d2S(double *matrix_d2D, double *matrix_d2S,
 
         const double D_direct_product_prefactor = (-two_eij_over_sqrt_pi_exp_minus_eij2_rij2 * (15 * rij_6 + 10 * eij2 * rij_4 + 4 * eij4 * rij_2)
                                                    + 15 * rij_7 * erf_eij_rij) * nj_rij;
-        if (i == j) {
-            matrix_d2D[i*n + j         ] = 0.0;
-            matrix_d2D[i*n + j + n2    ] = 0.0;
-            matrix_d2D[i*n + j + n2 * 2] = 0.0;
-            matrix_d2D[i*n + j + n2 * 3] = 0.0;
-            matrix_d2D[i*n + j + n2 * 4] = 0.0;
-            matrix_d2D[i*n + j + n2 * 5] = 0.0;
-            matrix_d2D[i*n + j + n2 * 6] = 0.0;
-            matrix_d2D[i*n + j + n2 * 7] = 0.0;
-            matrix_d2D[i*n + j + n2 * 8] = 0.0;
-        } else {
-            matrix_d2D[i*n + j         ] = D_direct_product_prefactor * dx * dx - S_direct_product_prefactor * (dx * nxj + dx * nxj + nj_rij);
-            matrix_d2D[i*n + j + n2    ] = D_direct_product_prefactor * dx * dy - S_direct_product_prefactor * (dy * nxj + dx * nyj);
-            matrix_d2D[i*n + j + n2 * 2] = D_direct_product_prefactor * dx * dz - S_direct_product_prefactor * (dz * nxj + dx * nzj);
-            matrix_d2D[i*n + j + n2 * 3] = D_direct_product_prefactor * dy * dx - S_direct_product_prefactor * (dx * nyj + dy * nxj);
-            matrix_d2D[i*n + j + n2 * 4] = D_direct_product_prefactor * dy * dy - S_direct_product_prefactor * (dy * nyj + dy * nyj + nj_rij);
-            matrix_d2D[i*n + j + n2 * 5] = D_direct_product_prefactor * dy * dz - S_direct_product_prefactor * (dz * nyj + dy * nzj);
-            matrix_d2D[i*n + j + n2 * 6] = D_direct_product_prefactor * dz * dx - S_direct_product_prefactor * (dx * nzj + dz * nxj);
-            matrix_d2D[i*n + j + n2 * 7] = D_direct_product_prefactor * dz * dy - S_direct_product_prefactor * (dy * nzj + dz * nyj);
-            matrix_d2D[i*n + j + n2 * 8] = D_direct_product_prefactor * dz * dz - S_direct_product_prefactor * (dz * nzj + dz * nzj + nj_rij);
-        }
+        matrix_d2D[i*n + j         ] = D_direct_product_prefactor * dx * dx - S_direct_product_prefactor * (dx * nxj + dx * nxj + nj_rij);
+        matrix_d2D[i*n + j + n2    ] = D_direct_product_prefactor * dx * dy - S_direct_product_prefactor * (dy * nxj + dx * nyj);
+        matrix_d2D[i*n + j + n2 * 2] = D_direct_product_prefactor * dx * dz - S_direct_product_prefactor * (dz * nxj + dx * nzj);
+        matrix_d2D[i*n + j + n2 * 3] = D_direct_product_prefactor * dy * dx - S_direct_product_prefactor * (dx * nyj + dy * nxj);
+        matrix_d2D[i*n + j + n2 * 4] = D_direct_product_prefactor * dy * dy - S_direct_product_prefactor * (dy * nyj + dy * nyj + nj_rij);
+        matrix_d2D[i*n + j + n2 * 5] = D_direct_product_prefactor * dy * dz - S_direct_product_prefactor * (dz * nyj + dy * nzj);
+        matrix_d2D[i*n + j + n2 * 6] = D_direct_product_prefactor * dz * dx - S_direct_product_prefactor * (dx * nzj + dz * nxj);
+        matrix_d2D[i*n + j + n2 * 7] = D_direct_product_prefactor * dz * dy - S_direct_product_prefactor * (dy * nzj + dz * nyj);
+        matrix_d2D[i*n + j + n2 * 8] = D_direct_product_prefactor * dz * dz - S_direct_product_prefactor * (dz * nzj + dz * nzj + nj_rij);
     }
 }
 

--- a/gpu4pyscf/lib/solvent/pcm.cu
+++ b/gpu4pyscf/lib/solvent/pcm.cu
@@ -78,9 +78,9 @@ static void _pcm_d_s(double *matrix_d, double *matrix_s,
 
 __global__
 static void _pcm_dD_dS(double *matrix_dd, double *matrix_ds,
-                    const double *coords, const double *norm_vec, const double *r_vdw,
-                    const double *charge_exp, const double *switch_fun,
-                    int n)
+                       const double *coords, const double *norm_vec,
+                       const double *charge_exp,
+                       int n)
 {
     int i = blockIdx.x * blockDim.x + threadIdx.x;
     int j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -130,6 +130,105 @@ static void _pcm_dD_dS(double *matrix_dd, double *matrix_ds,
     }
 }
 
+
+__global__
+static void _pcm_d2D_d2S(double *matrix_d2D, double *matrix_d2S,
+                         const double *coords, const double *norm_vec,
+                         const double *charge_exp,
+                         int n)
+{
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    const int j = blockIdx.y * blockDim.y + threadIdx.y;
+    if (i >= n || j >= n) {
+        return;
+    }
+
+    // calculate xi
+    const double ei = charge_exp[i];
+    const double ej = charge_exp[j];
+    const double eij = ei * ej / sqrt(ei*ei + ej*ej);
+
+    // calculate r
+    const double dx = coords[3*i]   - coords[3*j];
+    const double dy = coords[3*i+1] - coords[3*j+1];
+    const double dz = coords[3*i+2] - coords[3*j+2];
+    const double rij = norm3d(dx, dy, dz);
+    const double rij_1 = 1.0 / rij;
+    const double rij_2 = rij_1 * rij_1;
+    const double rij_3 = rij_2 * rij_1;
+    const double rij_4 = rij_2 * rij_2;
+    const double rij_5 = rij_2 * rij_3;
+    const double eij2 = eij * eij;
+
+    const double eij_rij = eij * rij;
+    const double erf_eij_rij = erf(eij_rij);
+    const double exp_minus_eij2_rij2 = exp(-eij_rij * eij_rij);
+    const double two_eij_over_sqrt_pi = 2.0 * eij / SQRT_PI;
+    const double two_eij_over_sqrt_pi_exp_minus_eij2_rij2 = exp_minus_eij2_rij2 * two_eij_over_sqrt_pi;
+
+    const double S_direct_product_prefactor = -two_eij_over_sqrt_pi_exp_minus_eij2_rij2 * (3 * rij_4 + 2 * eij2 * rij_2)
+                                              + 3 * rij_5 * erf_eij_rij;
+    const double S_xyz_diagonal_prefactor = two_eij_over_sqrt_pi_exp_minus_eij2_rij2 * rij_2 - rij_3 * erf_eij_rij;
+
+    const int n2 = n * n;
+    if (i == j) {
+        matrix_d2S[i*n + j         ] = 0.0;
+        matrix_d2S[i*n + j + n2    ] = 0.0;
+        matrix_d2S[i*n + j + n2 * 2] = 0.0;
+        matrix_d2S[i*n + j + n2 * 3] = 0.0;
+        matrix_d2S[i*n + j + n2 * 4] = 0.0;
+        matrix_d2S[i*n + j + n2 * 5] = 0.0;
+        matrix_d2S[i*n + j + n2 * 6] = 0.0;
+        matrix_d2S[i*n + j + n2 * 7] = 0.0;
+        matrix_d2S[i*n + j + n2 * 8] = 0.0;
+    } else {
+        matrix_d2S[i*n + j         ] = dx * dx * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
+        matrix_d2S[i*n + j + n2    ] = dx * dy * S_direct_product_prefactor;
+        matrix_d2S[i*n + j + n2 * 2] = dx * dz * S_direct_product_prefactor;
+        matrix_d2S[i*n + j + n2 * 3] = dy * dx * S_direct_product_prefactor;
+        matrix_d2S[i*n + j + n2 * 4] = dy * dy * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
+        matrix_d2S[i*n + j + n2 * 5] = dy * dz * S_direct_product_prefactor;
+        matrix_d2S[i*n + j + n2 * 6] = dz * dx * S_direct_product_prefactor;
+        matrix_d2S[i*n + j + n2 * 7] = dz * dy * S_direct_product_prefactor;
+        matrix_d2S[i*n + j + n2 * 8] = dz * dz * S_direct_product_prefactor + S_xyz_diagonal_prefactor;
+    }
+
+    if (matrix_d2D != NULL) {
+        const double nxj = norm_vec[3*j];
+        const double nyj = norm_vec[3*j+1];
+        const double nzj = norm_vec[3*j+2];
+        const double nj_rij = dx * nxj + dy * nyj + dz * nzj;
+
+        const double eij4 = eij2 * eij2;
+        const double rij_6 = rij_4 * rij_2;
+        const double rij_7 = rij_4 * rij_3;
+
+        const double D_direct_product_prefactor = (-two_eij_over_sqrt_pi_exp_minus_eij2_rij2 * (15 * rij_6 + 10 * eij2 * rij_4 + 4 * eij4 * rij_2)
+                                                   + 15 * rij_7 * erf_eij_rij) * nj_rij;
+        if (i == j) {
+            matrix_d2D[i*n + j         ] = 0.0;
+            matrix_d2D[i*n + j + n2    ] = 0.0;
+            matrix_d2D[i*n + j + n2 * 2] = 0.0;
+            matrix_d2D[i*n + j + n2 * 3] = 0.0;
+            matrix_d2D[i*n + j + n2 * 4] = 0.0;
+            matrix_d2D[i*n + j + n2 * 5] = 0.0;
+            matrix_d2D[i*n + j + n2 * 6] = 0.0;
+            matrix_d2D[i*n + j + n2 * 7] = 0.0;
+            matrix_d2D[i*n + j + n2 * 8] = 0.0;
+        } else {
+            matrix_d2D[i*n + j         ] = D_direct_product_prefactor * dx * dx - S_direct_product_prefactor * (dx * nxj + dx * nxj + nj_rij);
+            matrix_d2D[i*n + j + n2    ] = D_direct_product_prefactor * dx * dy - S_direct_product_prefactor * (dy * nxj + dx * nyj);
+            matrix_d2D[i*n + j + n2 * 2] = D_direct_product_prefactor * dx * dz - S_direct_product_prefactor * (dz * nxj + dx * nzj);
+            matrix_d2D[i*n + j + n2 * 3] = D_direct_product_prefactor * dy * dx - S_direct_product_prefactor * (dx * nyj + dy * nxj);
+            matrix_d2D[i*n + j + n2 * 4] = D_direct_product_prefactor * dy * dy - S_direct_product_prefactor * (dy * nyj + dy * nyj + nj_rij);
+            matrix_d2D[i*n + j + n2 * 5] = D_direct_product_prefactor * dy * dz - S_direct_product_prefactor * (dz * nyj + dy * nzj);
+            matrix_d2D[i*n + j + n2 * 6] = D_direct_product_prefactor * dz * dx - S_direct_product_prefactor * (dx * nzj + dz * nxj);
+            matrix_d2D[i*n + j + n2 * 7] = D_direct_product_prefactor * dz * dy - S_direct_product_prefactor * (dy * nzj + dz * nyj);
+            matrix_d2D[i*n + j + n2 * 8] = D_direct_product_prefactor * dz * dz - S_direct_product_prefactor * (dz * nzj + dz * nzj + nj_rij);
+        }
+    }
+}
+
 extern "C" {
 int pcm_d_s(cudaStream_t stream, double *matrix_d, double *matrix_s,
                     const double *coords, const double *norm_vec, const double *r_vdw,
@@ -149,15 +248,32 @@ int pcm_d_s(cudaStream_t stream, double *matrix_d, double *matrix_s,
 }
 
 int pcm_dd_ds(cudaStream_t stream, double *matrix_dD, double *matrix_dS,
-                    const double *coords, const double *norm_vec, const double *r_vdw,
-                    const double *charge_exp, const double *switch_fun,
-                    int n)
+              const double *coords, const double *norm_vec,
+              const double *charge_exp,
+              int n)
 {
     int ntilex = (n + THREADS - 1) / THREADS;
     int ntiley = (n + THREADS - 1) / THREADS;
     dim3 threads(THREADS, THREADS);
     dim3 blocks(ntilex, ntiley);
-    _pcm_dD_dS<<<blocks, threads, 0, stream>>>(matrix_dD, matrix_dS, coords, norm_vec, r_vdw, charge_exp, switch_fun, n);
+    _pcm_dD_dS<<<blocks, threads, 0, stream>>>(matrix_dD, matrix_dS, coords, norm_vec, charge_exp, n);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}
+
+int pcm_d2d_d2s(cudaStream_t stream, double *matrix_d2D, double *matrix_d2S,
+                const double *coords, const double *norm_vec,
+                const double *charge_exp,
+                int n)
+{
+    const int ntilex = (n + THREADS - 1) / THREADS;
+    const int ntiley = (n + THREADS - 1) / THREADS;
+    const dim3 threads(THREADS, THREADS);
+    const dim3 blocks(ntilex, ntiley);
+    _pcm_d2D_d2S<<<blocks, threads, 0, stream>>>(matrix_d2D, matrix_d2S, coords, norm_vec, charge_exp, n);
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
         return 1;

--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -40,13 +40,6 @@ def grad_switch_h(x):
     dy[x>1] = 0.0
     return dy
 
-def gradgrad_switch_h(x):
-    ''' 2nd derivative of h(x) '''
-    ddy = 60.0*x - 180.0*x**2 + 120*x**3
-    ddy[x<0] = 0.0
-    ddy[x>1] = 0.0
-    return ddy
-
 def get_dF_dA(surface):
     '''
     J. Chem. Phys. 133, 244111 (2010), Appendix C
@@ -63,10 +56,9 @@ def get_dF_dA(surface):
     dF = cupy.zeros([ngrids, natom, 3])
     dA = cupy.zeros([ngrids, natom, 3])
 
-    for ia in range(atom_coords.shape[0]):
+    for ia in range(natom):
         p0,p1 = surface['gslice_by_atom'][ia]
         coords = grid_coords[p0:p1]
-        p1 = p0 + coords.shape[0]
         ri_rJ = cupy.expand_dims(coords, axis=1) - atom_coords
         riJ = cupy.linalg.norm(ri_rJ, axis=-1)
         diJ = (riJ - R_in_J) / R_sw_J

--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -181,7 +181,7 @@ def get_dSii(surface, dF):
     dSii = dSii_dF[:,None] * dF
     return dSii
 
-def grad_nuc(pcmobj, dm):
+def grad_nuc(pcmobj, dm, q_sym = None):
     mol = pcmobj.mol
     log = logger.new_logger(mol, mol.verbose)
     t1 = log.init_timer()
@@ -194,7 +194,8 @@ def grad_nuc(pcmobj, dm):
         pcmobj._get_vind(dm)
 
     mol = pcmobj.mol
-    q_sym        = pcmobj._intermediates['q_sym'].get()
+    if q_sym is None:
+        q_sym = pcmobj._intermediates['q_sym'].get()
     gridslice    = pcmobj.surface['gslice_by_atom']
     grid_coords  = pcmobj.surface['grid_coords'].get()
     exponents    = pcmobj.surface['charge_exp'].get()
@@ -220,7 +221,7 @@ def grad_nuc(pcmobj, dm):
     t1 = log.timer_debug1('grad nuc', *t1)
     return de
 
-def grad_qv(pcmobj, dm):
+def grad_qv(pcmobj, dm, q_sym = None):
     '''
     contributions due to integrals
     '''
@@ -237,7 +238,8 @@ def grad_qv(pcmobj, dm):
     gridslice   = pcmobj.surface['gslice_by_atom']
     charge_exp  = pcmobj.surface['charge_exp']
     grid_coords = pcmobj.surface['grid_coords']
-    q_sym       = pcmobj._intermediates['q_sym']
+    if q_sym is None:
+        q_sym = pcmobj._intermediates['q_sym']
 
     intopt = int3c1e.VHFOpt(mol)
     intopt.build(1e-14, aosym=False)

--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -137,9 +137,7 @@ def get_dD_dS(surface, with_S=True, with_D=False, stream=None):
     '''
     charge_exp  = surface['charge_exp']
     grid_coords = surface['grid_coords']
-    switch_fun  = surface['switch_fun']
     norm_vec    = surface['norm_vec']
-    R_vdw       = surface['R_vdw']
     n = charge_exp.shape[0]
     dS = cupy.empty([3,n,n])
     dD = None
@@ -155,9 +153,7 @@ def get_dD_dS(surface, with_S=True, with_D=False, stream=None):
         dD_ptr, dS_ptr,
         ctypes.cast(grid_coords.data.ptr, ctypes.c_void_p),
         ctypes.cast(norm_vec.data.ptr, ctypes.c_void_p),
-        ctypes.cast(R_vdw.data.ptr, ctypes.c_void_p),
         ctypes.cast(charge_exp.data.ptr, ctypes.c_void_p),
-        ctypes.cast(switch_fun.data.ptr, ctypes.c_void_p),
         ctypes.c_int(n)
     )
     if err != 0:

--- a/gpu4pyscf/solvent/hessian/pcm.py
+++ b/gpu4pyscf/solvent/hessian/pcm.py
@@ -365,7 +365,7 @@ def get_v_dot_d2D_dot_q(d2D, v_left, q_right, natom, gridslice):
 def get_v_dot_d2DT_dot_q(d2D, v_left, q_right, natom, gridslice):
     return get_v_dot_d2D_dot_q(d2D.transpose(0,1,3,2), v_left, q_right, natom, gridslice)
 
-def analytical_hess_solver(pcmobj, dm):
+def analytical_hess_solver(pcmobj, dm, verbose=None):
     if not pcmobj._intermediates:
         pcmobj.build()
     dm_cache = pcmobj._intermediates.get('dm', None)
@@ -374,7 +374,7 @@ def analytical_hess_solver(pcmobj, dm):
     else:
         pcmobj._get_vind(dm)
     mol = pcmobj.mol
-    log = logger.new_logger(mol, mol.verbose)
+    log = logger.new_logger(mol, verbose)
     t1 = log.init_timer()
 
     natom = mol.natm

--- a/gpu4pyscf/solvent/hessian/smd.py
+++ b/gpu4pyscf/solvent/hessian/smd.py
@@ -22,8 +22,6 @@ from pyscf import lib
 from gpu4pyscf import scf
 from gpu4pyscf.lib import logger
 from gpu4pyscf.solvent import smd
-from gpu4pyscf.solvent.grad import smd as smd_grad
-from gpu4pyscf.solvent.grad import pcm as pcm_grad
 from gpu4pyscf.solvent.hessian import pcm as pcm_hess
 from gpu4pyscf.hessian.jk import _ao2mo
 
@@ -59,45 +57,6 @@ def get_cds(smdobj):
             hess_cds[ia,:,j] = (grad0_cds - grad1_cds) / (2.0 * eps)
     t1 = log.timer_debug1('solvent energy', *t1)
     return hess_cds # hartree
-
-
-def hess_elec(smdobj, dm, verbose=None):
-    '''
-    slow version with finite difference
-    TODO: use analytical hess_nuc
-    '''
-    log = logger.new_logger(smdobj, verbose)
-    t1 = log.init_timer()
-    pmol = smdobj.mol.copy()
-    mol = pmol.copy()
-    coords = mol.atom_coords(unit='Bohr')
-
-    def pcm_grad_scanner(mol):
-        # TODO: use more analytical forms
-        smdobj.reset(mol)
-        e, v = smdobj._get_vind(dm)
-        #return grad_elec(smdobj, dm)
-        grad = pcm_grad.grad_nuc(smdobj, dm)
-        grad+= smd_grad.grad_solver(smdobj, dm)
-        grad+= pcm_grad.grad_qv(smdobj, dm)
-        return grad
-
-    mol.verbose = 0
-    de = np.zeros([mol.natm, mol.natm, 3, 3])
-    eps = 1e-3
-    for ia in range(mol.natm):
-        for ix in range(3):
-            dv = np.zeros_like(coords)
-            dv[ia,ix] = eps
-            mol.set_geom_(coords + dv, unit='Bohr')
-            g0 = pcm_grad_scanner(mol)
-
-            mol.set_geom_(coords - dv, unit='Bohr')
-            g1 = pcm_grad_scanner(mol)
-            de[ia,:,ix] = (g0 - g1)/2.0/eps
-    t1 = log.timer_debug1('solvent energy', *t1)
-    smdobj.reset(pmol)
-    return de
 
 def make_hess_object(hess_method):
     '''For hess_method in vacuum, add nuclear Hessian of solvent smdobj'''
@@ -140,8 +99,9 @@ class WithSolventHess:
             dm = dm[0] + dm[1]
         is_equilibrium = self.base.with_solvent.equilibrium_solvation
         self.base.with_solvent.equilibrium_solvation = True
-        self.de_solvent = pcm_hess.hess_elec(self.base.with_solvent, dm, verbose=self.verbose)
-        #self.de_solvent+= hess_nuc(self.base.with_solvent)
+        self.de_solvent  =    pcm_hess.analytical_hess_nuc(self.base.with_solvent, dm, verbose=self.verbose)
+        self.de_solvent +=     pcm_hess.analytical_hess_qv(self.base.with_solvent, dm, verbose=self.verbose)
+        self.de_solvent += pcm_hess.analytical_hess_solver(self.base.with_solvent, dm, verbose=self.verbose)
         self.de_solute = super().kernel(*args, **kwargs)
         self.de_cds = get_cds(self.base.with_solvent)
         self.de = self.de_solute + self.de_solvent + self.de_cds

--- a/gpu4pyscf/solvent/hessian/smd.py
+++ b/gpu4pyscf/solvent/hessian/smd.py
@@ -154,7 +154,7 @@ class WithSolventHess:
         h1ao = super().make_h1(mo_coeff, mo_occ, atmlst=atmlst, verbose=verbose)
         if isinstance(self.base, scf.hf.RHF):
             dm = self.base.make_rdm1(ao_repr=True)
-            dv = pcm_hess.analytic_grad_vmat(self.base.with_solvent, dm, mo_coeff, mo_occ, atmlst=atmlst, verbose=verbose)
+            dv = pcm_hess.analytical_grad_vmat(self.base.with_solvent, dm, mo_coeff, mo_occ, atmlst=atmlst, verbose=verbose)
             for i0, ia in enumerate(atmlst):
                 h1ao[i0] += dv[i0]
             return h1ao
@@ -163,8 +163,8 @@ class WithSolventHess:
             solvent = self.base.with_solvent
             dm = self.base.make_rdm1(ao_repr=True)
             dm = dm[0] + dm[1]
-            dva = pcm_hess.analytic_grad_vmat(solvent, dm, mo_coeff[0], mo_occ[0], atmlst=atmlst, verbose=verbose)
-            dvb = pcm_hess.analytic_grad_vmat(solvent, dm, mo_coeff[1], mo_occ[1], atmlst=atmlst, verbose=verbose)
+            dva = pcm_hess.analytical_grad_vmat(solvent, dm, mo_coeff[0], mo_occ[0], atmlst=atmlst, verbose=verbose)
+            dvb = pcm_hess.analytical_grad_vmat(solvent, dm, mo_coeff[1], mo_occ[1], atmlst=atmlst, verbose=verbose)
             for i0, ia in enumerate(atmlst):
                 h1aoa[i0] += dva[i0]
                 h1aob[i0] += dvb[i0]

--- a/gpu4pyscf/solvent/tests/test_pcm_grad.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_grad.py
@@ -36,6 +36,7 @@ H       0.7570000000     0.0000000000    -0.4696000000
     mol.basis = 'sto3g'
     mol.output = '/dev/null'
     mol.build(verbose=0)
+    # Warning: This system has all orbitals filled, which is FAR from physical
     mol.nelectron = mol.nao * 2
     epsilon = 35.9
     lebedev_order = 3
@@ -169,11 +170,14 @@ class KnownValues(unittest.TestCase):
 
     def test_grad_SSVPE(self):
         grad = _grad_with_solvent('SS(V)PE')
-        g0 = numpy.asarray(
-            [[ 3.42479745e-15, -1.00280742e-16, -1.61117735e+00],
-            [ 1.07135985e+00, -6.97375148e-16,  8.05588676e-01],
-            [-1.07135985e+00,  7.91425487e-16,  8.05588676e-01]]
-        )
+        # Note: This reference value is obtained via finite difference with dx = 1e-5
+        #       QChem 6.1 has a bug in SSVPE gradient, they use the IEFPCM gradient algorithm
+        #       to compute SSVPE gradient, which is wrong.
+        g0 = numpy.asarray([
+            [ 2.13162821e-09,  0.00000000e+00, -5.89116532e-02],
+            [ 2.28518083e-02, -2.13162821e-09,  2.94558255e-02],
+            [-2.28518090e-02,  0.00000000e+00,  2.94558234e-02],
+        ])
         print(f"Gradient error in RHF with SS(V)PE: {numpy.linalg.norm(g0 - grad)}")
         assert numpy.linalg.norm(g0 - grad) < 1e-6
 

--- a/gpu4pyscf/solvent/tests/test_pcm_grad.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_grad.py
@@ -174,9 +174,9 @@ class KnownValues(unittest.TestCase):
         #       QChem 6.1 has a bug in SSVPE gradient, they use the IEFPCM gradient algorithm
         #       to compute SSVPE gradient, which is wrong.
         g0 = numpy.asarray([
-            [ 2.13162821e-09,  0.00000000e+00, -5.89116532e-02],
-            [ 2.28518083e-02, -2.13162821e-09,  2.94558255e-02],
-            [-2.28518090e-02,  0.00000000e+00,  2.94558234e-02],
+            [ 0.00000000e+00, -7.10542736e-10, -1.63195623e+00],
+            [ 1.07705138e+00,  2.13162821e-09,  8.15978117e-01],
+            [-1.07705138e+00, -2.13162821e-09,  8.15978116e-01],
         ])
         print(f"Gradient error in RHF with SS(V)PE: {numpy.linalg.norm(g0 - grad)}")
         assert numpy.linalg.norm(g0 - grad) < 1e-6


### PR DESCRIPTION
- Change all finite difference implementation of PCM second derivative to analytical form.
- Bug fix in C-PCM gradient. The absolute error is at 1e-9 level for a gradient calculation, but will be magnified to 1e-4 level when computing hessian using finite difference.
- Bug fix in SS(V)PE gradient. SS(V)PE and IEF-PCM do not share gradient algorithm. We were misled by QChem 6.1 implementation.
