### PR TITLE
Change all K^-1 algorithm in PCM from LU solve to SVD pseudo inverse

### DIFF
--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -276,10 +276,10 @@ def grad_solver(pcmobj, dm):
     A            = pcmobj._intermediates['A']
     D            = pcmobj._intermediates['D']
     S            = pcmobj._intermediates['S']
-    K            = pcmobj._intermediates['K']
+    inverse_K    = pcmobj._intermediates['inverse_K']
     q            = pcmobj._intermediates['q']
 
-    vK_1 = cupy.linalg.solve(K.T, v_grids)
+    vK_1 = cupy.dot(inverse_K.T, v_grids)
     epsilon = pcmobj.eps
 
     de = cupy.zeros([pcmobj.mol.natm,3])

--- a/gpu4pyscf/solvent/hessian/pcm.py
+++ b/gpu4pyscf/solvent/hessian/pcm.py
@@ -153,7 +153,7 @@ def hess_elec(pcmobj, dm, verbose=None):
     pcmobj.reset(pmol)
     return de
 
-def get_dqsym_dx_fix_vgrids(pcmobj, atmlst, inverse_K):
+def get_dqsym_dx_fix_vgrids(pcmobj, atmlst):
     assert pcmobj._intermediates is not None
 
     gridslice    = pcmobj.surface['gslice_by_atom']
@@ -162,6 +162,7 @@ def get_dqsym_dx_fix_vgrids(pcmobj, atmlst, inverse_K):
     D            = pcmobj._intermediates['D']
     S            = pcmobj._intermediates['S']
     R            = pcmobj._intermediates['R']
+    inverse_K    = pcmobj._intermediates['inverse_K']
     q_sym        = pcmobj._intermediates['q_sym']
     f_epsilon    = pcmobj._intermediates['f_epsilon']
 
@@ -317,7 +318,7 @@ def get_dqsym_dx_fix_vgrids(pcmobj, atmlst, inverse_K):
 
     return dqdx_fix_Vq
 
-def get_dqsym_dx_fix_K_R(pcmobj, dm, atmlst, inverse_K, intopt_derivative):
+def get_dqsym_dx_fix_K_R(pcmobj, dm, atmlst, intopt_derivative):
     assert pcmobj._intermediates is not None
 
     mol = pcmobj.mol
@@ -325,6 +326,7 @@ def get_dqsym_dx_fix_K_R(pcmobj, dm, atmlst, inverse_K, intopt_derivative):
     charge_exp   = pcmobj.surface['charge_exp']
     grid_coords  = pcmobj.surface['grid_coords']
     R            = pcmobj._intermediates['R']
+    inverse_K    = pcmobj._intermediates['inverse_K']
 
     atom_coords = mol.atom_coords(unit='B')
     atom_charges = numpy.asarray(mol.atom_charges(), dtype=numpy.float64)
@@ -357,9 +359,7 @@ def get_dqsym_dx_fix_K_R(pcmobj, dm, atmlst, inverse_K, intopt_derivative):
     return dqdx_fix_K_R
 
 def get_dqsym_dx(pcmobj, dm, atmlst, intopt_derivative):
-    K = pcmobj._intermediates['K']
-    inverse_K = cupy.linalg.inv(K)
-    return get_dqsym_dx_fix_vgrids(pcmobj, atmlst, inverse_K) + get_dqsym_dx_fix_K_R(pcmobj, dm, atmlst, inverse_K, intopt_derivative)
+    return get_dqsym_dx_fix_vgrids(pcmobj, atmlst) + get_dqsym_dx_fix_K_R(pcmobj, dm, atmlst, intopt_derivative)
 
 def analytic_grad_vmat(pcmobj, dm, mo_coeff, mo_occ, atmlst=None, verbose=None):
     '''

--- a/gpu4pyscf/solvent/smd.py
+++ b/gpu4pyscf/solvent/smd.py
@@ -381,11 +381,15 @@ class SMD(pcm.PCM):
         K = S - f_epsilon/(2.0*np.pi) * DAS
         R = -f_epsilon * (cupy.eye(K.shape[0]) - 1.0/(2.0*np.pi)*DA)
 
+        # Notice the SVD in pseudo inverse scales badly with ngrids
+        inverse_K = cupy.linalg.pinv(K)
+
         intermediates = {
             'S': cupy.asarray(S),
             'D': cupy.asarray(D),
             'A': cupy.asarray(A),
             'K': cupy.asarray(K),
+            'inverse_K': cupy.asarray(inverse_K),
             'R': cupy.asarray(R),
             'f_epsilon': f_epsilon
         }

--- a/gpu4pyscf/solvent/tests/test_pcm_hessian.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_hessian.py
@@ -195,7 +195,7 @@ class KnownValues(unittest.TestCase):
         test_grad_vmat = analytic_grad_vmat(hobj.base.with_solvent, dm, mo_coeff, mo_occ)
         ref_grad_vmat = _fd_grad_vmat(hobj.base.with_solvent, dm, mo_coeff, mo_occ)
 
-        cp.testing.assert_allclose(ref_grad_vmat, test_grad_vmat, atol = 1e-10)
+        cp.testing.assert_allclose(ref_grad_vmat, test_grad_vmat, atol = 3e-10)
 
     def test_grad_vmat_iefpcm(self):
         print("testing IEF-PCM dV_solv/dx")
@@ -209,7 +209,7 @@ class KnownValues(unittest.TestCase):
         test_grad_vmat = analytic_grad_vmat(hobj.base.with_solvent, dm, mo_coeff, mo_occ)
         ref_grad_vmat = _fd_grad_vmat(hobj.base.with_solvent, dm, mo_coeff, mo_occ)
 
-        cp.testing.assert_allclose(ref_grad_vmat, test_grad_vmat, atol = 1e-10)
+        cp.testing.assert_allclose(ref_grad_vmat, test_grad_vmat, atol = 3e-10)
 
     def test_grad_vmat_ssvpe(self):
         print("testing SS(V)PE dV_solv/dx")
@@ -223,7 +223,7 @@ class KnownValues(unittest.TestCase):
         test_grad_vmat = analytic_grad_vmat(hobj.base.with_solvent, dm, mo_coeff, mo_occ)
         ref_grad_vmat = _fd_grad_vmat(hobj.base.with_solvent, dm, mo_coeff, mo_occ)
 
-        cp.testing.assert_allclose(ref_grad_vmat, test_grad_vmat, atol = 1e-10)
+        cp.testing.assert_allclose(ref_grad_vmat, test_grad_vmat, atol = 3e-10)
 
     @pytest.mark.skipif(pyscf_25, reason='requires pyscf 2.6 or higher')
     def test_to_gpu(self):


### PR DESCRIPTION
`cupy.linalg.solve()` and `cupy.linalg.inv()` both uses general matrix LU algorithm (gesv), and `cupy.linalg.lstsq()` and `cupy.linalg.qinv()` both uses SVD algorithm.