### PR TITLE
Reduce GPU memory footprint in SCF

### DIFF
--- a/gpu4pyscf/df/tests/test_df_uhf.py
+++ b/gpu4pyscf/df/tests/test_df_uhf.py
@@ -31,15 +31,11 @@ bas='def2tzvpp'
 
 def setUpModule():
     global mol_sph, mol_cart
-    mol_sph = pyscf.M(atom=atom, basis=bas, charge=1, spin=1, max_memory=32000)
-    mol_sph.output = '/dev/null'
-    mol_sph.build()
-    mol_sph.verbose = 1
+    mol_sph = pyscf.M(atom=atom, basis=bas, charge=1, spin=1, max_memory=32000,
+                      output='/dev/null', verbose=1)
 
-    mol_cart = pyscf.M(atom=atom, basis=bas, charge=1, spin=1, cart=1, max_memory=32000)
-    mol_cart.output = '/dev/null'
-    mol_cart.build()
-    mol_cart.verbose = 1
+    mol_cart = pyscf.M(atom=atom, basis=bas, charge=1, spin=1, cart=1, max_memory=32000,
+                       output='/dev/null', verbose=1)
 
 def tearDownModule():
     global mol_sph, mol_cart

--- a/gpu4pyscf/dft/__init__.py
+++ b/gpu4pyscf/dft/__init__.py
@@ -11,7 +11,7 @@ def KS(mol, xc='LDA,VWN'):
     else:
         return UKS(mol, xc)
 
-def RKS(mol, xc):
+def RKS(mol, xc='LDA,VWN'):
     from gpu4pyscf.lib.cupy_helper import get_avail_mem
     from . import rks_lowmem
     mem = get_avail_mem()

--- a/gpu4pyscf/dft/__init__.py
+++ b/gpu4pyscf/dft/__init__.py
@@ -1,5 +1,6 @@
 from . import rks
-from .rks import KohnShamDFT
+from .rks import RKS, KohnShamDFT
+from .rks_lowmem import RKS as LRKS
 from .uks import UKS
 from .gks import GKS
 from .roks import ROKS
@@ -10,13 +11,3 @@ def KS(mol, xc='LDA,VWN'):
         return RKS(mol, xc)
     else:
         return UKS(mol, xc)
-
-def RKS(mol, xc='LDA,VWN'):
-    from gpu4pyscf.lib.cupy_helper import get_avail_mem
-    from . import rks_lowmem
-    mem = get_avail_mem()
-    nao = mol.nao
-    if nao**2*40*8 > mem:
-        return rks_lowmem.RKS(mol, xc)
-    else:
-        return rks.RKS(mol, xc)

--- a/gpu4pyscf/dft/__init__.py
+++ b/gpu4pyscf/dft/__init__.py
@@ -1,5 +1,5 @@
 from . import rks
-from .rks import RKS, KohnShamDFT
+from .rks import KohnShamDFT
 from .uks import UKS
 from .gks import GKS
 from .roks import ROKS
@@ -10,3 +10,13 @@ def KS(mol, xc='LDA,VWN'):
         return RKS(mol, xc)
     else:
         return UKS(mol, xc)
+
+def RKS(mol, xc):
+    from gpu4pyscf.lib.cupy_helper import get_avail_mem
+    from . import rks_lowmem
+    mem = get_avail_mem()
+    nao = mol.nao
+    if nao**2*40*8 > mem:
+        return rks_lowmem.RKS(mol, xc)
+    else:
+        return rks.RKS(mol, xc)

--- a/gpu4pyscf/dft/numint.py
+++ b/gpu4pyscf/dft/numint.py
@@ -1673,7 +1673,7 @@ def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
             pad, idx, non0shl_idx, ctr_offsets_slice, ao_loc_slice = ni.non0ao_idx[lookup_key]
             if len(idx) == 0: 
                 continue
-            
+
             ao_mask = eval_ao(
                 _sorted_mol, coords, deriv,
                 nao_slice=len(idx),

--- a/gpu4pyscf/dft/rks_lowmem.py
+++ b/gpu4pyscf/dft/rks_lowmem.py
@@ -134,8 +134,8 @@ class RKS(rks.RKS):
                 vklr *= (alpha - hyb)
                 vk += vklr
             _dm = None
-            assert vj.ndim == 3
 
+            assert vj.ndim == 3
             vj_last = getattr(vhf_last, 'vj', None)
             vk_last = getattr(vhf_last, 'vk', None)
             coeff = cp.asarray(vhfopt.coeff)

--- a/gpu4pyscf/dft/rks_lowmem.py
+++ b/gpu4pyscf/dft/rks_lowmem.py
@@ -1,0 +1,170 @@
+# Copyright 2021-2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+The RKS implemented in this module prioritizes a reduced GPU memory footprint.
+'''
+
+import numpy as np
+import cupy as cp
+from gpu4pyscf.lib import logger
+from gpu4pyscf.dft import numint, gen_grid, rks
+from gpu4pyscf.scf import hf_lowmem, jk
+from gpu4pyscf.lib.cupy_helper import tag_array, sandwich_dot, pack_tril
+from pyscf import __config__
+
+__all__ = [
+    'RKS',
+]
+
+class RKS(rks.RKS):
+
+    DIIS = hf_lowmem.CDIIS
+
+    kernel = scf = hf_lowmem.kernel
+    density_fit              = NotImplemented
+    as_scanner               = NotImplemented
+    newton                   = NotImplemented
+    x2c = x2c1e = sfx2c1e    = NotImplemented
+    stability                = NotImplemented
+    to_hf = NotImplemented
+
+    check_sanity = hf_lowmem.RHF.check_sanity
+    get_hcore = hf_lowmem.RHF.get_hcore
+    get_jk = hf_lowmem.RHF.get_jk
+    get_k = hf_lowmem.RHF.get_k
+    get_j = hf_lowmem.RHF.get_j
+    get_fock = hf_lowmem.RHF.get_j
+    make_rdm1 = hf_lowmem.RHF.make_rdm1
+
+    def __init__(self, mol, xc='LDA,VWN'):
+        hf_lowmem.RHF.__init__(self, mol)
+        rks.KohnShamDFT.__init__(self, xc)
+
+    def dump_flags(self, verbose=None):
+        hf_lowmem.RHF.dump_flags(self, verbose)
+        return rks.KohnShamDFT.dump_flags(self, verbose)
+
+    def get_veff(self, mol, dm, dm_last=None, vhf_last=0, hermi=1):
+        '''Constructus the lower-triangular part of the Fock matrix.'''
+        assert hermi == 1
+        log = logger.new_logger(mol, self.verbose)
+        cput0 = log.init_timer()
+        rks.initialize_grids(self, mol, dm)
+
+        ni = self._numint
+        n, exc, vxc = ni.nr_rks(mol, self.grids, self.xc, dm)
+        if self.do_nlc():
+            if ni.libxc.is_nlc(self.xc):
+                xc = self.xc
+            else:
+                assert ni.libxc.is_nlc(self.nlc)
+                xc = self.nlc
+            n, enlc, vnlc = ni.nr_nlc_vxc(mol, self.nlcgrids, xc, dm)
+            exc += enlc
+            vxc += vnlc
+        vxc = pack_tril(vxc)
+        logger.debug(self, 'nelec by numeric integration = %s', n)
+        cput1 = logger.timer_debug1(self, 'vxc tot', *cput0)
+
+        omega = mol.omega
+        vhfopt = self._opt_gpu.get(omega)
+        if vhfopt is None:
+            vhfopt = self._opt_gpu[omega] = jk._VHFOpt(mol, self.direct_scf_tol).build()
+            if isinstance(vhfopt.coeff, cp.ndarray):
+                vhfopt.coeff = vhfopt.coeff.get()
+        dm = self._delta_rdm1(dm, dm_last, vhfopt)
+
+        vj = vk = None
+        if not ni.libxc.is_hybrid_xc(self.xc):
+            vj = vhfopt.get_j(dm, log)
+            vj = sandwich_dot(vj, cp.asarray(vhfopt.coeff))
+            vj = pack_tril(vj)
+            vj_last = getattr(vhf_last, 'vj', None)
+            if isinstance(vj_last, cp.ndarray):
+                vj += vj_last
+            else:
+                vj = vj_last
+            vxc += vj
+        else:
+            omega, alpha, hyb = ni.rsh_and_hybrid_coeff(self.xc, spin=mol.spin)
+            if omega == 0:
+                vj, vk = vhfopt.get_jk(dm, hermi, True, True, log)
+                vk *= hyb
+            elif alpha == 0: # LR=0, only SR exchange
+                vj = vhfopt.get_j(dm, log)
+                vk = _get_k_sorted_mol(self, dm, hermi, -omega, log)
+                vk *= hyb
+            elif hyb == 0: # SR=0, only LR exchange
+                vj = vhfopt.get_j(dm, log)
+                vk = _get_k_sorted_mol(self, dm, hermi, omega, log)
+                vk *= alpha
+            else: # SR and LR exchange with different ratios
+                vj, vk = vhfopt.get_jk(mol, dm, hermi)
+                vk *= hyb
+                vklr = _get_k_sorted_mol(self, dm, hermi, omega, log)
+                vklr *= (alpha - hyb)
+                vk += vklr
+
+            coeff = cp.asarray(vhfopt.coeff)
+            vj = sandwich_dot(vj, coeff)
+            vk = sandwich_dot(vk, coeff)
+            vj = pack_tril(vj)
+            vk = pack_tril(vk)
+            vj_last = getattr(vhf_last, 'vj', None)
+            vk_last = getattr(vhf_last, 'vk', None)
+            if isinstance(vj_last, cp.ndarray):
+                vj += vj_last
+                vk += vk_last
+            else:
+                vj = vj_last
+                vk = vk_last
+            vxc += vj
+            vxc -= vk * .5
+
+        logger.timer_debug1(self, 'jk total', *cput1)
+        vxc = tag_array(vxc, exc=exc, vj=vj, vk=vk)
+        return vxc
+
+    def energy_elec(self, dm, h1e, vhf):
+        assert dm.dtype == np.float64
+        assert h1e.ndim == vhf.ndim == 1
+        dm_tril = pack_tril(dm)
+        nao = dm.shape[0]
+        i = cp.arange(nao)
+        diag = i*(i+1)//2 + i
+        dm_tril[diag] *= .5
+        e1 = float(h1e.dot(dm_tril) * 2)
+        ecoul = float(vhf.vj.dot(dm_tril))
+        exc = vhf.exc
+        if vhf.vk is not None:
+            exc -= float(vhf.vk.dot(dm_tril)) * .5
+        e2 = ecoul + exc
+        self.scf_summary['e1'] = e1
+        self.scf_summary['coul'] = ecoul
+        self.scf_summary['exc'] = exc
+        logger.debug(self, 'E1 = %s  Ecoul = %s  Exc = %s', e1, ecoul, exc)
+        return e1+e2, e2
+
+    def to_cpu(self):
+        raise NotImplementedError
+
+def _get_k_sorted_mol(mf, dm, hermi, omega, log):
+    mol = mf.mol
+    vhfopt = mf._opt_gpu.get(omega)
+    if vhfopt is None:
+        vhfopt = mf._opt_gpu[omega] = jk._VHFOpt(mol, mf.direct_scf_tol).build()
+        if isinstance(vhfopt.coeff, cp.ndarray):
+            vhfopt.coeff = vhfopt.coeff.get()
+    return vhfopt.get_jk(dm, hermi, False, True, log)[1]

--- a/gpu4pyscf/dft/rks_lowmem.py
+++ b/gpu4pyscf/dft/rks_lowmem.py
@@ -45,8 +45,9 @@ class RKS(rks.RKS):
     get_jk = hf_lowmem.RHF.get_jk
     get_k = hf_lowmem.RHF.get_k
     get_j = hf_lowmem.RHF.get_j
-    get_fock = hf_lowmem.RHF.get_j
+    get_fock = hf_lowmem.RHF.get_fock
     make_rdm1 = hf_lowmem.RHF.make_rdm1
+    _delta_rdm1 = hf_lowmem.RHF._delta_rdm1
 
     def __init__(self, mol, xc='LDA,VWN'):
         hf_lowmem.RHF.__init__(self, mol)
@@ -56,24 +57,40 @@ class RKS(rks.RKS):
         hf_lowmem.RHF.dump_flags(self, verbose)
         return rks.KohnShamDFT.dump_flags(self, verbose)
 
+    def _get_k_sorted_mol(self, dm, hermi, omega, log):
+        mol = self.mol
+        with mol.with_range_coulomb(omega):
+            vhfopt = self._opt_gpu.get(omega)
+            if vhfopt is None:
+                vhfopt = self._opt_gpu[omega] = jk._VHFOpt(mol, self.direct_scf_tol).build()
+                if isinstance(vhfopt.coeff, cp.ndarray):
+                    vhfopt.coeff = vhfopt.coeff.get()
+            return vhfopt.get_jk(dm, hermi, False, True, log)[1]
+
     def get_veff(self, mol, dm, dm_last=None, vhf_last=0, hermi=1):
         '''Constructus the lower-triangular part of the Fock matrix.'''
         assert hermi == 1
         log = logger.new_logger(mol, self.verbose)
         cput0 = log.init_timer()
-        rks.initialize_grids(self, mol, dm)
+        if dm is None:
+            _dm = tag_array(self.make_rdm1(),
+                            mo_coeff=self.mo_coeff, mo_occ=self.mo_occ)
+        else:
+            _dm = dm
+        initialize_grids(self, mol, _dm)
 
         ni = self._numint
-        n, exc, vxc = ni.nr_rks(mol, self.grids, self.xc, dm)
+        n, exc, vxc = ni.nr_rks(mol, self.grids, self.xc, _dm)
         if self.do_nlc():
             if ni.libxc.is_nlc(self.xc):
                 xc = self.xc
             else:
                 assert ni.libxc.is_nlc(self.nlc)
                 xc = self.nlc
-            n, enlc, vnlc = ni.nr_nlc_vxc(mol, self.nlcgrids, xc, dm)
+            n, enlc, vnlc = ni.nr_nlc_vxc(mol, self.nlcgrids, xc, _dm)
             exc += enlc
             vxc += vnlc
+        _dm = None
         vxc = pack_tril(vxc)
         logger.debug(self, 'nelec by numeric integration = %s', n)
         cput1 = logger.timer_debug1(self, 'vxc tot', *cput0)
@@ -84,51 +101,53 @@ class RKS(rks.RKS):
             vhfopt = self._opt_gpu[omega] = jk._VHFOpt(mol, self.direct_scf_tol).build()
             if isinstance(vhfopt.coeff, cp.ndarray):
                 vhfopt.coeff = vhfopt.coeff.get()
-        dm = self._delta_rdm1(dm, dm_last, vhfopt)
+        _dm = self._delta_rdm1(dm, dm_last, vhfopt)
 
         vj = vk = None
         if not ni.libxc.is_hybrid_xc(self.xc):
-            vj = vhfopt.get_j(dm, log)
+            vj = vhfopt.get_j(_dm, log)
+            _dm = None
             vj = sandwich_dot(vj, cp.asarray(vhfopt.coeff))
-            vj = pack_tril(vj)
+            vj = pack_tril(vj[0])
             vj_last = getattr(vhf_last, 'vj', None)
             if isinstance(vj_last, cp.ndarray):
-                vj += vj_last
-            else:
+                vj_last += vj # Reuse the memory of the previous Veff
                 vj = vj_last
             vxc += vj
         else:
             omega, alpha, hyb = ni.rsh_and_hybrid_coeff(self.xc, spin=mol.spin)
             if omega == 0:
-                vj, vk = vhfopt.get_jk(dm, hermi, True, True, log)
+                vj, vk = vhfopt.get_jk(_dm, hermi, True, True, log)
                 vk *= hyb
             elif alpha == 0: # LR=0, only SR exchange
-                vj = vhfopt.get_j(dm, log)
-                vk = _get_k_sorted_mol(self, dm, hermi, -omega, log)
+                vj = vhfopt.get_j(_dm, log)
+                vk = self._get_k_sorted_mol(_dm, hermi, -omega, log)
                 vk *= hyb
             elif hyb == 0: # SR=0, only LR exchange
-                vj = vhfopt.get_j(dm, log)
-                vk = _get_k_sorted_mol(self, dm, hermi, omega, log)
+                vj = vhfopt.get_j(_dm, log)
+                vk = self._get_k_sorted_mol(_dm, hermi, omega, log)
                 vk *= alpha
             else: # SR and LR exchange with different ratios
-                vj, vk = vhfopt.get_jk(mol, dm, hermi)
+                vj, vk = vhfopt.get_jk(_dm, hermi, True, True, log)
                 vk *= hyb
-                vklr = _get_k_sorted_mol(self, dm, hermi, omega, log)
+                vklr = self._get_k_sorted_mol(_dm, hermi, omega, log)
                 vklr *= (alpha - hyb)
                 vk += vklr
+            _dm = None
+            assert vj.ndim == 3
 
-            coeff = cp.asarray(vhfopt.coeff)
-            vj = sandwich_dot(vj, coeff)
-            vk = sandwich_dot(vk, coeff)
-            vj = pack_tril(vj)
-            vk = pack_tril(vk)
             vj_last = getattr(vhf_last, 'vj', None)
             vk_last = getattr(vhf_last, 'vk', None)
+            coeff = cp.asarray(vhfopt.coeff)
+            vj = sandwich_dot(vj, coeff)
+            vj = pack_tril(vj[0])
             if isinstance(vj_last, cp.ndarray):
-                vj += vj_last
-                vk += vk_last
-            else:
+                vj_last += vj
                 vj = vj_last
+            vk = sandwich_dot(vk, coeff)
+            vk = pack_tril(vk[0])
+            if isinstance(vk_last, cp.ndarray):
+                vk_last += vk
                 vk = vk_last
             vxc += vj
             vxc -= vk * .5
@@ -160,11 +179,29 @@ class RKS(rks.RKS):
     def to_cpu(self):
         raise NotImplementedError
 
-def _get_k_sorted_mol(mf, dm, hermi, omega, log):
-    mol = mf.mol
-    vhfopt = mf._opt_gpu.get(omega)
-    if vhfopt is None:
-        vhfopt = mf._opt_gpu[omega] = jk._VHFOpt(mol, mf.direct_scf_tol).build()
-        if isinstance(vhfopt.coeff, cp.ndarray):
-            vhfopt.coeff = vhfopt.coeff.get()
-    return vhfopt.get_jk(dm, hermi, False, True, log)[1]
+def initialize_grids(ks, mol=None, dm=None):
+    # Initialize self.grids the first time call get_veff
+    if mol is None: mol = ks.mol
+    if ks.grids.coords is None:
+        t0 = logger.init_timer(ks)
+        ks.grids.build()
+        #ks.grids.build(with_non0tab=True)
+        ks.grids.weights = cp.asarray(ks.grids.weights)
+        ks.grids.coords = cp.asarray(ks.grids.coords)
+        if ks.small_rho_cutoff > 1e-20:
+            # Filter grids the first time setup grids
+            ks.grids = rks.prune_small_rho_grids_(ks, ks.mol, dm, ks.grids)
+        t0 = logger.timer_debug1(ks, 'setting up grids', *t0)
+
+        if ks.do_nlc() and ks.nlcgrids.coords is None:
+            if ks.nlcgrids.coords is None:
+                t0 = logger.init_timer(ks)
+                #ks.nlcgrids.build(with_non0tab=True)
+                ks.nlcgrids.build()
+                ks.nlcgrids.weights = cp.asarray(ks.nlcgrids.weights)
+                ks.nlcgrids.coords = cp.asarray(ks.nlcgrids.coords)
+                if ks.small_rho_cutoff > 1e-20:
+                    # Filter grids the first time setup grids
+                    ks.nlcgrids = rks.prune_small_rho_grids_(ks, ks.mol, dm, ks.nlcgrids)
+                t0 = logger.timer_debug1(ks, 'setting up nlc grids', *t0)
+    return ks

--- a/gpu4pyscf/dft/rks_lowmem.py
+++ b/gpu4pyscf/dft/rks_lowmem.py
@@ -29,6 +29,9 @@ __all__ = [
 ]
 
 class RKS(rks.RKS):
+    '''The low-memory RKS class for large systems. Not fully compatible with the
+    default RKS class in rks.py.
+    '''
 
     DIIS = hf_lowmem.CDIIS
 

--- a/gpu4pyscf/dft/tests/test_rks_lowmem.py
+++ b/gpu4pyscf/dft/tests/test_rks_lowmem.py
@@ -33,6 +33,7 @@ def setUpModule():
     )
 
 def tearDownModule():
+    global mol_sph
     del mol_sph
 
 def run_dft(xc, mol, disp=None):

--- a/gpu4pyscf/dft/tests/test_rks_lowmem.py
+++ b/gpu4pyscf/dft/tests/test_rks_lowmem.py
@@ -33,8 +33,6 @@ def setUpModule():
     )
 
 def tearDownModule():
-    global mol_sph
-    mol_sph.stdout.close()
     del mol_sph
 
 def run_dft(xc, mol, disp=None):

--- a/gpu4pyscf/dft/tests/test_rks_lowmem.py
+++ b/gpu4pyscf/dft/tests/test_rks_lowmem.py
@@ -1,0 +1,80 @@
+# Copyright 2021-2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import unittest
+import pyscf
+from gpu4pyscf.dft import rks_lowmem
+
+atom = '''
+O       0.0000000000    -0.0000000000     0.1174000000
+H      -0.7570000000    -0.0000000000    -0.4696000000
+H       0.7570000000     0.0000000000    -0.4696000000
+'''
+bas='def2-tzvp'
+
+def setUpModule():
+    global mol_sph
+    mol_sph = pyscf.M(
+        atom=atom,
+        basis=bas,
+        max_memory=32000,
+    )
+
+def tearDownModule():
+    global mol_sph
+    mol_sph.stdout.close()
+    del mol_sph
+
+def run_dft(xc, mol, disp=None):
+    mf = rks_lowmem.RKS(mol, xc=xc)
+    mf.disp = disp
+    e_dft = mf.kernel()
+    return e_dft
+
+class KnownValues(unittest.TestCase):
+    '''
+    known values are obtained by Q-Chem
+    '''
+    def test_rks_lda(self):
+        print('------- LDA ----------------')
+        e_tot = run_dft('SVWN', mol_sph)
+        e_ref = mol_sph.RKS(xc='SVWN').kernel()
+        print('| CPU - GPU |:', e_tot - e_ref)
+        assert np.abs(e_tot - e_ref) < 1e-8
+
+    def test_rks_b3lyp(self):
+        print('-------- B3LYP -------------')
+        e_tot = run_dft('B3LYP', mol_sph)
+        e_ref = mol_sph.RKS(xc='B3LYP').kernel()
+        print('| CPU - GPU |:', e_tot - e_ref)
+        assert np.abs(e_tot - e_ref) < 1e-8
+
+    def test_rks_wb97x(self):
+        print('-------- wb97 -------------')
+        e_tot = run_dft('wb97', mol_sph)
+        e_ref = mol_sph.RKS(xc='wb97').kernel()
+        print('| CPU - GPU |:', e_tot - e_ref)
+        assert np.abs(e_tot - e_ref) < 1e-8
+
+    def test_rks_wb97m(self):
+        print('-------- wb97mv -------------')
+        e_tot = run_dft('wb97mv', mol_sph)
+        e_ref = mol_sph.RKS(xc='wb97mv').kernel()
+        print('| CPU - GPU |:', e_tot - e_ref)
+        assert np.abs(e_tot - e_ref) < 1e-7
+
+if __name__ == "__main__":
+    print("Full Tests for rks_lowmem")
+    unittest.main()

--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -196,14 +196,13 @@ def return_cupy_array(fn):
     return filter_ret
 
 def pack_tril(a, stream=None):
-    assert a.flags.c_contiguous
     ndim = a.ndim
     assert ndim in (2, 3)
     if ndim == 2:
         a = a[None]
 
     counts, n = a.shape[:2]
-    if a.dtype != np.float64:
+    if a.dtype != np.float64 or not a.flags.c_contiguous:
         idx = cupy.arange(n)
         mask = idx[:,None] >= idx
         a_tril = a[:,mask]

--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -495,7 +495,10 @@ def hermi_triu(mat, hermi=1, inplace=True, stream=None):
     '''
     assert hermi in (1, 2)
     assert mat.dtype == np.float64
-    assert mat.flags.c_contiguous
+    if inplace:
+        assert mat.flags.c_contiguous
+    else:
+        mat = mat.copy('C')
 
     if mat.ndim == 2:
         n = mat.shape[0]

--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -166,6 +166,16 @@ def tag_array(a, **kwargs):
     t.__dict__.update(kwargs)
     return t
 
+def asarray(a, **kwargs):
+    '''Similar to cupy.asarray, when the object is an instance of
+    CPArrayWithTag, this function will remove the attributes within
+    the tagged array'''
+    if isinstance(a, CPArrayWithTag):
+        a = a.view(cp.ndarray)
+    if kwargs:
+        a = cupy.asarray(a, **kwargs)
+    return a
+
 def to_cupy(a):
     '''Converts a numpy (and subclass) object to a cupy object'''
     if isinstance(a, lib.NPArrayWithTag):

--- a/gpu4pyscf/lib/cupy_helper/transpose.cu
+++ b/gpu4pyscf/lib/cupy_helper/transpose.cu
@@ -20,19 +20,6 @@
 #define BLOCK_DIM   32
 
 __global__
-static void _dsymm_triu(double *a, int n)
-{
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    int j = blockIdx.y * blockDim.y + threadIdx.y;
-    if (i < j || i >= n || j >= n) {
-        return;
-    }
-    size_t N = n;
-    size_t off = N * N * blockIdx.z;
-    a[off + j * N + i] = a[off + i * N + j];
-}
-
-__global__
 void _transpose_sum(double *a, int n)
 {
     if(blockIdx.x > blockIdx.y){
@@ -70,20 +57,6 @@ void _transpose_sum(double *a, int n)
 }
 
 extern "C" {
-__host__
-int CPdsymm_triu(double *a, int n, int counts)
-{
-    int ntile = (n + THREADS - 1) / THREADS;
-    dim3 threads(THREADS, THREADS);
-    dim3 blocks(ntile, ntile, counts);
-    _dsymm_triu<<<blocks, threads>>>(a, n);
-    cudaError_t err = cudaGetLastError();
-    if (err != cudaSuccess) {
-        return 1;
-    }
-    return 0;
-}
-
 __host__
 int transpose_sum(cudaStream_t stream, double *a, int n, int counts){
     int ntile = (n + THREADS - 1) / THREADS;

--- a/gpu4pyscf/lib/cupy_helper/unpack.cu
+++ b/gpu4pyscf/lib/cupy_helper/unpack.cu
@@ -96,6 +96,24 @@ void _unpack_sparse(const double *cderi_sparse, const long *row, const long *col
 }
 
 extern "C" {
+int fill_triu(cudaStream_t stream, double *a, int n, int counts, int hermi)
+{
+    dim3 threads(THREADS, THREADS);
+    int nx = (n + threads.x - 1) / threads.x;
+    int ny = (n + threads.y - 1) / threads.y;
+    dim3 blocks(nx, ny, counts);
+    if (hermi == 1) {
+        _fill_triu_sym<<<blocks, threads, 0, stream>>>(a, n);
+    } else if (hermi == 2) {
+        _fill_triu_antisym<<<blocks, threads, 0, stream>>>(a, n);
+    }
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}
+
 int pack_tril(cudaStream_t stream, double *a_tril, double *a, int n, int counts)
 {
     dim3 threads(THREADS, THREADS);

--- a/gpu4pyscf/lib/cupy_helper/unpack.cu
+++ b/gpu4pyscf/lib/cupy_helper/unpack.cu
@@ -20,38 +20,66 @@
 #define THREADS       32
 #define BDIM 32
 
-__global__
-void _unpack_tril(const double *eri_tril, double *eri, int nao){
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    int j = blockIdx.y * blockDim.y + threadIdx.y;
+__global__ static
+void _pack_tril(double *a_tril, double *a, int n)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    int i = blockIdx.y * blockDim.y + threadIdx.y;
+    int p = blockIdx.z;
+    int stride = ((n + 1) * n) / 2;
+
+    if (i >= n || j >= n || i < j) {
+        return;
+    }
+    int ptr = i*(i+1)/2 + j;
+    a_tril[ptr + p*stride] = a[p*n*n + i*n + j];
+}
+
+__global__ static
+void _unpack_tril(double *eri_tril, double *eri, int nao)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    int i = blockIdx.y * blockDim.y + threadIdx.y;
     int p = blockIdx.z;
     int stride = ((nao + 1) * nao) / 2;
 
-    if(i >= nao || j >= nao || i < j){
+    if (i >= nao || j >= nao || i < j) {
         return;
     }
-    int ptr = j + (i+1)*i/2;
-    eri[p*nao*nao + j*nao + i] = eri_tril[ptr + p*stride];
+    int ptr = i*(i+1)/2 + j;
+    eri[p*nao*nao + i*nao + j] = eri_tril[ptr + p*stride];
 }
 
-__global__
-void _unpack_triu(const double *eri_tril, double *eri, int nao){
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    int j = blockIdx.y * blockDim.y + threadIdx.y;
+__global__ static
+void _fill_triu_sym(double *eri, int nao)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    int i = blockIdx.y * blockDim.y + threadIdx.y;
     int p = blockIdx.z;
-    int stride = ((nao + 1) * nao) / 2;
-
-    if(i >= nao || j >= nao || i > j){
+    if (i >= nao || j >= nao || i >= j) {
         return;
     }
-    int ptr = i + (j+1)*j/2;
-
-    eri[p*nao*nao + j*nao + i] = eri_tril[ptr + p*stride];
+    int off = p * nao * nao;
+    eri[off + i*nao + j] = eri[off + j*nao + i];
 }
 
-__global__
+__global__ static
+void _fill_triu_antisym(double *eri, int nao)
+{
+    int j = blockIdx.x * blockDim.x + threadIdx.x;
+    int i = blockIdx.y * blockDim.y + threadIdx.y;
+    int p = blockIdx.z;
+    if (i >= nao || j >= nao || i >= j) {
+        return;
+    }
+    int off = p * nao * nao;
+    eri[off + i*nao + j] = -eri[off + j*nao + i];
+}
+
+__global__ static
 void _unpack_sparse(const double *cderi_sparse, const long *row, const long *col,
-                    double *out, int nao, int nij, int stride_sparse, int p0, int p1){
+                    double *out, int nao, int nij, int stride_sparse, int p0, int p1)
+{
     int ij = blockIdx.x * blockDim.x + threadIdx.x;
     int k = blockIdx.y * blockDim.y + threadIdx.y;
 
@@ -68,13 +96,33 @@ void _unpack_sparse(const double *cderi_sparse, const long *row, const long *col
 }
 
 extern "C" {
-int unpack_tril(cudaStream_t stream, const double *eri_tril, double *eri, int nao, int blk_size){
+int pack_tril(cudaStream_t stream, double *a_tril, double *a, int n, int counts)
+{
+    dim3 threads(THREADS, THREADS);
+    int nx = (n + threads.x - 1) / threads.x;
+    int ny = (n + threads.y - 1) / threads.y;
+    dim3 blocks(nx, ny, counts);
+    _pack_tril<<<blocks, threads, 0, stream>>>(a_tril, a, n);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}
+
+int unpack_tril(cudaStream_t stream, double *eri_tril, double *eri,
+                int nao, int blk_size, int hermi)
+{
     dim3 threads(THREADS, THREADS);
     int nx = (nao + threads.x - 1) / threads.x;
     int ny = (nao + threads.y - 1) / threads.y;
     dim3 blocks(nx, ny, blk_size);
     _unpack_tril<<<blocks, threads, 0, stream>>>(eri_tril, eri, nao);
-    _unpack_triu<<<blocks, threads, 0, stream>>>(eri_tril, eri, nao);
+    if (hermi == 1) {
+        _fill_triu_sym<<<blocks, threads, 0, stream>>>(eri, nao);
+    } else if (hermi == 2) {
+        _fill_triu_antisym<<<blocks, threads, 0, stream>>>(eri, nao);
+    }
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
         return 1;
@@ -83,7 +131,8 @@ int unpack_tril(cudaStream_t stream, const double *eri_tril, double *eri, int na
 }
 
 int unpack_sparse(cudaStream_t stream, const double *cderi_sparse, const long *row, const long *col,
-                double *eri, int nao, int nij, int naux, int p0, int p1){
+                double *eri, int nao, int nij, int naux, int p0, int p1)
+{
     int blockx = (nij + THREADS - 1) / THREADS;
     int blocky = (p1 - p0 + THREADS - 1) / THREADS;
     dim3 threads(THREADS, THREADS);

--- a/gpu4pyscf/lib/cusolver.py
+++ b/gpu4pyscf/lib/cusolver.py
@@ -127,15 +127,15 @@ def eigh(h, s):
             fn = libcusolver.cusolverDnZhegvd_bufferSize
         status = fn(
             _handle,
-            ctypes.c_int(CUSOLVER_EIG_TYPE_1),
-            ctypes.c_int(CUSOLVER_EIG_MODE_VECTOR),
+            CUSOLVER_EIG_TYPE_1,
+            CUSOLVER_EIG_MODE_VECTOR,
             cublas.CUBLAS_FILL_MODE_LOWER,
-            ctypes.c_int(n),
-            ctypes.cast(A.data.ptr, ctypes.c_void_p),
-            ctypes.c_int(n),
-            ctypes.cast(B.data.ptr, ctypes.c_void_p),
-            ctypes.c_int(n),
-            ctypes.cast(w.data.ptr, ctypes.c_void_p),
+            n,
+            A.data.ptr,
+            n,
+            B.data.ptr,
+            n,
+            w.data.ptr,
             ctypes.byref(lwork)
         )
         lwork = lwork.value
@@ -152,18 +152,18 @@ def eigh(h, s):
     devInfo = cupy.empty(1, dtype=np.int32)
     status = fn(
         _handle,
-        ctypes.c_int(CUSOLVER_EIG_TYPE_1),
-        ctypes.c_int(CUSOLVER_EIG_MODE_VECTOR),
+        CUSOLVER_EIG_TYPE_1,
+        CUSOLVER_EIG_MODE_VECTOR,
         cublas.CUBLAS_FILL_MODE_LOWER,
-        ctypes.c_int(n),
-        ctypes.cast(A.data.ptr, ctypes.c_void_p),
-        ctypes.c_int(n),
-        ctypes.cast(B.data.ptr, ctypes.c_void_p),
-        ctypes.c_int(n),
-        ctypes.cast(w.data.ptr, ctypes.c_void_p),
-        ctypes.cast(work.data.ptr, ctypes.c_void_p),
+        n,
+        A.data.ptr,
+        n,
+        B.data.ptr,
+        n,
+        w.data.ptr,
+        work.data.ptr,
         lwork,
-        ctypes.cast(devInfo.data.ptr, ctypes.c_void_p),
+        devInfo.data.ptr,
     )
 
     if status != 0:

--- a/gpu4pyscf/lib/cusolver.py
+++ b/gpu4pyscf/lib/cusolver.py
@@ -121,15 +121,14 @@ def eigh(h, s):
     else:
         lwork = ctypes.c_int(0)
         w = cupy.zeros(n)
-        _buffersize[h.dtype, n] = lwork, w
         if h.dtype == np.float64:
             fn = libcusolver.cusolverDnDsygvd_bufferSize
         else:
             fn = libcusolver.cusolverDnZhegvd_bufferSize
         status = fn(
             _handle,
-            ctype.c_int(CUSOLVER_EIG_TYPE_1),
-            ctype.c_int(CUSOLVER_EIG_MODE_VECTOR),
+            ctypes.c_int(CUSOLVER_EIG_TYPE_1),
+            ctypes.c_int(CUSOLVER_EIG_MODE_VECTOR),
             cublas.CUBLAS_FILL_MODE_LOWER,
             ctypes.c_int(n),
             ctypes.cast(A.data.ptr, ctypes.c_void_p),
@@ -140,6 +139,7 @@ def eigh(h, s):
             ctypes.byref(lwork)
         )
         lwork = lwork.value
+        _buffersize[h.dtype, n] = lwork, w
 
         if status != 0:
             raise RuntimeError("failed in buffer size")
@@ -152,8 +152,8 @@ def eigh(h, s):
     devInfo = cupy.empty(1, dtype=np.int32)
     status = fn(
         _handle,
-        ctype.c_int(CUSOLVER_EIG_TYPE_1),
-        ctype.c_int(CUSOLVER_EIG_MODE_VECTOR),
+        ctypes.c_int(CUSOLVER_EIG_TYPE_1),
+        ctypes.c_int(CUSOLVER_EIG_MODE_VECTOR),
         cublas.CUBLAS_FILL_MODE_LOWER,
         ctypes.c_int(n),
         ctypes.cast(A.data.ptr, ctypes.c_void_p),

--- a/gpu4pyscf/lib/cusolver.py
+++ b/gpu4pyscf/lib/cusolver.py
@@ -114,13 +114,13 @@ def eigh(h, s):
         A = h.copy()
         B = s.copy()
     _handle = device.get_cusolver_handle()
+    w = cupy.zeros(n)
 
     # TODO: reuse workspace
     if (h.dtype, n) in _buffersize:
-        lwork, w = _buffersize[h.dtype, n]
+        lwork = _buffersize[h.dtype, n]
     else:
         lwork = ctypes.c_int(0)
-        w = cupy.zeros(n)
         if h.dtype == np.float64:
             fn = libcusolver.cusolverDnDsygvd_bufferSize
         else:
@@ -139,7 +139,7 @@ def eigh(h, s):
             ctypes.byref(lwork)
         )
         lwork = lwork.value
-        _buffersize[h.dtype, n] = lwork, w
+        _buffersize[h.dtype, n] = lwork
 
         if status != 0:
             raise RuntimeError("failed in buffer size")

--- a/gpu4pyscf/lib/diis.py
+++ b/gpu4pyscf/lib/diis.py
@@ -27,7 +27,7 @@ from pyscf.lib import misc
 from pyscf import __config__
 
 # TODO: should be different for GPU?
-INCORE_SIZE = getattr(__config__, 'lib_diis_incore_size', 1000000000)  # 8000 MB
+INCORE_SIZE = getattr(__config__, 'lib_diis_incore_size', 300000000)  # 2400 MB
 BLOCK_SIZE  = getattr(__config__, 'lib_diis_block_size', 20000000)  # ~ 160/320 MB
 
 # PCCP, 4, 11 (2002); DOI:10.1039/B108658H

--- a/gpu4pyscf/lib/tests/test_cupy_helper.py
+++ b/gpu4pyscf/lib/tests/test_cupy_helper.py
@@ -215,6 +215,10 @@ class KnownValues(unittest.TestCase):
         ref[:,idx,idy] = atril
         assert abs(a - ref).max() < 1e-12
 
+        ref = atril
+        atril = cupy_helper.pack_tril(a)
+        assert abs(atril - ref).max() < 1e-12
+
     def test_copy_host2dev(self):
         host_array = cupy.cuda.alloc_pinned_memory(10*10*10 * 8)
         host_data = numpy.ndarray(10**3, dtype=cupy.float64, buffer=host_array)

--- a/gpu4pyscf/pbc/dft/tests/test_pbc_rks.py
+++ b/gpu4pyscf/pbc/dft/tests/test_pbc_rks.py
@@ -98,8 +98,8 @@ class KnownValues(unittest.TestCase):
     def test_gga_fft_with_kpt(self):
         np.random.seed(1)
         k = np.random.random(3)
-        mf = pbcdft.RKS(cell, xc='pbe0', kpt=k).run()
-        mf_ref = mf.to_cpu().run()
+        mf = pbcdft.RKS(cell, xc='pbe0', kpt=k).run(conv_tol=1e-10)
+        mf_ref = mf.to_cpu().run(conv_tol=1e-10)
         self.assertAlmostEqual(mf.e_tot, mf_ref.e_tot, 7)
 
         # test bands
@@ -113,8 +113,8 @@ class KnownValues(unittest.TestCase):
     def test_rsh_fft_with_kpt(self):
         np.random.seed(1)
         k = np.random.random(3)
-        mf = pbcdft.RKS(cell, xc='camb3lyp', kpt=k).run(conv_tol=1e-8)
-        mf_ref = mf.to_cpu().run()
+        mf = pbcdft.RKS(cell, xc='camb3lyp', kpt=k).run(conv_tol=1e-10)
+        mf_ref = mf.to_cpu().run(conv_tol=1e-10)
         self.assertAlmostEqual(mf.e_tot, mf_ref.e_tot, 7)
 
         # test bands

--- a/gpu4pyscf/pbc/dft/tests/test_pbc_uks.py
+++ b/gpu4pyscf/pbc/dft/tests/test_pbc_uks.py
@@ -98,8 +98,8 @@ class KnownValues(unittest.TestCase):
     def test_gga_fft_with_kpt(self):
         np.random.seed(1)
         k = np.random.random(3)
-        mf = pbcdft.UKS(cell, xc='pbe0', kpt=k).run(conv_tol=1e-9)
-        mf_ref = mf.to_cpu().run()
+        mf = pbcdft.UKS(cell, xc='pbe0', kpt=k).run(conv_tol=1e-10)
+        mf_ref = mf.to_cpu().run(conv_tol=1e-10)
         self.assertAlmostEqual(mf.e_tot, mf_ref.e_tot, 7)
 
         # test bands
@@ -107,14 +107,14 @@ class KnownValues(unittest.TestCase):
         kpts_band = np.random.random((2,3))
         e0, c0 = mf_ref.get_bands(kpts_band)
         e1, c1 = mf.get_bands(kpts_band)
-        self.assertAlmostEqual(abs(e1[0].get() - e0[0]).max(), 0, 7)
-        self.assertAlmostEqual(abs(e1[1].get() - e0[1]).max(), 0, 7)
+        self.assertAlmostEqual(abs(e1[0].get() - e0[0]).max(), 0, 5)
+        self.assertAlmostEqual(abs(e1[1].get() - e0[1]).max(), 0, 5)
 
     def test_rsh_fft_with_kpt(self):
         np.random.seed(1)
         k = np.random.random(3)
-        mf = pbcdft.UKS(cell, xc='camb3lyp', kpt=k).run(conv_tol=1e-8)
-        mf_ref = mf.to_cpu().run()
+        mf = pbcdft.UKS(cell, xc='camb3lyp', kpt=k).run(conv_tol=1e-10)
+        mf_ref = mf.to_cpu().run(conv_tol=1e-10)
         self.assertAlmostEqual(mf.e_tot, mf_ref.e_tot, 7)
 
         # test bands
@@ -122,8 +122,8 @@ class KnownValues(unittest.TestCase):
         kpts_band = np.random.random((2,3))
         e0, c0 = mf_ref.get_bands(kpts_band)
         e1, c1 = mf.get_bands(kpts_band)
-        self.assertAlmostEqual(abs(e1[0].get() - e0[0]).max(), 0, 7)
-        self.assertAlmostEqual(abs(e1[1].get() - e0[1]).max(), 0, 7)
+        self.assertAlmostEqual(abs(e1[0].get() - e0[0]).max(), 0, 6)
+        self.assertAlmostEqual(abs(e1[1].get() - e0[1]).max(), 0, 6)
 
     def test_kpts_lda_fft(self):
         nk = [2, 1, 1]

--- a/gpu4pyscf/qmmm/pbc/tests/test_qmmm.py
+++ b/gpu4pyscf/qmmm/pbc/tests/test_qmmm.py
@@ -86,12 +86,12 @@ class KnownValues(unittest.TestCase):
     def test_rks_pbe0(self):
         print('-------- RKS PBE0 -------------')
         e_tot, g_qm, g_mm = run_dft('PBE0')
-        assert np.allclose(e_tot, -76.00178807)
-        assert np.allclose(g_qm, np.array([[ 0.03002572,  0.13947702, -0.09234864],
-                                           [-0.00462601, -0.04602809,  0.02750759],
-                                           [-0.01821532, -0.18473378,  0.04189843]]))
-        assert np.allclose(g_mm, np.array([[-0.00914559,  0.08992359,  0.02114633],
-                                           [ 0.00196155,  0.00136132,  0.00179565]]))
+        assert abs(e_tot - -76.00178807) < 1e-7
+        assert abs(g_qm - np.array([[ 0.03002572,  0.13947702, -0.09234864],
+                                    [-0.00462601, -0.04602809,  0.02750759],
+                                    [-0.01821532, -0.18473378, 0.04189843]])).max() < 1e-6
+        assert abs(g_mm - np.array([[-0.00914559,  0.08992359,  0.02114633],
+                                    [ 0.00196155,  0.00136132, 0.00179565]])).max() < 1e-6
 
 if __name__ == "__main__":
     print("Full Tests for QMMM PBC")

--- a/gpu4pyscf/qmmm/tests/test_chelpg.py
+++ b/gpu4pyscf/qmmm/tests/test_chelpg.py
@@ -55,14 +55,14 @@ def run_dft_chelpg(xc, deltaR):
     mf.grids.level = grids_level
     e_dft = mf.kernel()
     q = chelpg.eval_chelpg_layer_gpu(mf, deltaR=deltaR)
-    return e_dft, q
+    return e_dft, q.get()
 
 def run_udft_chelpg(xc, deltaR):
     mf = uks.UKS(molu, xc=xc)
     mf.grids.level = grids_level
     e_dft = mf.kernel()
     q = chelpg.eval_chelpg_layer_gpu(mf, deltaR=deltaR)
-    return e_dft, q
+    return e_dft, q.get()
 
 class KnownValues(unittest.TestCase):
     '''
@@ -96,14 +96,14 @@ class KnownValues(unittest.TestCase):
     def test_rks_b3lyp(self):
         print('-------- RKS B3LYP -------------')
         e_tot, q = run_dft_chelpg('B3LYP', 0.1)
-        assert np.allclose(e_tot, -76.4666495181)
-        assert np.allclose(q, np.array([-0.712558, 0.356292, 0.356266]))
+        assert abs(e_tot - -76.4666495181) < 1e-6
+        assert abs(q - np.array([-0.712558, 0.356292, 0.356266])).max() < 1e-5
 
     def test_uks_b3lyp(self):
         print('-------- UKS B3LYP -------------')
         e_tot, q = run_udft_chelpg('B3LYP', 0.1)
-        assert np.allclose(e_tot, -75.9987351018)
-        assert np.allclose(q, np.array([0.046042, 0.476984, 0.476974]), rtol=5.0E-5)
+        assert abs(e_tot - -75.9987351018) < 1e-6
+        assert abs(q - np.array([0.046042, 0.476984, 0.476974])).max() < 1e-5
 
 
 if __name__ == "__main__":

--- a/gpu4pyscf/scf/__init__.py
+++ b/gpu4pyscf/scf/__init__.py
@@ -30,6 +30,6 @@ def RHF(mol, *args):
     mem = get_avail_mem()
     nao = mol.nao
     if nao**2*30*8 > mem:
-        return hf_low_memory.RHF(mol, *args)
+        return hf_lowmem.RHF(mol, *args)
     else:
         return hf.RHF(mol, *args)

--- a/gpu4pyscf/scf/__init__.py
+++ b/gpu4pyscf/scf/__init__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from . import hf
-from .hf import RHF
 from .uhf import UHF
 from .ghf import GHF
 from .rohf import ROHF
@@ -24,3 +23,13 @@ def HF(mol, *args):
         return RHF(mol, *args)
     else:
         return UHF(mol, *args)
+
+def RHF(mol, *args):
+    from gpu4pyscf.lib.cupy_helper import get_avail_mem
+    from . import hf_lowmem
+    mem = get_avail_mem()
+    nao = mol.nao
+    if nao**2*30*8 > mem:
+        return hf_low_memory.RHF(mol, *args)
+    else:
+        return hf.RHF(mol, *args)

--- a/gpu4pyscf/scf/__init__.py
+++ b/gpu4pyscf/scf/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from . import hf
+from .hf import RHF
+from .hf_lowmem import RHF as LRHF
 from .uhf import UHF
 from .ghf import GHF
 from .rohf import ROHF
@@ -23,13 +25,3 @@ def HF(mol, *args):
         return RHF(mol, *args)
     else:
         return UHF(mol, *args)
-
-def RHF(mol, *args):
-    from gpu4pyscf.lib.cupy_helper import get_avail_mem
-    from . import hf_lowmem
-    mem = get_avail_mem()
-    nao = mol.nao
-    if nao**2*30*8 > mem:
-        return hf_lowmem.RHF(mol, *args)
-    else:
-        return hf.RHF(mol, *args)

--- a/gpu4pyscf/scf/diis.py
+++ b/gpu4pyscf/scf/diis.py
@@ -26,7 +26,8 @@ import scipy.optimize
 import pyscf.scf.diis as cpu_diis
 import gpu4pyscf.lib as lib
 from gpu4pyscf.lib import logger
-from gpu4pyscf.lib.cupy_helper import contract, eigh, sandwich_dot
+from gpu4pyscf.lib.cupy_helper import (
+    contract, eigh, sandwich_dot, pack_tril, unpack_tril)
 
 # J. Mol. Struct. 114, 31-34 (1984); DOI:10.1016/S0022-2860(84)87198-7
 # PCCP, 4, 11 (2002); DOI:10.1039/B108658H
@@ -45,10 +46,13 @@ class CDIIS(lib.diis.DIIS):
 
     def update(self, s, d, f, *args, **kwargs):
         errvec = self.get_err_vec(s, d, f)
-        xnew = lib.diis.DIIS.update(self, f, xerr=errvec)
+        nao = self.Corth.shape[1]
+        errvec = pack_tril(errvec.reshape(-1,nao,nao))
+        f_tril = pack_tril(f.reshape(-1,nao,nao))
+        xnew = lib.diis.DIIS.update(self, f_tril, xerr=errvec)
         if self.rollback > 0 and len(self._bookkeep) == self.space:
             self._bookkeep = self._bookkeep[-self.rollback:]
-        return xnew
+        return unpack_tril(xnew).reshape(f.shape)
 
     def get_num_vec(self):
         if self.rollback:

--- a/gpu4pyscf/scf/diis.py
+++ b/gpu4pyscf/scf/diis.py
@@ -45,7 +45,7 @@ class CDIIS(lib.diis.DIIS):
         self.space = 8
 
     def update(self, s, d, f, *args, **kwargs):
-        errvec = self.get_err_vec(s, d, f)
+        errvec = self._sdf_err_vec(s, d, f)
         nao = self.Corth.shape[1]
         errvec = pack_tril(errvec.reshape(-1,nao,nao))
         f_tril = pack_tril(f.reshape(-1,nao,nao))
@@ -60,7 +60,7 @@ class CDIIS(lib.diis.DIIS):
         else:
             return len(self._bookkeep)
 
-    def get_err_vec(self, s, d, f, Corth):
+    def _sdf_err_vec(self, s, d, f):
         '''error vector = SDF - FDS'''
         if f.ndim == s.ndim+1: # UHF
             assert len(f) == 2

--- a/gpu4pyscf/scf/diis.py
+++ b/gpu4pyscf/scf/diis.py
@@ -20,14 +20,13 @@
 DIIS
 """
 
-import numpy
-import cupy
+import cupy as cp
 import scipy.linalg
 import scipy.optimize
 import pyscf.scf.diis as cpu_diis
 import gpu4pyscf.lib as lib
 from gpu4pyscf.lib import logger
-from gpu4pyscf.lib.cupy_helper import contract
+from gpu4pyscf.lib.cupy_helper import contract, eigh, sandwich_dot
 
 # J. Mol. Struct. 114, 31-34 (1984); DOI:10.1016/S0022-2860(84)87198-7
 # PCCP, 4, 11 (2002); DOI:10.1039/B108658H
@@ -41,10 +40,11 @@ class CDIIS(lib.diis.DIIS):
     def __init__(self, mf=None, filename=None):
         lib.diis.DIIS.__init__(self, mf, filename)
         self.rollback = False
+        self.Corth = None
         self.space = 8
 
     def update(self, s, d, f, *args, **kwargs):
-        errvec = get_err_vec(s, d, f)
+        errvec = self.get_err_vec(s, d, f)
         xnew = lib.diis.DIIS.update(self, f, xerr=errvec)
         if self.rollback > 0 and len(self._bookkeep) == self.space:
             self._bookkeep = self._bookkeep[-self.rollback:]
@@ -56,36 +56,55 @@ class CDIIS(lib.diis.DIIS):
         else:
             return len(self._bookkeep)
 
-SCFDIIS = SCF_DIIS = DIIS = CDIIS
+    def get_err_vec(self, s, d, f, Corth):
+        '''error vector = SDF - FDS'''
+        if f.ndim == s.ndim+1: # UHF
+            assert len(f) == 2
+            if s.ndim == 2: # molecular SCF or single k-point
+                if self.Corth is None:
+                    self.Corth = eigh(f[0], s)[1]
+                sdf = cp.empty_like(f)
+                s.dot(d[0]).dot(f[0], out=sdf[0])
+                s.dot(d[1]).dot(f[1], out=sdf[1])
+                sdf = sandwich_dot(sdf, self.Corth)
+                errvec = sdf - sdf.conj().transpose(0,2,1)
+            else: # k-points
+                if self.Corth is None:
+                    self.Corth = cp.empty_like(s)
+                    for k, (fk, sk) in enumerate(zip(f[0], s)):
+                        self.Corth[k] = eigh(fk, sk)[1]
+                Corth = cp.asarray(self.Corth)
+                sdf = cp.empty_like(f)
+                tmp = None
+                tmp = contract('Kij,Kjk->Kik', d[0], f[0], out=tmp)
+                contract('Kij,Kjk->Kik', s, tmp, out=sdf[0])
+                tmp = contract('Kpq,Kqj->Kpj', sdf[0], Corth, out=tmp)
+                contract('Kpj,Kpi->Kij', tmp, Corth.conj(), out=sdf[0])
 
-def get_err_vec(s, d, f):
-    '''error vector = SDF - FDS'''
-    if f.ndim == s.ndim+1: # UHF
-        assert len(f) == 2
-        if s.ndim == 2: # molecular SCF or single k-point
-            sdf = cupy.stack([s.dot(d[0]).dot(f[0]),
-                              s.dot(d[1]).dot(f[1])])
-            errvec = sdf - sdf.conj().transpose(0,2,1)
-        else: # k-points
-            nkpts = len(f)
-            sdf = cupy.empty_like(f)
-            for k in range(nkpts):
-                sdf[0,k] = s[k].dot(d[0,k]).dot(f[0,k])
-                sdf[1,k] = s[k].dot(d[1,k]).dot(f[1,k])
-            sdf = sdf - sdf.conj().transpose(0,1,3,2)
-            df0 = contract('Kij,Kjk->Kik', d[0], f[0])
-            df1 = contract('Kij,Kjk->Kik', d[1], f[1])
-            sdf = cupy.stack([contract('Kij,Kjk->Kik', s, df0),
-                              contract('Kij,Kjk->Kik', s, df1)])
-            errvec = sdf - sdf.conj().transpose(0,1,3,2)
-    else: # RHF
-        assert f.ndim == s.ndim
-        if f.ndim == 2: # molecular SCF or single k-point
-            sdf = s.dot(d).dot(f)
-            errvec = sdf - sdf.conj().T
-        else: # k-points
-            nkpts = len(f)
-            sd = contract('Kij,Kjk->Kik', s, d)
-            sdf = contract('Kij,Kjk->Kik', sd, f)
-            errvec = sdf - sdf.conj().transpose(0,2,1)
-    return errvec.ravel()
+                tmp = contract('Kij,Kjk->Kik', d[1], f[1], out=tmp)
+                contract('Kij,Kjk->Kik', s, tmp, out=sdf[1])
+                tmp = contract('Kpq,Kqj->Kpj', sdf[1], Corth, out=tmp)
+                contract('Kpj,Kpi->Kij', tmp, Corth.conj(), out=sdf[1])
+                errvec = sdf - sdf.conj().transpose(0,1,3,2)
+        else: # RHF
+            assert f.ndim == s.ndim
+            if f.ndim == 2: # molecular SCF or single k-point
+                if self.Corth is None:
+                    self.Corth = eigh(f, s)[1]
+                sdf = s.dot(d).dot(f)
+                sdf = sandwich_dot(sdf, self.Corth)
+                errvec = sdf - sdf.conj().T
+            else: # k-points
+                if self.Corth is None:
+                    self.Corth = cp.empty_like(s)
+                    for k, (fk, sk) in enumerate(zip(f, s)):
+                        self.Corth[k] = eigh(fk, sk)[1]
+                sd = contract('Kij,Kjk->Kik', s, d)
+                sdf = contract('Kij,Kjk->Kik', sd, f)
+                Corth = cp.asarray(self.Corth)
+                sdf = contract('Kpq,Kqj->Kpj', sdf, Corth)
+                sdf = contract('Kpj,Kpi->Kij', sdf, Corth.conj())
+                errvec = sdf - sdf.conj().transpose(0,2,1)
+        return errvec.ravel()
+
+SCFDIIS = SCF_DIIS = DIIS = CDIIS

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -60,7 +60,7 @@ def make_rdm1(mo_coeff, mo_occ):
     mocc = mo_coeff[:, is_occ]
     dm = cupy.dot(mocc*mo_occ[is_occ], mocc.conj().T)
     occ_coeff = mo_coeff[:, is_occ]
-    return dm
+    return tag_array(dm, occ_coeff=occ_coeff, mo_occ=mo_occ, mo_coeff=mo_coeff)
 
 def get_occ(mf, mo_energy=None, mo_coeff=None):
     if mo_energy is None: mo_energy = mf.mo_energy
@@ -165,7 +165,6 @@ def _kernel(mf, conv_tol=1e-10, conv_tol_grad=None,
             dm0 = tag_array(dm0, mo_occ=mo_occ, mo_coeff=mo_coeff)
         else:
             # Drop attributes like mo_coeff, mo_occ for UHF and other methods.
-            # The get_veff function supports density matrices as input.
             dm0 = asarray(dm0, order='C')
 
     dm, dm0 = asarray(dm0, order='C'), None

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -23,7 +23,7 @@ from pyscf.scf import chkfile
 from gpu4pyscf import lib
 from gpu4pyscf.lib import utils
 from gpu4pyscf.lib.cupy_helper import (
-    eigh, tag_array, return_cupy_array, cond, asarray)
+    eigh, tag_array, return_cupy_array, cond, asarray, get_avail_mem)
 from gpu4pyscf.scf import diis, jk
 from gpu4pyscf.lib import logger
 
@@ -524,6 +524,11 @@ class RHF(SCF):
         if mol.nelectron != 1 and mol.spin != 0:
             logger.warn(self, 'Invalid number of electrons %d for RHF method.',
                         mol.nelectron)
+        mem = get_avail_mem()
+        nao = mol.nao
+        if nao**2*20*8 > mem:
+            logger.warn(self, 'GPU memory may be insufficient for SCF of this system. '
+                        'It is recommended to use the scf.LRHF or dft.LRKS class for this system.')
         return SCF.check_sanity(self)
 
     def energy_elec(self, dm=None, h1e=None, vhf=None):

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -102,16 +102,16 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
              diis_start_cycle=None, level_shift_factor=None, damp_factor=None):
     if h1e is None: h1e = mf.get_hcore()
     if vhf is None: vhf = mf.get_veff(mf.mol, dm)
-    if not isinstance(h1e, cupy.ndarray): h1e = cupy.asarray(h1e)
-    if not isinstance(vhf, cupy.ndarray): vhf = cupy.asarray(vhf)
+    h1e = cupy.asarray(h1e)
+    vhf = cupy.asarray(vhf)
     f = h1e + vhf
     if cycle < 0 and diis is None:  # Not inside the SCF iteration
         return f
 
     if s1e is None: s1e = mf.get_ovlp()
     if dm is None: dm = mf.make_rdm1()
-    if not isinstance(s1e, cupy.ndarray): s1e = cupy.asarray(s1e)
-    if not isinstance(dm, cupy.ndarray): dm = cupy.asarray(dm)
+    s1e = cupy.asarray(s1e)
+    dm = cupy.asarray(dm)
     if diis_start_cycle is None:
         diis_start_cycle = mf.diis_start_cycle
     if level_shift_factor is None:
@@ -218,7 +218,7 @@ def _kernel(mf, conv_tol=1e-10, conv_tol_grad=None,
         dm = asarray(dm) # Remove the attached attributes
         t1 = log.timer_debug1('veff', *t1)
 
-        fock = mf.get_fock(h1e, None, vhf)  # = h1e + vhf, no DIIS
+        fock = mf.get_fock(h1e, s1e, vhf, dm)  # = h1e + vhf, no DIIS
         norm_gorb = cupy.linalg.norm(mf.get_grad(mo_coeff, mo_occ, fock))
         e_tot = mf.energy_tot(dm, h1e, vhf)
 

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import h5py
+import numpy as np
 import cupy
+import h5py
 from functools import reduce
 from pyscf import gto
 from pyscf import lib as pyscf_lib
@@ -161,7 +162,7 @@ def _kernel(mf, conv_tol=1e-10, conv_tol_grad=None,
         if dm0.ndim == 2:
             mo_coeff = cupy.asarray(dm0.mo_coeff[:,dm0.mo_occ>0])
             mo_occ = cupy.asarray(dm0.mo_occ[dm0.mo_occ>0])
-            dm = tag_array(dm, mo_occ=mo_occ, mo_coeff=mo_coeff)
+            dm0 = tag_array(dm0, mo_occ=mo_occ, mo_coeff=mo_coeff)
         else:
             # Drop attributes like mo_coeff, mo_occ for UHF and other methods.
             # The get_veff function supports density matrices as input.

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -151,8 +151,6 @@ def _init_diis(mf, h1e, s1e, vhf, dm):
         mf_diis = mf.DIIS(mf, mf.diis_file)
         mf_diis.space = mf.diis_space
         mf_diis.rollback = mf.diis_space_rollback
-        fock = mf.get_fock(h1e, s1e, vhf, dm)
-        _, mf_diis.Corth = mf.eig(fock, s1e)
     else:
         mf_diis = None
     return mf_diis

--- a/gpu4pyscf/scf/hf_lowmem.py
+++ b/gpu4pyscf/scf/hf_lowmem.py
@@ -154,9 +154,10 @@ class CDIIS(diis.CDIIS):
         return out
 
 class RHF(hf.RHF):
-    '''RHF class for large systems. Not fully compatible with the default RHF
-    class in hf.py . Some methods return the lower-triangular part of the square
-    matrix; some methods are simplified.'''
+    '''The low-memory RHF class for large systems. Not fully compatible with the
+    default RHF class in hf.py . Some methods return the lower-triangular part
+    of the square matrix; some methods are simplified.
+    '''
 
     DIIS = CDIIS
 

--- a/gpu4pyscf/scf/hf_lowmem.py
+++ b/gpu4pyscf/scf/hf_lowmem.py
@@ -1,0 +1,295 @@
+# Copyright 2021-2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+The RHF implementation in this module prioritizes a reduced GPU memory footprint
+at the cost of efficiency.
+'''
+
+import numpy as np
+import cupy as cp
+from pyscf.scf import hf as hf_cpu
+from pyscf.scf import chkfile
+from gpu4pyscf.lib.cupy_helper import asarray, pack_tril, unpack_tril, sandwich_dot
+from gpu4pyscf.scf import diis, jk, hf
+from gpu4pyscf.lib import logger
+
+__all__ = [
+    'RHF',
+]
+
+def kernel(mf, dm0=None, conv_tol=1e-10, conv_tol_grad=None,
+          dump_chk=True, callback=None, conv_check=True, **kwargs):
+    mol = mf.mol
+    verbose = mf.verbose
+    log = logger.new_logger(mol, verbose)
+    cput0 = log.init_timer()
+
+    mf.dump_flags()
+    mf.build(mf.mol)
+
+    conv_tol = mf.conv_tol
+    if(conv_tol_grad is None):
+        conv_tol_grad = conv_tol**.5
+        logger.info(mf, 'Set gradient conv threshold to %g', conv_tol_grad)
+
+    if dm0 is None:
+        if mf.mo_coeff is not None and mf.mo_occ is not None:
+            # Initial guess from existing wavefunction
+            dm0 = mf.make_rdm1()
+        else:
+            dm0 = mf.get_init_guess(mol, mf.init_guess)
+
+    dm, dm0 = asarray(dm0, order='C'), None
+    h1e = cp.asarray(mf.get_hcore(mol))
+    vhf = mf.get_veff(mol, dm)
+    e_tot = mf.energy_tot(dm, h1e, vhf)
+    logger.info(mf, 'init E= %.15g', e_tot)
+    scf_conv = False
+
+    # Skip SCF iterations. Compute only the total energy of the initial density
+    if mf.max_cycle <= 0:
+        mf.e_tot = e_tot
+        if mf.mo_coeff is None:
+            s1e = mf.get_ovlp(mol)
+            fock = mf.get_fock(h1e, s1e, vhf, dm)  # = h1e + vhf, no DIIS
+            mf.mo_energy, mf.mo_coeff = mf.eig(fock, s1e)
+            mf.mo_occ = mf.get_occ(mf.mo_energy, mf.mo_coeff)
+            mf.converged = scf_conv
+        return e_tot
+
+    mf_diis = mf.DIIS(mf, mf.diis_file)
+    mf_diis.space = mf.diis_space
+    mf_diis.rollback = mf.diis_space_rollback
+
+    dump_chk = dump_chk and mf.chkfile is not None
+    if dump_chk:
+        # Explicit overwrite the mol object in chkfile
+        # Note in pbc.scf, mf.mol == mf.cell, cell is saved under key "mol"
+        chkfile.save_mol(mol, mf.chkfile)
+
+    for cycle in range(mf.max_cycle):
+        t0 = log.init_timer()
+        mo_coeff = mo_occ = mo_energy = fock = None
+        last_hf_e = e_tot
+
+        s1e = mf.get_ovlp(mol)
+        fock = mf.get_fock(h1e, s1e, vhf, dm, cycle, mf_diis)
+        t1 = log.timer_debug1('DIIS', *t0)
+        mo_energy, mo_coeff = mf.eig(fock, s1e)
+        fock = s1e = None
+        t1 = log.timer_debug1('eig', *t1)
+
+        mo_occ = mf.get_occ(mo_energy, mo_coeff)
+        # Update mo_coeff and mo_occ, allowing get_veff to generate DMs on the fly
+        mf.mo_coeff = mo_coeff
+        mf.mo_occ = mo_occ
+        vhf = mf.get_veff(mol, None, dm, vhf)
+
+        fock = mf.get_fock(h1e, None, vhf)  # = h1e + vhf, no DIIS
+        norm_gorb = cp.linalg.norm(mf.get_grad(mo_coeff, mo_occ, fock))
+        fock = None
+        dm, dm_last = mf.make_rdm1(mo_coeff, mo_occ), dm
+        e_tot = mf.energy_tot(dm, h1e, vhf)
+        norm_ddm = cp.linalg.norm(dm-dm_last)
+        dm_last = None
+        t1 = log.timer_debug1('SCF iteration', *t0)
+        logger.info(mf, 'cycle= %d E= %.15g  delta_E= %4.3g  |ddm|= %4.3g',
+                    cycle+1, e_tot, e_tot-last_hf_e, norm_ddm)
+
+        if dump_chk:
+            mf.dump_chk(locals())
+
+        e_diff = abs(e_tot-last_hf_e)
+        if(e_diff < conv_tol and norm_gorb < conv_tol_grad):
+            scf_conv = True
+            break
+    else:
+        logger.warn(mf, "SCF failed to converge")
+
+    mf.converged = scf_conv
+    mf.e_tot = e_tot
+    mf.mo_energy = mo_energy
+    mf.mo_coeff = mo_coeff
+    mf.mo_occ = mo_occ
+    logger.timer(mf, 'SCF', *cput0)
+    mf._finalize()
+    return e_tot
+
+class WaveFunction:
+    def __init__(self, mo_coeff, mo_occ):
+        self.mo_coeff
+        self.mo_occ
+
+    def make_rdm1(self):
+        raise NotImplementedError
+
+class RHFWfn(WaveFunction):
+    def make_rdm1(self):
+        mo_coeff = cp.asarray(self.mo_coeff)
+        mo_occ = cp.asarray(self.mo_occ)
+        is_occ = mo_occ > 0
+        mocc = mo_coeff[:, is_occ]
+        mocc *= mo_occ[is_occ]**.5
+        dm = mocc.dot(mocc.conj().T)
+        return dm
+
+class CDIIS(diis.CDIIS):
+    def update(self, s, d, f, *args, **kwargs):
+        out = super().update(s, d, f, *args, **kwargs)
+        if isinstance(self.Corth, cp.ndarray):
+            # Store Corth on host memory to reduce GPU memory pressure
+            self.Corth = self.Corth.get()
+        return out
+
+class RHF(hf.RHF):
+    '''RHF class for large systems. Not fully compatible with the default RHF
+    class in hf.py . Some methods return the lower-triangular part of the square
+    matrix; some methods are simplified.'''
+
+    DIIS = CDIIS
+
+    kernel = scf = kernel
+    density_fit              = NotImplemented
+    as_scanner               = NotImplemented
+    newton                   = NotImplemented
+    x2c = x2c1e = sfx2c1e    = NotImplemented
+    stability                = NotImplemented
+
+    def check_sanity(self):
+        mol = self.mol
+        if mol.spin != 0:
+            raise RuntimeError(
+                f'Invalid number of electrons {mol.nelectron} for RHF method.')
+        return self
+
+    def get_hcore(self):
+        '''The lower triangular part of Hcore'''
+        hcore = hf_cpu.RHF.get_hcore(self)
+        nao = hcore.shape[0]
+        idx = np.arange(nao)
+        return cp.asarray(hcore[idx[:,None] >= idx])
+
+    def get_jk(self, mol, dm, hermi=1, vhfopt=None, with_j=True, with_k=True, omega=None):
+        raise NotImplementedError
+
+    def get_j(self, mol=None, dm=None, hermi=1, omega=None):
+        raise NotImplementedError
+
+    def get_k(self, mol=None, dm=None, hermi=1, omega=None):
+        raise NotImplementedError
+
+    def get_veff(self, mol, dm, dm_last=None, vhf_last=0, hermi=1, vhfopt=None):
+        '''Constructus the lower-triangular part of the Fock matrix.'''
+        log = logger.new_logger(mol, self.verbose)
+        cput0 = log.init_timer()
+
+        omega = mol.omega
+        vhfopt = self._opt_gpu.get(omega)
+        if vhfopt is None:
+            vhfopt = self._opt_gpu[omega] = jk._VHFOpt(mol, self.direct_scf_tol).build()
+            if isinstance(vhfopt.coeff, cp.ndarray):
+                vhfopt.coeff = vhfopt.coeff.get()
+
+        if dm is None:
+            if isinstance(dm, WaveFunction):
+                mo_coeff = dm.mo_coeff
+                mo_occ = dm.mo_occ
+            else:
+                mo_coeff = self.mo_coeff
+                mo_occ = self.mo_occ
+            mask = mo_occ > 0
+            occ_coeff = cp.asarray(vhfopt.coeff).dot(mo_coeff[:,mask])
+            occ_coeff *= mo_occ[mask]
+            dm = occ_coeff.dot(occ_coeff.T)
+            mo_coeff = mo_occ = mask = None
+        else:
+            dm = sandwich_dot(dm, cp.asarray(vhfopt.coeff).T)
+        dm -= cp.asarray(dm_last)
+        vj, vk = vhfopt.get_jk(dm, hermi, True, True, log)
+        dm = None
+        coeff = cp.asarray(vhfopt.coeff)
+        vk = sandwich_dot(vk, coeff)
+        vhf_last -= pack_tril(vk) * .5
+        vk = None
+        vj = sandwich_dot(vj, cp.asarray(vhfopt.coeff))
+        vhf_last += pack_tril(vj)
+        log.timer('vj and vk', *cput0)
+        return vhf_last
+
+    def make_rdm1(self, mo_coeff, mo_occ):
+        return RHFWfn(mo_coeff, mo_occ).make_rdm1()
+
+    def get_fock(self, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
+                 diis_start_cycle=None, level_shift_factor=None, damp_factor=None):
+        '''Return Fock matrix in square storage'''
+        if h1e is None: h1e = self.get_hcore()
+        if vhf is None: vhf = self.get_veff(self.mol, dm)
+        if not isinstance(h1e, cp.ndarray): h1e = cp.asarray(h1e)
+        if not isinstance(vhf, cp.ndarray): vhf = cp.asarray(vhf)
+        # h1e and vhf must be both in tril storage or square-matrix storage
+        assert h1e.shape[-1] == vhf.shape[-1]
+        f = unpack_tril(h1e + vhf)
+        if cycle < 0 and diis is None:  # Not inside the SCF iteration
+            return f
+
+        if s1e is None: s1e = self.get_ovlp()
+        if dm is None: dm = self.make_rdm1()
+        if not isinstance(s1e, cp.ndarray): s1e = cp.asarray(s1e)
+        if not isinstance(dm, cp.ndarray): dm = cp.asarray(dm)
+        # Ensure overlap in square-matrix format
+        if s1e.shape[-1] != f.shape[-1]:
+            s1e = unpack_tril(s1e)
+
+        if diis_start_cycle is None:
+            diis_start_cycle = self.diis_start_cycle
+        if level_shift_factor is None:
+            level_shift_factor = self.level_shift
+        if damp_factor is None:
+            damp_factor = self.damp
+
+        if 0 <= cycle < diis_start_cycle-1 and abs(damp_factor) > 1e-4:
+            f = hf.damping(s1e, dm*.5, f, damp_factor)
+        if diis is not None and cycle >= diis_start_cycle:
+            f = diis.update(s1e, dm, f)
+
+        if abs(level_shift_factor) > 1e-4:
+            #:f = hf.level_shift(s1e, dm*.5, f, level_shift_factor)
+            dm_vir = s1e.dot(dm).dot(s1e)
+            dm_vir *= -.5
+            dm_vir += s1e
+            dm_vir *= level_shift_factor
+            f += dm_vir
+        return f
+
+    def energy_elec(self, dm, h1e, vhf):
+        '''
+        electronic energy
+        '''
+        assert dm.dtype == np.float64
+        assert h1e.ndim == vhf.ndim == 1
+        dm_tril = pack_tril(dm)
+        nao = dm.shape[0]
+        i = cp.arange(nao)
+        diag = i*(i+1)//2 + i
+        dm_tril[diag] *= .5
+        e1 = float(h1e.dot(dm_tril) * 2)
+        e_coul = float(vhf.dot(dm_tril))
+        self.scf_summary['e1'] = e1
+        self.scf_summary['e2'] = e_coul
+        logger.debug(self, 'E1 = %s  E_coul = %s', e1, e_coul)
+        return e1+e_coul, e_coul
+
+    def to_cpu(self):
+        raise NotImplementedError

--- a/gpu4pyscf/scf/jk.py
+++ b/gpu4pyscf/scf/jk.py
@@ -66,7 +66,6 @@ def get_jk(mol, dm, hermi=0, vhfopt=None, with_j=True, with_k=True, verbose=None
     if vhfopt is None:
         vhfopt = _VHFOpt(mol).build()
 
-    mol = vhfopt.sorted_mol
     coeff = cp.asarray(vhfopt.coeff)
     nao_orig = coeff.shape[1]
     dm = cp.asarray(dm, order='C')
@@ -93,7 +92,6 @@ def get_j(mol, dm, hermi=0, vhfopt=None, verbose=None):
     if vhfopt is None:
         vhfopt = _VHFOpt(mol).build()
 
-    mol = vhfopt.sorted_mol
     nao_orig = vhfopt.coeff.shape[1]
     dm = cp.asarray(dm, order='C')
     dms = dm.reshape(-1,nao_orig,nao_orig)

--- a/gpu4pyscf/scf/jk.py
+++ b/gpu4pyscf/scf/jk.py
@@ -71,7 +71,7 @@ def get_jk(mol, dm, hermi=0, vhfopt=None, with_j=True, with_k=True, verbose=None
     dm = cp.asarray(dm, order='C')
     dms = dm.reshape(-1,nao_orig,nao_orig)
     #:dms = cp.einsum('pi,nij,qj->npq', vhfopt.coeff, dms, vhfopt.coeff)
-    dms = sandwich_dot(dms, vhfopt.coeff.T)
+    dms = sandwich_dot(dms, cp.asarray(vhfopt.coeff).T)
     dms = cp.asarray(dms, order='C')
 
     ao_loc = mol.ao_loc
@@ -245,7 +245,7 @@ def get_jk(mol, dm, hermi=0, vhfopt=None, with_j=True, with_k=True, verbose=None
             vj1 = vs_h[0]
         else:
             vk1 = vs_h[0]
-        coeff = vhfopt.coeff
+        coeff = cp.asarray(vhfopt.coeff)
         idx, idy = np.tril_indices(nao, -1)
         if with_j:
             vj1[:,idy,idx] = vj1[:,idx,idy]
@@ -257,7 +257,7 @@ def get_jk(mol, dm, hermi=0, vhfopt=None, with_j=True, with_k=True, verbose=None
             for i, v in enumerate(vk1):
                 vk[i] += coeff.T.dot(cp.asarray(v)).dot(coeff)
         log.timer_debug1('get_jk pass 2 for h functions on cpu', *cput1)
-    
+
     if with_j:
         vj = vj.reshape(dm.shape)
     if with_k:
@@ -282,7 +282,7 @@ def get_j(mol, dm, hermi=0, vhfopt=None, verbose=None):
     n_dm = dms.shape[0]
     assert n_dm == 1
     #:dms = cp.einsum('pi,nij,qj->npq', vhfopt.coeff, dms, vhfopt.coeff)
-    dms = sandwich_dot(dms, vhfopt.coeff.T)
+    dms = sandwich_dot(dms, cp.asarray(vhfopt.coeff).T)
     dms = cp.asarray(dms, order='C')
     if hermi != 1:
         dms = transpose_sum(dms)

--- a/gpu4pyscf/scf/jk.py
+++ b/gpu4pyscf/scf/jk.py
@@ -225,6 +225,7 @@ class _VHFOpt:
         '''Build JK for the sorted_mol. Density matrices dms and the return JK
         matrices are all corresponding to the sorted_mol
         '''
+        assert dms.ndim == 3
         mol = self.sorted_mol
         log = logger.new_logger(mol, verbose)
         ao_loc = mol.ao_loc
@@ -401,6 +402,7 @@ class _VHFOpt:
         return vj, vk
 
     def get_j(self, dms, verbose):
+        assert dms.ndim == 3
         mol = self.sorted_mol
         log = logger.new_logger(mol, verbose)
         ao_loc = mol.ao_loc
@@ -546,7 +548,7 @@ class _VHFOpt:
         libvhf_rys.transform_xyz_to_cart(
             vj.ctypes, vj_xyz.ctypes, ao_loc.ctypes, pair_loc.ctypes,
             mol._bas.ctypes, ctypes.c_int(mol.nbas), mol._env.ctypes)
-        vj = transpose_sum(vj)
+        vj = transpose_sum(cp.asarray(vj))
         vj *= 2.
 
         h_shls = self.h_shls

--- a/gpu4pyscf/scf/tests/test_hf_lowmem.py
+++ b/gpu4pyscf/scf/tests/test_hf_lowmem.py
@@ -1,0 +1,47 @@
+# Copyright 2021-2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import tempfile
+import numpy as np
+import cupy
+import pyscf
+from pyscf import lib
+from gpu4pyscf.scf import hf_lowmem
+
+mol = pyscf.M(
+    atom = '''
+    O       0.0000000000    -0.0000000000     0.1174000000
+    H      -0.7570000000    -0.0000000000    -0.4696000000
+    H       0.7570000000     0.0000000000    -0.4696000000
+    ''',
+    basis='ccpvdz',
+    spin=None,
+    output = '/dev/null'
+)
+
+def tearDownModule():
+    global mol
+    mol.stdout.close()
+    del mol
+
+class KnownValues(unittest.TestCase):
+    def test_rhf_scf(self):
+        e_tot = hf_lowmem.RHF(mol).kernel()
+        e_ref = -76.02676567311744
+        assert np.abs(e_tot - e_ref) < 1e-8
+
+if __name__ == "__main__":
+    print("Full Tests for hf_lowmem")
+    unittest.main()

--- a/gpu4pyscf/scf/uhf.py
+++ b/gpu4pyscf/scf/uhf.py
@@ -60,28 +60,26 @@ def spin_square(mo, s=1):
 
 def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
              diis_start_cycle=None, level_shift_factor=None, damp_factor=None):
-    if dm is None: dm = mf.make_rdm1()
     if h1e is None: h1e = mf.get_hcore()
-    if s1e is None: s1e = mf.get_ovlp()
     if vhf is None: vhf = mf.get_veff(mf.mol, dm)
-    if not isinstance(s1e, cupy.ndarray): s1e = cupy.asarray(s1e)
-    if not isinstance(dm, cupy.ndarray): dm = cupy.asarray(dm)
-    if not isinstance(h1e, cupy.ndarray): h1e = cupy.asarray(h1e)
-    if not isinstance(vhf, cupy.ndarray): vhf = cupy.asarray(vhf)
+    h1e = cupy.asarray(h1e)
+    vhf = cupy.asarray(vhf)
     f = h1e + vhf
     if f.ndim == 2:
         f = (f, f)
     if cycle < 0 and diis is None:  # Not inside the SCF iteration
         return f
 
+    if s1e is None: s1e = mf.get_ovlp()
+    if dm is None: dm = mf.make_rdm1()
+    s1e = cupy.asarray(s1e)
+    dm = cupy.asarray(dm)
     if diis_start_cycle is None:
         diis_start_cycle = mf.diis_start_cycle
     if level_shift_factor is None:
         level_shift_factor = mf.level_shift
     if damp_factor is None:
         damp_factor = mf.damp
-    if s1e is None: s1e = mf.get_ovlp()
-    if dm is None: dm = mf.make_rdm1()
 
     if isinstance(level_shift_factor, (tuple, list, np.ndarray)):
         shifta, shiftb = level_shift_factor

--- a/gpu4pyscf/tdscf/tests/test_tdrhf.py
+++ b/gpu4pyscf/tdscf/tests/test_tdrhf.py
@@ -45,7 +45,7 @@ class KnownValues(unittest.TestCase):
         assert td.device == 'gpu'
         e = td.kernel()[0]
         ref = [11.9027511, 11.9027511, 16.8603101]
-        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 4)
         dip = td.transition_dipole()
         self.assertAlmostEqual(lib.fp(np.linalg.norm(dip, axis=1)), -0.65616659, 5)
 
@@ -65,7 +65,7 @@ class KnownValues(unittest.TestCase):
         td.singlet = False
         e = td.kernel()[0]
         ref = [11.0174650, 11.0174650, 13.1694960]
-        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 4)
         dip = td.transition_dipole()
         self.assertAlmostEqual(abs(dip).max(), 0, 8)
 
@@ -85,7 +85,7 @@ class KnownValues(unittest.TestCase):
         assert td.device == 'gpu'
         e = td.kernel()[0]
         ref = [11.8348584, 11.8348584, 16.6630381]
-        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 4)
         dip = td.transition_dipole()
         self.assertAlmostEqual(lib.fp(np.linalg.norm(dip, axis=1)), -0.64009191, 5)
 
@@ -105,7 +105,7 @@ class KnownValues(unittest.TestCase):
         td.singlet = False
         e = td.kernel()[0]
         ref = [10.8919091, 10.8919091, 12.6343507]
-        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(e[:len(ref)] * 27.2114 - ref).max(), 0, 4)
         dip = td.transition_dipole()
         self.assertAlmostEqual(abs(dip).max(), 0, 8)
 

--- a/gpu4pyscf/tdscf/tests/test_tduks.py
+++ b/gpu4pyscf/tdscf/tests/test_tduks.py
@@ -176,8 +176,8 @@ class KnownValues(unittest.TestCase):
         assert td.device == 'gpu'
         es = td.kernel(nstates=5)[0]
         ref = td.to_cpu().kernel(nstates=5)[0]
-        self.assertAlmostEqual(abs(es - ref[:5]).max(), 0, 8)
-        self.assertAlmostEqual(lib.fp(es), -0.7530329968766932, 6)
+        self.assertAlmostEqual(abs(es - ref[:5]).max(), 0, 9)
+        self.assertAlmostEqual(lib.fp(es), -0.7530329968766932, 5)
 
     def test_tda_vind(self):
         mf = self.mf_bp86


### PR DESCRIPTION
* [x] Promptly release the attributes of the tagged arrays (dm, veff)
* [x] Promptly release the unused variables within the SCF iteration
* [x] Only save the lower triangular part of the matrices in DIIS
* [x] Hold certain transformation matrices on host memory
   - [x] vhfopt.coeff
   - [x] diis.Corth
* A separated direct SCF driver for large-size systems:
   - [x] overlap matrix computed on the fly
   - [x] Save only the lower triangular part of hcore, veff matrices
* Bugfix: Use orthogonal bases in DIIS error vector construction.
