### PR TITLE
Fix multi-GPU bug for gradient and hessian calculation

### DIFF
--- a/gpu4pyscf/grad/rhf.py
+++ b/gpu4pyscf/grad/rhf.py
@@ -71,6 +71,8 @@ def _ejk_ip1_task(mol, dms, vhfopt, task_list, j_factor=1.0, k_factor=1.0,
     with cp.cuda.Device(device_id), _streams[device_id]:
         log = logger.new_logger(mol, verbose)
         cput0 = log.init_timer()
+        init_constant(mol)
+
         dms = cp.asarray(dms)
 
         tile_q_ptr = ctypes.cast(vhfopt.tile_q_cond.data.ptr, ctypes.c_void_p)
@@ -83,7 +85,7 @@ def _ejk_ip1_task(mol, dms, vhfopt, task_list, j_factor=1.0, k_factor=1.0,
 
         ao_loc = mol.ao_loc
         dm_cond = cp.log(condense('absmax', dms, ao_loc) + 1e-300).astype(np.float32)
-        log_max_dm = dm_cond.max()
+        log_max_dm = float(dm_cond.max())
         log_cutoff = math.log(vhfopt.direct_scf_tol)
         tile_mappings = _make_tril_tile_mappings(l_ctr_bas_loc, vhfopt.tile_q_cond,
                                                  log_cutoff-log_max_dm)
@@ -154,8 +156,6 @@ def _jk_energy_per_atom(mol, dm, vhfopt=None,
     #:dms = cp.einsum('pi,nij,qj->npq', vhfopt.coeff, dms, vhfopt.coeff)
     dms = sandwich_dot(dms, vhfopt.coeff.T)
     dms = cp.asarray(dms, order='C')
-
-    init_constant(mol)
 
     uniq_l_ctr = vhfopt.uniq_l_ctr
     uniq_l = uniq_l_ctr[:,0]

--- a/gpu4pyscf/gto/mole.py
+++ b/gpu4pyscf/gto/mole.py
@@ -23,9 +23,9 @@ from pyscf.gto import (ANG_OF, ATOM_OF, NPRIM_OF, NCTR_OF, PTR_COORD, PTR_COEFF,
 
 PTR_BAS_COORD = 7
 
-@functools.lru_cache(20)
+# @functools.lru_cache(20) # This cache introduces a bug in mutli-gpu mode
 def cart2sph_by_l(l, normalized='sp'):
-    c2s = gto.mole.cart2sph(l, normalized='sp')
+    c2s = gto.mole.cart2sph(l, normalized=normalized)
     return cp.asarray(c2s, order='C')
 
 def basis_seg_contraction(mol, allow_replica=1):

--- a/gpu4pyscf/hessian/jk.py
+++ b/gpu4pyscf/hessian/jk.py
@@ -55,6 +55,8 @@ def _jk_task(mol, dms, mo_coeff, mo_occ, vhfopt, task_list, hermi=0,
     with cp.cuda.Device(device_id), _streams[device_id]:
         log = logger.new_logger(mol, verbose)
         cput0 = log.init_timer()
+        init_constant(mol)
+
         dms = cp.asarray(dms)
         coeff = cp.asarray(vhfopt.coeff)
 
@@ -82,7 +84,7 @@ def _jk_task(mol, dms, mo_coeff, mo_occ, vhfopt, task_list, hermi=0,
 
         ao_loc = mol.ao_loc
         dm_cond = cp.log(condense('absmax', dms, ao_loc) + 1e-300).astype(np.float32)
-        log_max_dm = dm_cond.max()
+        log_max_dm = float(dm_cond.max())
         log_cutoff = math.log(vhfopt.direct_scf_tol)
         tile_mappings = _make_tril_tile_mappings(l_ctr_bas_loc, vhfopt.tile_q_cond,
                                                  log_cutoff-log_max_dm)
@@ -186,8 +188,6 @@ def get_jk(mol, dm, mo_coeff, mo_occ, hermi=0, vhfopt=None,
     n_dm = dms.shape[0]
 
     assert with_j or with_k
-
-    init_constant(mol)
 
     uniq_l_ctr = vhfopt.uniq_l_ctr
     uniq_l = uniq_l_ctr[:,0]

--- a/gpu4pyscf/hessian/rhf.py
+++ b/gpu4pyscf/hessian/rhf.py
@@ -178,6 +178,8 @@ def _ejk_ip2_task(mol, dms, vhfopt, task_list, j_factor=1.0, k_factor=1.0,
     with cp.cuda.Device(device_id), _streams[device_id]:
         log = logger.new_logger(mol, verbose)
         cput0 = log.init_timer()
+        init_constant(mol)
+
         dms = cp.asarray(dms)
         coeff = cp.asarray(vhfopt.coeff)
 
@@ -196,7 +198,7 @@ def _ejk_ip2_task(mol, dms, vhfopt, task_list, j_factor=1.0, k_factor=1.0,
 
         ao_loc = mol.ao_loc
         dm_cond = cp.log(condense('absmax', dms, ao_loc) + 1e-300).astype(np.float32)
-        log_max_dm = dm_cond.max()
+        log_max_dm = float(dm_cond.max())
         log_cutoff = math.log(vhfopt.direct_scf_tol)
         tile_mappings = _make_tril_tile_mappings(l_ctr_bas_loc, vhfopt.tile_q_cond,
                                                  log_cutoff-log_max_dm)
@@ -287,8 +289,6 @@ def _partial_ejk_ip2(mol, dm, vhfopt=None, j_factor=1., k_factor=1., verbose=Non
 
     dm = cp.asarray(dm, order='C')
     dms = dm.reshape(-1,nao_orig,nao_orig)
-
-    init_constant(mol)
 
     uniq_l_ctr = vhfopt.uniq_l_ctr
     uniq_l = uniq_l_ctr[:,0]
@@ -431,6 +431,8 @@ def _build_jk_ip1_task(mol, dms, vhfopt, task_list, atoms_slice,
     with cp.cuda.Device(device_id), _streams[device_id]:
         log = logger.new_logger(mol, verbose)
         cput0 = log.init_timer()
+        init_constant(mol)
+
         dms = cp.asarray(dms)
 
         vj = vk = None
@@ -445,7 +447,7 @@ def _build_jk_ip1_task(mol, dms, vhfopt, task_list, atoms_slice,
 
         ao_loc = mol.ao_loc
         dm_cond = cp.log(condense('absmax', dms, ao_loc) + 1e-300).astype(np.float32)
-        log_max_dm = dm_cond.max()
+        log_max_dm = float(dm_cond.max())
         log_cutoff = math.log(vhfopt.direct_scf_tol)
         tril_tile_mappings = _make_tril_tile_mappings(
             l_ctr_bas_loc, vhfopt.tile_q_cond, log_cutoff-log_max_dm, 1)
@@ -536,8 +538,6 @@ def _get_jk_ip1(mol, dm, with_j=True, with_k=True, atoms_slice=None, verbose=Non
     if atoms_slice is None:
         atoms_slice = 0, natm
     atom0, atom1 = atoms_slice
-
-    init_constant(mol)
 
     uniq_l_ctr = vhfopt.uniq_l_ctr
     uniq_l = uniq_l_ctr[:,0]


### PR DESCRIPTION
- Fix a bug of maxDynamicSharedMemorySize not set on different GPUs for gradient and hessian calculation
- Enhance error printing in kernel
- Confirmed that `functools.lru_cache` of cupy array naively is a bug in multigpu mode