### PR TITLE
Reduce memory footprint in grad/rks and grad/uks

### DIFF
--- a/gpu4pyscf/df/grad/uks.py
+++ b/gpu4pyscf/df/grad/uks.py
@@ -103,8 +103,12 @@ def get_veff(ks_grad, mol=None, dm=None, verbose=None):
             ek_aux = (ekaux0+ekaux1) * hyb
 
         if omega != 0:
-            ek_lr0, ekaux_lr0 = ks_grad.get_k(mol, dm[0], mo_coeff=ks_grad.base.mo_coeff[0], mo_occ=ks_grad.base.mo_occ[0], omega=omega)
-            ek_lr1, ekaux_lr1 = ks_grad.get_k(mol, dm[1], mo_coeff=ks_grad.base.mo_coeff[1], mo_occ=ks_grad.base.mo_occ[1], omega=omega)
+            mocc0 = ks_grad.base.mo_coeff[0]
+            mocc1 = ks_grad.base.mo_coeff[1]
+            mo_coeff0 = ks_grad.base.mo_coeff[0]
+            mo_coeff1 = ks_grad.base.mo_coeff[1]
+            ek_lr0, ekaux_lr0 = ks_grad.get_k(mol, dm[0], mo_coeff=mo_coeff0, mo_occ=mocc0, omega=omega)
+            ek_lr1, ekaux_lr1 = ks_grad.get_k(mol, dm[1], mo_coeff=mo_coeff1, mo_occ=mocc1, omega=omega)
             ek += (ek_lr0 + ek_lr1) * (alpha-hyb)
             if ks_grad.auxbasis_response:
                 ek_aux += (ekaux_lr0 + ekaux_lr1) * (alpha-hyb)

--- a/gpu4pyscf/df/grad/uks.py
+++ b/gpu4pyscf/df/grad/uks.py
@@ -103,8 +103,8 @@ def get_veff(ks_grad, mol=None, dm=None, verbose=None):
             ek_aux = (ekaux0+ekaux1) * hyb
 
         if omega != 0:
-            mocc0 = ks_grad.base.mo_coeff[0]
-            mocc1 = ks_grad.base.mo_coeff[1]
+            mocc0 = ks_grad.base.mo_occ[0]
+            mocc1 = ks_grad.base.mo_occ[1]
             mo_coeff0 = ks_grad.base.mo_coeff[0]
             mo_coeff1 = ks_grad.base.mo_coeff[1]
             ek_lr0, ekaux_lr0 = ks_grad.get_k(mol, dm[0], mo_coeff=mo_coeff0, mo_occ=mocc0, omega=omega)

--- a/gpu4pyscf/grad/uks.py
+++ b/gpu4pyscf/grad/uks.py
@@ -261,7 +261,6 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     _sorted_mol = opt._sorted_mol
     nao = _sorted_mol.nao
     dms = cupy.asarray(dms)
-    dms = cupy.asarray(dms)
     assert dms.ndim == 3 and dms.shape[0] == 2
     dms = opt.sort_orbitals(dms.reshape(-1,nao,nao), axis=[1,2])
 


### PR DESCRIPTION
- get_vxc -> get_exc, contract density matrix with vxc inside get_exc
- Lazy evaluate opt.coeff, reduce memory footprint in most DFT modules.