### PR TITLE
Improve the efficiency of ECP gradient

### DIFF
--- a/gpu4pyscf/__config__.py
+++ b/gpu4pyscf/__config__.py
@@ -24,10 +24,10 @@ for device_id in range(num_devices):
 
 props = cupy.cuda.runtime.getDeviceProperties(0)
 GB = 1024*1024*1024
-min_ao_blksize = 128
-min_grid_blksize = 128*128
-ao_aligned = 32
-grid_aligned = 256
+min_ao_blksize = 256        # maxisum batch size of AOs
+min_grid_blksize = 128*128  # maximum batch size of grids for DFT
+ao_aligned = 32             # global AO alignment for slicing
+grid_aligned = 256          # 256 alignment for grids globally
 
 # Use smaller blksize for old gaming GPUs
 if props['totalGlobalMem'] < 16 * GB:

--- a/gpu4pyscf/drivers/dft_wb97x3c_sample.json
+++ b/gpu4pyscf/drivers/dft_wb97x3c_sample.json
@@ -20,6 +20,6 @@
     "with_gpu": true,
     "with_df": true,
     "with_grad": true,
-    "with_hess": false,
+    "with_hess": true,
     "save_density": false
 }]

--- a/gpu4pyscf/drivers/dft_wb97x3c_sample.json
+++ b/gpu4pyscf/drivers/dft_wb97x3c_sample.json
@@ -20,6 +20,6 @@
     "with_gpu": true,
     "with_df": true,
     "with_grad": true,
-    "with_hess": true,
+    "with_hess": false,
     "save_density": false
 }]

--- a/gpu4pyscf/grad/rhf.py
+++ b/gpu4pyscf/grad/rhf.py
@@ -246,6 +246,18 @@ def get_hcore(mf, mol):
         h += get_ecp_ip(mol).sum(axis=0)
     return -h
 
+def get_hcore_no_ecp(mf, mol):
+    '''
+    Nuclear gradients of core Hamiltonian, w/o ECP
+    '''
+    h = mol.intor('int1e_ipkin', comp=3)
+    if mol._pseudo:
+        NotImplementedError('Nuclear gradients for GTH PP')
+    else:
+        h += mol.intor('int1e_ipnuc', comp=3)
+    h = cupy.asarray(h)
+    return -h
+
 def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     '''
     Electronic part of RHF/RKS gradients
@@ -262,7 +274,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     if mo_occ is None:    mo_occ = mf.mo_occ
     if mo_coeff is None:  mo_coeff = mf.mo_coeff
     log = logger.Logger(mf_grad.stdout, mf_grad.verbose)
-    t0 = log.init_timer()
+    t0 = t3 = log.init_timer()
 
     mo_energy = cupy.asarray(mo_energy)
     mo_occ = cupy.asarray(mo_occ)
@@ -271,16 +283,19 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     dme0 = mf_grad.make_rdm1e(mo_energy, mo_coeff, mo_occ)
 
     # (\nabla i | hcore | j) - (\nabla i | j)
-    h1 = cupy.asarray(mf_grad.get_hcore(mol))
+    h1 = cupy.asarray(mf_grad.get_hcore_no_ecp(mol))
     s1 = cupy.asarray(mf_grad.get_ovlp(mol))
 
     # (i | \nabla hcore | j)
-    t3 = log.init_timer()
     dh1e = int3c2e.get_dh1e(mol, dm0)
 
     if mol.has_ecp():
+        # TODO: slice ecp_atoms
         ecp_atoms = sorted(set(mol._ecpbas[:,gto.ATOM_OF]))
-        dh1e[ecp_atoms] += get_dh1e_ecp(mol, dm0)
+        h1_ecp = get_ecp_ip(mol, ecp_atoms=ecp_atoms)
+        h1 -= h1_ecp.sum(axis=0)
+
+        dh1e[ecp_atoms] += 2.0 * contract('nxij,ij->nx', h1_ecp, dm0)
     t3 = log.timer_debug1('gradients of h1e', *t3)
 
     dvhf = mf_grad.get_veff(mol, dm0)
@@ -431,7 +446,8 @@ class Gradients(GradientsBase):
 
     make_rdm1e = rhf_grad_cpu.Gradients.make_rdm1e
     grad_elec = grad_elec
-
+    get_hcore_no_ecp = get_hcore_no_ecp
+    
     def get_veff(self, mol=None, dm=None, verbose=None):
         '''
         Computes the first-order derivatives of the energy contributions from

--- a/gpu4pyscf/grad/uhf.py
+++ b/gpu4pyscf/grad/uhf.py
@@ -66,12 +66,14 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     de = cupy.zeros((len(atmlst),3))
     
     # (\nabla i | hcore | j) - (\nabla i | j)
-    h1 = cupy.asarray(mf_grad.get_hcore_no_ecp(mol))
+    h1 = cupy.asarray(mf_grad.get_hcore(mol, exclude_ecp=True))
     s1 = cupy.asarray(mf_grad.get_ovlp(mol))
 
     # (i | \nabla hcore | j)
     dh1e = int3c2e.get_dh1e(mol, dm0_sf)
 
+    # Calculate ECP contributions in (i | \nabla hcore | j) and 
+    # (\nabla i | hcore | j) simultaneously
     if mol.has_ecp():
         ecp_atoms = sorted(set(mol._ecpbas[:,gto.ATOM_OF]))
         h1_ecp = get_ecp_ip(mol, ecp_atoms=ecp_atoms)
@@ -110,7 +112,6 @@ class Gradients(rhf_grad.GradientsBase):
     device = utils.device
 
     grad_elec = grad_elec
-    get_hcore_no_ecp = rhf_grad.get_hcore_no_ecp
 
     def get_veff(self, mol, dm, verbose=None):
         '''

--- a/gpu4pyscf/gto/tests/test_ecp.py
+++ b/gpu4pyscf/gto/tests/test_ecp.py
@@ -65,19 +65,19 @@ def setUpModule():
 Na nelec 10
 Na ul
 2       1.0                   0.5
-#Na S
-#2      13.652203             732.2692
-#2       6.826101              26.484721
-#Na P
-#2      10.279868             299.489474
-#2       5.139934              26.466234
-#Na D
-#2       7.349859             124.457595
-#2       3.674929              14.035995
-#Na F
-#2       3.034072              21.531031
-#Na G
-#2       4.808857             -21.607597
+Na S
+2      13.652203             732.2692
+2       6.826101              26.484721
+Na P
+2      10.279868             299.489474
+2       5.139934              26.466234
+Na D
+2       7.349859             124.457595
+2       3.674929              14.035995
+Na F
+2       3.034072              21.531031
+Na G
+2       4.808857             -21.607597
                                          ''')})
 def tearDownModule():
     global mol1, mol2
@@ -95,14 +95,14 @@ class KnownValues(unittest.TestCase):
         h1_cpu = mol2.intor('ECPscalar_sph')
         h1_gpu = get_ecp(mol2)
         assert np.linalg.norm(h1_cpu - h1_gpu.get()) < 1e-8
-    
+
     @unittest.skipIf(shm_size < 64*1024, "Not enough shared memory")
     def test_ecp_cart_ip1(self):
         h1_cpu = mol1.intor('ECPscalar_iprinv_cart')
         h1_gpu = get_ecp_ip(mol1)
         h1_gpu = np.sum(h1_gpu, axis=0)
         assert np.linalg.norm(h1_cpu - h1_gpu.get()) < 1e-8
-    
+
     @unittest.skipIf(shm_size < 64*1024, "Not enough shared memory")
     def test_ecp_sph_iprinv(self):
         nao = mol2.nao
@@ -119,13 +119,13 @@ class KnownValues(unittest.TestCase):
         h1_cpu = mol2.intor('ECPscalar_ipnuc_sph')
         h1_gpu = get_ecp_ip(mol2).sum(axis=0)
         assert np.linalg.norm(h1_cpu - h1_gpu.get()) < 1e-8
-    
+
     @unittest.skipIf(shm_size < 64*1024, "Not enough shared memory")
     def test_ecp_cart_ipipv(self):
         h1_cpu = mol2.intor('ECPscalar_ipipnuc', comp=9)
         h1_gpu = get_ecp_ipip(mol2, 'ipipv').sum(axis=0)
         assert np.linalg.norm(h1_cpu - h1_gpu.get()) < 1e-8
-    
+
     @unittest.skipIf(shm_size < 64*1024, "Not enough shared memory")
     def test_ecp_cart_ipvip_cart(self):
         h1_cpu = mol2.intor('ECPscalar_ipnucip', comp=9)

--- a/gpu4pyscf/gto/tests/test_ecp.py
+++ b/gpu4pyscf/gto/tests/test_ecp.py
@@ -65,19 +65,19 @@ def setUpModule():
 Na nelec 10
 Na ul
 2       1.0                   0.5
-Na S
-2      13.652203             732.2692
-2       6.826101              26.484721
-Na P
-2      10.279868             299.489474
-2       5.139934              26.466234
-Na D
-2       7.349859             124.457595
-2       3.674929              14.035995
-Na F
-2       3.034072              21.531031
-Na G
-2       4.808857             -21.607597
+#Na S
+#2      13.652203             732.2692
+#2       6.826101              26.484721
+#Na P
+#2      10.279868             299.489474
+#2       5.139934              26.466234
+#Na D
+#2       7.349859             124.457595
+#2       3.674929              14.035995
+#Na F
+#2       3.034072              21.531031
+#Na G
+#2       4.808857             -21.607597
                                          ''')})
 def tearDownModule():
     global mol1, mol2
@@ -119,19 +119,19 @@ class KnownValues(unittest.TestCase):
         h1_cpu = mol2.intor('ECPscalar_ipnuc_sph')
         h1_gpu = get_ecp_ip(mol2).sum(axis=0)
         assert np.linalg.norm(h1_cpu - h1_gpu.get()) < 1e-8
-
+    
     @unittest.skipIf(shm_size < 64*1024, "Not enough shared memory")
     def test_ecp_cart_ipipv(self):
         h1_cpu = mol2.intor('ECPscalar_ipipnuc', comp=9)
         h1_gpu = get_ecp_ipip(mol2, 'ipipv').sum(axis=0)
         assert np.linalg.norm(h1_cpu - h1_gpu.get()) < 1e-8
-
+    
     @unittest.skipIf(shm_size < 64*1024, "Not enough shared memory")
     def test_ecp_cart_ipvip_cart(self):
         h1_cpu = mol2.intor('ECPscalar_ipnucip', comp=9)
         h1_gpu = get_ecp_ipip(mol2, 'ipvip').sum(axis=0)
         assert np.linalg.norm(h1_cpu - h1_gpu.get()) < 1e-8
-    
+
 if __name__ == "__main__":
     print("Full Tests for ECP Integrals")
     unittest.main()

--- a/gpu4pyscf/lib/ecp/common.cu
+++ b/gpu4pyscf/lib/ecp/common.cu
@@ -93,6 +93,7 @@ void cache_fac(double *fx, int LI, double *ri){
 
 __device__
 void block_reduce(double val, double *d_out) {
+    __syncthreads();
     __shared__ double sdata[THREADS];
     unsigned int tid = threadIdx.x;
 

--- a/gpu4pyscf/lib/ecp/common.cu
+++ b/gpu4pyscf/lib/ecp/common.cu
@@ -180,7 +180,6 @@ void _li_up(double *out, double *buf, const int li, const int lj){
         atomicAdd(outy + j*nfi + _y_addr[i], yfac * buf[j*nfi0 + i]);
         atomicAdd(outz + j*nfi + _z_addr[i], zfac * buf[j*nfi0 + i]);
     }
-    __syncthreads();
 }
 
 __device__
@@ -217,7 +216,6 @@ void _li_up_and_write(double *out, double *buf, const int li, const int lj, cons
         atomicAdd(outzy + j + i_addr[1]*nao, yfac * buf[j*nfi0 + i + 2*nfi0*nfj]);
         atomicAdd(outzz + j + i_addr[2]*nao, zfac * buf[j*nfi0 + i + 2*nfi0*nfj]);
     }
-    __syncthreads();
 }
 
 
@@ -238,7 +236,6 @@ void _li_down(double *out, double *buf, const int li, const int lj){
         atomicAdd(outy + j*nfi+i, fac * buf[j*nfi1+_y_addr[i]]);
         atomicAdd(outz + j*nfi+i, fac * buf[j*nfi1+_z_addr[i]]);
     }
-    __syncthreads();
 }
 
 __device__
@@ -274,7 +271,6 @@ void _li_down_and_write(double *out, double *buf, const int li, const int lj, co
         atomicAdd(outzy + j + i*nao, fac * buf[j*nfi1 + i_addr[1] + 2*nfi1*nfj]);
         atomicAdd(outzz + j + i*nao, fac * buf[j*nfi1 + i_addr[2] + 2*nfi1*nfj]);
     }
-    __syncthreads();
 }
 
 
@@ -312,7 +308,6 @@ void _lj_up_and_write(double *out, double *buf, const int li, const int lj, cons
         atomicAdd(outzy + j_addr[1] + nao*i, yfac * buf[j*nfi + i + 2*nfi*nfj0]);
         atomicAdd(outzz + j_addr[2] + nao*i, zfac * buf[j*nfi + i + 2*nfi*nfj0]);
     }
-    __syncthreads();
 }
 
 __device__
@@ -347,7 +342,6 @@ void _lj_down_and_write(double *out, double *buf, const int li, const int lj, co
         atomicAdd(outzy + j + i*nao, fac * buf[j_addr[1]*nfi + i + 2*nfi*nfj1]);
         atomicAdd(outzz + j + i*nao, fac * buf[j_addr[2]*nfi + i + 2*nfi*nfj1]);
     }
-    __syncthreads();
 }
 
 /*

--- a/gpu4pyscf/lib/ecp/common.cu
+++ b/gpu4pyscf/lib/ecp/common.cu
@@ -78,15 +78,15 @@ void cache_fac(double *fx, int LI, double *ri){
     }
 
     const int nfi = (LI1+1)*LI1/2;
-    double *fy = fx + nfi;
-    double *fz = fy + nfi;
     for (int i = 0; i <= LI; i++){
-        const int ioffset = i*(i+1)/2;
+        const int xoffset = i*(i+1)/2;
+        const int yoffset = xoffset + nfi;
+        const int zoffset = yoffset + nfi;
         for (int j = 0; j <= i; j++){
-            const double bfac = _binom[ioffset+j]; // binom(i,j)
-            fx[ioffset+j] = bfac * xx[i-j];
-            fy[ioffset+j] = bfac * yy[i-j];
-            fz[ioffset+j] = bfac * zz[i-j];
+            const double bfac = _binom[xoffset+j]; // binom(i,j)
+            fx[xoffset+j] = bfac * xx[i-j];
+            fx[yoffset+j] = bfac * yy[i-j];
+            fx[zoffset+j] = bfac * zz[i-j];
         }
     }
 }
@@ -103,15 +103,15 @@ void cache_fac(double *fx, double *ri){
     }
 
     constexpr int nfi = (LI1+1)*LI1/2;
-    double *fy = fx + nfi;
-    double *fz = fy + nfi;
     for (int i = 0; i <= LI; i++){
-        const int ioffset = i*(i+1)/2;
+        const int xoffset = i*(i+1)/2;
+        const int yoffset = xoffset + nfi;
+        const int zoffset = yoffset + nfi;
         for (int j = 0; j <= i; j++){
-            const double bfac = _binom[ioffset+j]; // binom(i,j)
-            fx[ioffset+j] = bfac * xx[i-j];
-            fy[ioffset+j] = bfac * yy[i-j];
-            fz[ioffset+j] = bfac * zz[i-j];
+            const double bfac = _binom[xoffset+j]; // binom(i,j)
+            fx[xoffset+j] = bfac * xx[i-j];
+            fx[yoffset+j] = bfac * yy[i-j];
+            fx[zoffset+j] = bfac * zz[i-j];
         }
     }
 }

--- a/gpu4pyscf/lib/ecp/ecp_type1.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1.cu
@@ -127,6 +127,7 @@ void type1_rad_ang(double *rad_ang, const int LIJ, double *r, double *rad_all, c
         rad_ang[i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k] += fac*s;
         //atomicAdd(rad_ang + i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k, fac*s);
     }
+    __syncthreads();
 
     for (int n = threadIdx.x; n < (LIJ+1)*(LIJ+1)*(LIJ+1); n+=blockDim.x){
         const int i = n/(LIJ+1)/(LIJ+1);
@@ -146,6 +147,65 @@ void type1_rad_ang(double *rad_ang, const int LIJ, double *r, double *rad_all, c
         rad_ang[i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k] += fac*s;
         //atomicAdd(rad_ang + i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k, fac*s);
     }
+    __syncthreads();
+}
+
+template <int LIJ> __device__
+void type1_rad_ang(double *rad_ang, double *r, double *rad_all, const double fac)
+{
+    double unitr[3];
+    if (r[0]*r[0] + r[1]*r[1] + r[2]*r[2] < 1e-16){
+        unitr[0] = 0;
+        unitr[1] = 0;
+        unitr[2] = 0;
+    } else {
+        double norm_r = -rnorm3d(r[0], r[1], r[2]);
+        unitr[0] = r[0] * norm_r;
+        unitr[1] = r[1] * norm_r;
+        unitr[2] = r[2] * norm_r;
+    }
+
+    // loop over i+j+k<=LIJ
+    // TODO: find a closed form?
+    for (int n = threadIdx.x; n < (LIJ+1)*(LIJ+1)*(LIJ+1); n+=blockDim.x){
+        const int i = n/(LIJ+1)/(LIJ+1);
+        const int j = n/(LIJ+1)%(LIJ+1);
+        const int k = n%(LIJ+1);
+        if (i+j+k > LIJ || (i+j+k)%2 == 1){
+            continue;
+        }
+        // need_even to ensure (i+j+k+lmb) is even
+        double s = 0.0;
+        double *prad = rad_all + (i+j+k)*(LIJ+1);
+        if constexpr (LIJ >= 0) s += prad[0] * type1_ang_nuc_l<0>(i, j, k, unitr);
+        if constexpr (LIJ >= 2) s += prad[2] * type1_ang_nuc_l<2>(i, j, k, unitr);
+        if constexpr (LIJ >= 4) s += prad[4] * type1_ang_nuc_l<4>(i, j, k, unitr);
+        if constexpr (LIJ >= 6) s += prad[6] * type1_ang_nuc_l<6>(i, j, k, unitr);
+        if constexpr (LIJ >= 8) s += prad[8] * type1_ang_nuc_l<8>(i, j, k, unitr);
+        if constexpr (LIJ >= 10)s += prad[10]* type1_ang_nuc_l<10>(i, j, k, unitr);
+        rad_ang[i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k] += fac*s;
+        //atomicAdd(rad_ang + i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k, fac*s);
+    }
+
+    for (int n = threadIdx.x; n < (LIJ+1)*(LIJ+1)*(LIJ+1); n+=blockDim.x){
+        const int i = n/(LIJ+1)/(LIJ+1);
+        const int j = n/(LIJ+1)%(LIJ+1);
+        const int k = n%(LIJ+1);
+        if (i+j+k > LIJ || (i+j+k)%2 == 0){
+            continue;
+        }
+        // need_even to ensure (i+j+k+lmb) is even
+        double s = 0.0;
+        double *prad = rad_all + (i+j+k)*(LIJ+1);
+        if constexpr (LIJ >= 1) s += prad[1] * type1_ang_nuc_l<1>(i, j, k, unitr);
+        if constexpr (LIJ >= 3) s += prad[3] * type1_ang_nuc_l<3>(i, j, k, unitr);
+        if constexpr (LIJ >= 5) s += prad[5] * type1_ang_nuc_l<5>(i, j, k, unitr);
+        if constexpr (LIJ >= 7) s += prad[7] * type1_ang_nuc_l<7>(i, j, k, unitr);
+        if constexpr (LIJ >= 9) s += prad[9] * type1_ang_nuc_l<9>(i, j, k, unitr);
+        rad_ang[i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k] += fac*s;
+        //atomicAdd(rad_ang + i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k, fac*s);
+    }
+    __syncthreads();
 }
 
 template <int LI, int LJ> __global__
@@ -210,7 +270,8 @@ void type1_cart(double *gctr,
 
             const double eij = exp(-ai[ip]*r2ca - aj[jp]*r2cb);
             const double ceij = eij * ci[ip] * cj[jp];
-            type1_rad_ang(rad_ang, LI+LJ, rij, rad_all, fac*ceij);
+            type1_rad_ang<LI+LJ>(rad_ang, rij, rad_all, fac*ceij);
+            //type1_rad_ang(rad_ang, LI+LJ, rij, rad_all, fac*ceij);
             __syncthreads();
         }
     }
@@ -218,8 +279,8 @@ void type1_cart(double *gctr,
     constexpr int nfi = (LI+1) * (LI+2) / 2;
     constexpr int nfj = (LJ+1) * (LJ+2) / 2;
     double fi[3*nfi];
-    double fj[3*nfj];
     cache_fac(fi, LI, rca);
+    double fj[3*nfj];
     cache_fac(fj, LJ, rcb);
 
     for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
@@ -346,8 +407,8 @@ void type1_cart(double *gctr,
     const int nfj = (LJ+1) * (LJ+2) / 2;
     for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
         double fi[3*NF_MAX];
-        double fj[3*NF_MAX];
         cache_fac(fi, LI, rca);
+        double fj[3*NF_MAX];
         cache_fac(fj, LJ, rcb);
 
         const int mi = ij%nfi;

--- a/gpu4pyscf/lib/ecp/ecp_type1.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1.cu
@@ -145,7 +145,6 @@ void type1_rad_ang(double *rad_ang, const int LIJ, double *r, double *rad_all, c
         rad_ang[i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k] += fac*s;
         //atomicAdd(rad_ang + i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k, fac*s);
     }
-    __syncthreads();
 }
 
 template <int LIJ> __device__

--- a/gpu4pyscf/lib/ecp/ecp_type1.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1.cu
@@ -50,7 +50,6 @@ void type1_rad_part(double* __restrict__ rad_all, const int LIJ, double k, doubl
             block_reduce(rur*bval[i], rad_all+lab*LIJ1+i);
         }
     }
-    __syncthreads();
 }
 /*
 template <int l> __device__
@@ -204,7 +203,6 @@ void type1_rad_ang(double *rad_ang, double *r, double *rad_all, const double fac
         rad_ang[i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k] += fac*s;
         //atomicAdd(rad_ang + i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k, fac*s);
     }
-    __syncthreads();
 }
 
 template <int LI, int LJ> __global__
@@ -266,6 +264,7 @@ void type1_cart(double *gctr,
 
             __shared__ double rad_all[LIJ1*LIJ1];
             type1_rad_part(rad_all, LI+LJ, k, aij, ur);
+            __syncthreads();
 
             const double eij = exp(-ai[ip]*r2ca - aj[jp]*r2cb);
             const double ceij = eij * ci[ip] * cj[jp];
@@ -389,6 +388,7 @@ void type1_cart(double *gctr,
             const double k = 2.0 * norm3d(rij[0], rij[1], rij[2]);
             const double aij = ai_prim + aj_prim;
             type1_rad_part(rad_all, LI+LJ, k, aij, ur);
+            __syncthreads();
 
             const double eij = exp(-ai_prim*r2ca - aj_prim*r2cb);
             const double ceij = eij * ci[ip] * cj[jp];

--- a/gpu4pyscf/lib/ecp/ecp_type1.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1.cu
@@ -127,7 +127,6 @@ void type1_rad_ang(double *rad_ang, const int LIJ, double *r, double *rad_all, c
         rad_ang[i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k] += fac*s;
         //atomicAdd(rad_ang + i*(LIJ+1)*(LIJ+1) + j*(LIJ+1) + k, fac*s);
     }
-    __syncthreads();
 
     for (int n = threadIdx.x; n < (LIJ+1)*(LIJ+1)*(LIJ+1); n+=blockDim.x){
         const int i = n/(LIJ+1)/(LIJ+1);
@@ -279,9 +278,9 @@ void type1_cart(double *gctr,
     constexpr int nfi = (LI+1) * (LI+2) / 2;
     constexpr int nfj = (LJ+1) * (LJ+2) / 2;
     double fi[3*nfi];
-    cache_fac(fi, LI, rca);
+    cache_fac<LI>(fi, rca);
     double fj[3*nfj];
-    cache_fac(fj, LJ, rcb);
+    cache_fac<LJ>(fj, rcb);
 
     for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
         const int mi = ij%nfi;
@@ -307,11 +306,11 @@ void type1_cart(double *gctr,
         for (int i1 = 0; i1 <= ix; i1++){
         for (int i2 = 0; i2 <= iy; i2++){
         for (int i3 = 0; i3 <= iz; i3++){
-            double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
+            const double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
             for (int j1 = 0; j1 <= jx; j1++){
             for (int j2 = 0; j2 <= jy; j2++){
             for (int j3 = 0; j3 <= jz; j3++){
-                double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
+                const double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
                 const int ijr = (i1+j1)*LIJ1*LIJ1 + (i2+j2)*LIJ1 + (i3+j3);
                 tmp += ifac * jfac * rad_ang[ijr];
             }}}

--- a/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
@@ -77,12 +77,12 @@ void type1_cart_unrolled_kernel(double *gctr,
         }
     }
 
-    constexpr int NFI_MAX = (LI+orderi+1)*(LI+orderi+2)/2;
-    constexpr int NFJ_MAX = (LJ+orderj+1)*(LJ+orderj+2)/2;
-    double fi[3*NFI_MAX];
-    cache_fac(fi, LI, rca);
-    double fj[3*NFJ_MAX];
-    cache_fac(fj, LJ, rcb);
+    constexpr int NFI = (LI+1)*(LI+2)/2;
+    constexpr int NFJ = (LJ+1)*(LJ+2)/2;
+    double fi[3*NFI];
+    cache_fac<LI>(fi, rca);
+    double fj[3*NFJ];
+    cache_fac<LJ>(fj, rcb);
 
     constexpr int nfi = (LI+1) * (LI+2) / 2;
     constexpr int nfj = (LJ+1) * (LJ+2) / 2;
@@ -110,11 +110,11 @@ void type1_cart_unrolled_kernel(double *gctr,
         for (int i1 = 0; i1 <= ix; i1++){
         for (int i2 = 0; i2 <= iy; i2++){
         for (int i3 = 0; i3 <= iz; i3++){
-            double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
+            const double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
             for (int j1 = 0; j1 <= jx; j1++){
             for (int j2 = 0; j2 <= jy; j2++){
             for (int j3 = 0; j3 <= jz; j3++){
-                double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
+                const double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
                 const int ijr = (i1+j1)*LIJ1*LIJ1 + (i2+j2)*LIJ1 + (i3+j3);
                 tmp += ifac * jfac * rad_ang[ijr];
             }}}
@@ -175,8 +175,8 @@ void type1_cart_kernel(double *gctr,
     for (int ip = 0; ip < npi; ip++){
         for (int jp = 0; jp < npj; jp++){
             double rij[3];
-            double ai_prim = ai[ip];
-            double aj_prim = aj[jp];
+            const double ai_prim = ai[ip];
+            const double aj_prim = aj[jp];
             rij[0] = ai_prim * rca[0] + aj_prim * rcb[0];
             rij[1] = ai_prim * rca[1] + aj_prim * rcb[1];
             rij[2] = ai_prim * rca[2] + aj_prim * rcb[2];
@@ -225,11 +225,11 @@ void type1_cart_kernel(double *gctr,
         for (int i1 = 0; i1 <= ix; i1++){
         for (int i2 = 0; i2 <= iy; i2++){
         for (int i3 = 0; i3 <= iz; i3++){
-            double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
+            const double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
             for (int j1 = 0; j1 <= jx; j1++){
             for (int j2 = 0; j2 <= jy; j2++){
             for (int j3 = 0; j3 <= jz; j3++){
-                double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
+                const double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
                 const int ijr = (i1+j1)*LIJ1*LIJ1 + (i2+j2)*LIJ1 + (i3+j3);
                 tmp += ifac * jfac * rad_ang[ijr];
             }}}
@@ -275,7 +275,6 @@ void type1_cart_ip1(double *gctr,
         buf, ish, jsh, ksh, 
         ecpbas, ecploc, 
         atm, bas, env);
-    __syncthreads();
     _li_down(gctr_smem, buf, LI, LJ);
 
     if constexpr (LI > 0){
@@ -283,7 +282,6 @@ void type1_cart_ip1(double *gctr,
             buf, ish, jsh, ksh, 
             ecpbas, ecploc, 
             atm, bas, env);
-        __syncthreads();
         _li_up(gctr_smem, buf, LI, LJ);
     }
 

--- a/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
@@ -94,28 +94,27 @@ void type1_cart_unrolled_kernel(double *gctr,
         const int iy = _cart_pow_y[mi];
         const int iz = _cart_pow_z[mi];
         const int ix = LI - iy - iz;
-
-        double* fx_i = fi + (ix+1)*ix/2;
-        double* fy_i = fi + (iy+1)*iy/2 + nfi;
-        double* fz_i = fi + (iz+1)*iz/2 + 2*nfi;
+        const int ix_off = (ix+1)*ix/2;
+        const int iy_off = (iy+1)*iy/2 + nfi;
+        const int iz_off = (iz+1)*iz/2 + 2*nfi;
 
         const int jy = _cart_pow_y[mj];
         const int jz = _cart_pow_z[mj];
         const int jx = LJ - jy - jz;
-        double* fx_j = fj + (jx+1)*jx/2;
-        double* fy_j = fj + (jy+1)*jy/2 + nfj;
-        double* fz_j = fj + (jz+1)*jz/2 + 2*nfj;
+        const int jx_off = (jx+1)*jx/2;
+        const int jy_off = (jy+1)*jy/2 + nfj;
+        const int jz_off = (jz+1)*jz/2 + 2*nfj;
 
         // cache ifac and jfac in register
         double tmp = 0.0;
         for (int i1 = 0; i1 <= ix; i1++){
         for (int i2 = 0; i2 <= iy; i2++){
         for (int i3 = 0; i3 <= iz; i3++){
-            const double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
+            const double ifac = fi[i1+ix_off] * fi[i2+iy_off] * fi[i3+iz_off];
             for (int j1 = 0; j1 <= jx; j1++){
             for (int j2 = 0; j2 <= jy; j2++){
             for (int j3 = 0; j3 <= jz; j3++){
-                const double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
+                const double jfac = fj[j1+jx_off] * fj[j2+jy_off] * fj[j3+jz_off];
                 const int ijr = (i1+j1)*LIJ1*LIJ1 + (i2+j2)*LIJ1 + (i3+j3);
                 tmp += ifac * jfac * rad_ang[ijr];
             }}}
@@ -123,7 +122,6 @@ void type1_cart_unrolled_kernel(double *gctr,
         gctr[ij] = tmp;
     }
 }
-
 
 template <int orderi, int orderj> __device__
 void type1_cart_kernel(double *gctr,
@@ -209,28 +207,27 @@ void type1_cart_kernel(double *gctr,
         const int iy = _cart_pow_y[mi];
         const int iz = _cart_pow_z[mi];
         const int ix = LI - iy - iz;
-
-        double* fx_i = fi + (ix+1)*ix/2;
-        double* fy_i = fi + (iy+1)*iy/2 + nfi;
-        double* fz_i = fi + (iz+1)*iz/2 + 2*nfi;
+        const int ix_off = (ix+1)*ix/2;
+        const int iy_off = (iy+1)*iy/2 + nfi;
+        const int iz_off = (iz+1)*iz/2 + 2*nfi;
 
         const int jy = _cart_pow_y[mj];
         const int jz = _cart_pow_z[mj];
         const int jx = LJ - jy - jz;
-        double* fx_j = fj + (jx+1)*jx/2;
-        double* fy_j = fj + (jy+1)*jy/2 + nfj;
-        double* fz_j = fj + (jz+1)*jz/2 + 2*nfj;
+        const int jx_off = (jx+1)*jx/2;
+        const int jy_off = (jy+1)*jy/2 + nfj;
+        const int jz_off = (jz+1)*jz/2 + 2*nfj;
 
         // cache ifac and jfac in register
         double tmp = 0.0;
         for (int i1 = 0; i1 <= ix; i1++){
         for (int i2 = 0; i2 <= iy; i2++){
         for (int i3 = 0; i3 <= iz; i3++){
-            const double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
+            const double ifac = fi[i1+ix_off] * fi[i2+iy_off] * fi[i3+iz_off];
             for (int j1 = 0; j1 <= jx; j1++){
             for (int j2 = 0; j2 <= jy; j2++){
             for (int j3 = 0; j3 <= jz; j3++){
-                const double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
+                const double jfac = fj[j1+jx_off] * fj[j2+jy_off] * fj[j3+jz_off];
                 const int ijr = (i1+j1)*LIJ1*LIJ1 + (i2+j2)*LIJ1 + (i3+j3);
                 tmp += ifac * jfac * rad_ang[ijr];
             }}}

--- a/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
@@ -14,6 +14,116 @@
  * limitations under the License.
  */
 
+template <int orderi, int orderj, int LI, int LJ> __device__
+void type1_cart_unrolled_kernel(double *gctr,
+                const int ish, const int jsh, const int ksh,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const int npi = bas[NPRIM_OF+ish*BAS_SLOTS];
+    const int npj = bas[NPRIM_OF+jsh*BAS_SLOTS];
+    const double *ai = env + bas[PTR_EXP+ish*BAS_SLOTS];
+    const double *aj = env + bas[PTR_EXP+jsh*BAS_SLOTS];
+    const double *ci = env + bas[PTR_COEFF+ish*BAS_SLOTS];
+    const double *cj = env + bas[PTR_COEFF+jsh*BAS_SLOTS];
+    const double *ri = env + atm[PTR_COORD+bas[ATOM_OF+ish*BAS_SLOTS]*ATM_SLOTS];
+    const double *rj = env + atm[PTR_COORD+bas[ATOM_OF+jsh*BAS_SLOTS]*ATM_SLOTS];
+
+    const int atm_id = ecpbas[ATOM_OF+ecploc[ksh]*BAS_SLOTS];
+    const double *rc = env + atm[PTR_COORD+atm_id*ATM_SLOTS];
+
+    double rca[3], rcb[3];
+    rca[0] = rc[0] - ri[0];
+    rca[1] = rc[1] - ri[1];
+    rca[2] = rc[2] - ri[2];
+    rcb[0] = rc[0] - rj[0];
+    rcb[1] = rc[1] - rj[1];
+    rcb[2] = rc[2] - rj[2];
+    const double r2ca = rca[0]*rca[0] + rca[1]*rca[1] + rca[2]*rca[2];
+    const double r2cb = rcb[0]*rcb[0] + rcb[1]*rcb[1] + rcb[2]*rcb[2];
+
+    double ur = 0.0;
+    for (int kbas = ecploc[ksh]; kbas < ecploc[ksh+1]; kbas++){
+        ur += rad_part(kbas, ecpbas, env);
+    }
+
+    constexpr int LIJ1 = LI+LJ+1;
+    constexpr int LIJ3 = LIJ1*LIJ1*LIJ1;
+
+    __shared__ double rad_ang[LIJ3];
+    set_shared_memory(rad_ang, LIJ3);
+
+    const double fac = 16.0 * M_PI * M_PI * _common_fac[LI] * _common_fac[LJ];
+    for (int ip = 0; ip < npi; ip++){
+        for (int jp = 0; jp < npj; jp++){
+            double rij[3];
+            double ai_prim = ai[ip];
+            double aj_prim = aj[jp];
+            rij[0] = ai_prim * rca[0] + aj_prim * rcb[0];
+            rij[1] = ai_prim * rca[1] + aj_prim * rcb[1];
+            rij[2] = ai_prim * rca[2] + aj_prim * rcb[2];
+            const double k = 2.0 * norm3d(rij[0], rij[1], rij[2]);
+            const double aij = ai_prim + aj_prim;
+            
+            __shared__ double rad_all[LIJ1*LIJ1];
+            type1_rad_part(rad_all, LI+LJ, k, aij, ur);
+
+            const double eij = exp(-ai_prim*r2ca - aj_prim*r2cb);
+            const double eaij = eij * pow(-2.0*ai_prim, orderi) * pow(-2.0*aj_prim, orderj);
+            const double ceij = eaij * ci[ip] * cj[jp];
+            type1_rad_ang<LI+LJ>(rad_ang, rij, rad_all, fac*ceij);
+            //type1_rad_ang(rad_ang, LI+LJ, rij, rad_all, fac*ceij);
+            __syncthreads();
+        }
+    }
+
+    constexpr int NFI_MAX = (LI+orderi+1)*(LI+orderi+2)/2;
+    constexpr int NFJ_MAX = (LJ+orderj+1)*(LJ+orderj+2)/2;
+    double fi[3*NFI_MAX];
+    cache_fac(fi, LI, rca);
+    double fj[3*NFJ_MAX];
+    cache_fac(fj, LJ, rcb);
+
+    constexpr int nfi = (LI+1) * (LI+2) / 2;
+    constexpr int nfj = (LJ+1) * (LJ+2) / 2;
+    for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
+        const int mi = ij%nfi;
+        const int mj = ij/nfi;
+
+        const int iy = _cart_pow_y[mi];
+        const int iz = _cart_pow_z[mi];
+        const int ix = LI - iy - iz;
+
+        double* fx_i = fi + (ix+1)*ix/2;
+        double* fy_i = fi + (iy+1)*iy/2 + nfi;
+        double* fz_i = fi + (iz+1)*iz/2 + 2*nfi;
+
+        const int jy = _cart_pow_y[mj];
+        const int jz = _cart_pow_z[mj];
+        const int jx = LJ - jy - jz;
+        double* fx_j = fj + (jx+1)*jx/2;
+        double* fy_j = fj + (jy+1)*jy/2 + nfj;
+        double* fz_j = fj + (jz+1)*jz/2 + 2*nfj;
+
+        // cache ifac and jfac in register
+        double tmp = 0.0;
+        for (int i1 = 0; i1 <= ix; i1++){
+        for (int i2 = 0; i2 <= iy; i2++){
+        for (int i3 = 0; i3 <= iz; i3++){
+            double ifac = fx_i[i1] * fy_i[i2] * fz_i[i3];
+            for (int j1 = 0; j1 <= jx; j1++){
+            for (int j2 = 0; j2 <= jy; j2++){
+            for (int j3 = 0; j3 <= jz; j3++){
+                double jfac = fx_j[j1] * fy_j[j2] * fz_j[j3];
+                const int ijr = (i1+j1)*LIJ1*LIJ1 + (i2+j2)*LIJ1 + (i3+j3);
+                tmp += ifac * jfac * rad_ang[ijr];
+            }}}
+        }}}
+        gctr[ij] = tmp;
+    }
+    return;
+}
+
 
 template <int orderi, int orderj> __device__
 void type1_cart_kernel(double *gctr,
@@ -85,8 +195,8 @@ void type1_cart_kernel(double *gctr,
     constexpr int NFI_MAX = (AO_LMAX+orderi+1)*(AO_LMAX+orderi+2)/2;
     constexpr int NFJ_MAX = (AO_LMAX+orderj+1)*(AO_LMAX+orderj+2)/2;
     double fi[3*NFI_MAX];
-    double fj[3*NFJ_MAX];
     cache_fac(fi, LI, rca);
+    double fj[3*NFJ_MAX];
     cache_fac(fj, LJ, rcb);
 
     const int nfi = (LI+1) * (LI+2) / 2;
@@ -129,9 +239,69 @@ void type1_cart_kernel(double *gctr,
     return;
 }
 
+// Unrolling case
+template <int LI, int LJ> __global__
+void type1_cart_ip1(double *gctr,
+                const int *ao_loc, const int nao,
+                const int *tasks, const int ntasks,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const int task_id = blockIdx.x;
+    if (task_id >= ntasks){
+        return;
+    }
+
+    const int ish = tasks[task_id];
+    const int jsh = tasks[task_id + ntasks];
+    const int ksh = tasks[task_id + 2*ntasks];
+    const int ioff = ao_loc[ish];
+    const int joff = ao_loc[jsh];
+    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
+    gctr += 3*ecp_id*nao*nao + ioff*nao + joff;
+
+    constexpr int nfi = (LI+1) * (LI+2) / 2;
+    constexpr int nfj = (LJ+1) * (LJ+2) / 2;
+    __shared__ double gctr_smem[nfi*nfj*3];
+    for (int ij = threadIdx.x; ij < nfi*nfj*3; ij+=blockDim.x){
+        gctr_smem[ij] = 0.0;
+    }
+    __syncthreads();
+
+    constexpr int nfi1 = (LI+2)*(LI+3)/2;
+    __shared__ double buf[nfi1*nfj];
+
+    type1_cart_unrolled_kernel<1,0,LI+1,LJ>(
+        buf, ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+    _li_down(gctr_smem, buf, LI, LJ);
+
+    if constexpr (LI > 0){
+        type1_cart_unrolled_kernel<0,0,LI-1,LJ>(
+            buf, ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
+        __syncthreads();
+        _li_up(gctr_smem, buf, LI, LJ);
+    }
+
+    for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
+        const int i = ij%nfi;
+        const int j = ij/nfi;
+        double *gx = gctr;
+        double *gy = gctr +   nao*nao;
+        double *gz = gctr + 2*nao*nao;
+        atomicAdd(gx+i*nao+j, gctr_smem[ij]);
+        atomicAdd(gy+i*nao+j, gctr_smem[ij+nfi*nfj]);
+        atomicAdd(gz+i*nao+j, gctr_smem[ij+2*nfi*nfj]);
+    }
+    return;
+}
 
 __global__
-void type1_cart_ip1(double *gctr,
+void type1_cart_ip1_general(double *gctr,
                 const int LI, const int LJ,
                 const int *ao_loc, const int nao,
                 const int *tasks, const int ntasks,
@@ -161,12 +331,20 @@ void type1_cart_ip1(double *gctr,
     constexpr int nfj_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
     __shared__ double buf[nfi_max*nfj_max];
 
-    type1_cart_kernel<1,0>(buf, LI+1, LJ, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
+    type1_cart_kernel<1,0>(
+        buf, LI+1, LJ, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
     __syncthreads();
     _li_down(gctr_smem, buf, LI, LJ);
 
     if (LI > 0){
-        type1_cart_kernel<0,0>(buf, LI-1, LJ, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
+        type1_cart_kernel<0,0>(
+            buf, LI-1, LJ, 
+            ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
         __syncthreads();
         _li_up(gctr_smem, buf, LI, LJ);
     }
@@ -182,123 +360,6 @@ void type1_cart_ip1(double *gctr,
         atomicAdd(gx+i*nao+j, gctr_smem[ij]);
         atomicAdd(gy+i*nao+j, gctr_smem[ij+nfi*nfj]);
         atomicAdd(gz+i*nao+j, gctr_smem[ij+2*nfi*nfj]);
-    }
-    return;
-}
-
-__global__
-void type1_cart_ipipv(double *gctr,
-                const int LI, const int LJ,
-                const int *ao_loc, const int nao,
-                const int *tasks, const int ntasks,
-                const int *ecpbas, const int *ecploc,
-                const int *atm, const int *bas, const double *env)
-{
-    const int task_id = blockIdx.x;
-    if (task_id >= ntasks){
-        return;
-    }
-
-    const int ish = tasks[task_id];
-    const int jsh = tasks[task_id + ntasks];
-    const int ksh = tasks[task_id + 2*ntasks];
-
-    const int ioff = ao_loc[ish];
-    const int joff = ao_loc[jsh];
-    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
-    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
-
-    constexpr int nfi2_max = (AO_LMAX+3)*(AO_LMAX+4)/2;
-    constexpr int nfj_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
-    __shared__ double buf1[nfi2_max*nfj_max];
-    type1_cart_kernel<2,0>(buf1, LI+2, LJ, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-    __syncthreads();
-
-    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
-    __shared__ double buf[3*nfi1_max*nfj_max];
-    for (int i = threadIdx.x; i < 3*nfi1_max*nfj_max; i+=blockDim.x){
-        buf[i] = 0.0;
-    }
-    __syncthreads();
-    _li_down(buf, buf1, LI+1, LJ);
-
-    type1_cart_kernel<1,0>(buf1, LI, LJ, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-    __syncthreads();
-    _li_up(buf, buf1, LI+1, LJ);
-    _li_down_and_write(gctr, buf, LI, LJ, nao);
-
-    if (LI > 0){
-        for (int i = threadIdx.x; i < 3*nfi1_max*nfj_max; i+=blockDim.x){
-            buf[i] = 0.0;
-        }
-        __syncthreads();
-        _li_down(buf, buf1, LI-1, LJ);
-        if (LI > 1){
-            type1_cart_kernel<0,0>(buf1, LI-2, LJ, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-            __syncthreads();
-            _li_up(buf, buf1, LI-1, LJ);
-        }
-        _li_up_and_write(gctr, buf, LI, LJ, nao);
-    }
-    return;
-}
-
-__global__
-void type1_cart_ipvip(double *gctr,
-                const int LI, const int LJ,
-                const int *ao_loc, const int nao,
-                const int *tasks, const int ntasks,
-                const int *ecpbas, const int *ecploc,
-                const int *atm, const int *bas, const double *env)
-{
-    const int task_id = blockIdx.x;
-    if (task_id >= ntasks){
-        return;
-    }
-
-    const int ish = tasks[task_id];
-    const int jsh = tasks[task_id + ntasks];
-    const int ksh = tasks[task_id + 2*ntasks];
-
-    const int ioff = ao_loc[ish];
-    const int joff = ao_loc[jsh];
-    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
-    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
-
-    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
-    constexpr int nfj1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
-    __shared__ double buf1[nfi1_max*nfj1_max];
-    type1_cart_kernel<1,1>(buf1, LI+1, LJ+1, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-    __syncthreads();
-
-    constexpr int nfi_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
-    __shared__ double buf[3*nfi_max*nfj1_max];
-    for (int i = threadIdx.x; i < 3*nfi_max*nfj1_max; i+=blockDim.x){
-        buf[i] = 0.0;
-    }
-    __syncthreads();
-    _li_down(buf, buf1, LI, LJ+1);
-    if (LI > 0){
-        type1_cart_kernel<0,1>(buf1, LI-1, LJ+1, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-        __syncthreads();
-        _li_up(buf, buf1, LI, LJ+1);
-    }
-    _lj_down_and_write(gctr, buf, LI, LJ, nao);
-
-    if (LJ > 0){
-        for (int i = threadIdx.x; i < 3*nfi_max*nfj1_max; i+=blockDim.x){
-            buf[i] = 0.0;
-        }
-        __syncthreads();
-        type1_cart_kernel<1,0>(buf1, LI+1, LJ-1, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-        __syncthreads();
-        _li_down(buf, buf1, LI, LJ-1);
-        if (LI > 0){
-            type1_cart_kernel<0,0>(buf1, LI-1, LJ-1, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-            __syncthreads();
-            _li_up(buf, buf1, LI, LJ-1);
-        }
-        _lj_up_and_write(gctr, buf, LI, LJ, nao);
     }
     return;
 }

--- a/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1_ip.cu
@@ -183,6 +183,7 @@ void type1_cart_kernel(double *gctr,
             const double k = 2.0 * norm3d(rij[0], rij[1], rij[2]);
             const double aij = ai_prim + aj_prim;
             type1_rad_part(rad_all, LI+LJ, k, aij, ur);
+            __syncthreads();
 
             const double eij = exp(-ai_prim*r2ca - aj_prim*r2cb);
             const double eaij = eij * pow(-2.0*ai_prim, orderi) * pow(-2.0*aj_prim, orderj);
@@ -236,7 +237,6 @@ void type1_cart_kernel(double *gctr,
         }}}
         gctr[ij] = tmp;
     }
-    return;
 }
 
 // Unrolling case
@@ -284,6 +284,7 @@ void type1_cart_ip1(double *gctr,
             buf, ish, jsh, ksh,
             ecpbas, ecploc,
             atm, bas, env);
+        __syncthreads();
         _li_up(gctr_smem, buf, LI, LJ);
         __syncthreads();
     }

--- a/gpu4pyscf/lib/ecp/ecp_type1_ipip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type1_ipip.cu
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021-2025 The PySCF Developers. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+__global__
+void type1_cart_ipipv(double *gctr,
+                const int LI, const int LJ,
+                const int *ao_loc, const int nao,
+                const int *tasks, const int ntasks,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const int task_id = blockIdx.x;
+    if (task_id >= ntasks){
+        return;
+    }
+
+    const int ish = tasks[task_id];
+    const int jsh = tasks[task_id + ntasks];
+    const int ksh = tasks[task_id + 2*ntasks];
+
+    const int ioff = ao_loc[ish];
+    const int joff = ao_loc[jsh];
+    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
+    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
+
+    constexpr int nfi2_max = (AO_LMAX+3)*(AO_LMAX+4)/2;
+    constexpr int nfj_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
+    __shared__ double buf1[nfi2_max*nfj_max];
+    type1_cart_kernel<2,0>(
+        buf1, LI+2, LJ, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+
+    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
+    __shared__ double buf[3*nfi1_max*nfj_max];
+    for (int i = threadIdx.x; i < 3*nfi1_max*nfj_max; i+=blockDim.x){
+        buf[i] = 0.0;
+    }
+    __syncthreads();
+    _li_down(buf, buf1, LI+1, LJ);
+
+    type1_cart_kernel<1,0>(
+        buf1, LI, LJ, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+    _li_up(buf, buf1, LI+1, LJ);
+    _li_down_and_write(gctr, buf, LI, LJ, nao);
+
+    if (LI > 0){
+        for (int i = threadIdx.x; i < 3*nfi1_max*nfj_max; i+=blockDim.x){
+            buf[i] = 0.0;
+        }
+        __syncthreads();
+        _li_down(buf, buf1, LI-1, LJ);
+        if (LI > 1){
+            type1_cart_kernel<0,0>(
+                buf1, LI-2, LJ, 
+                ish, jsh, ksh, 
+                ecpbas, ecploc, 
+                atm, bas, env);
+            __syncthreads();
+            _li_up(buf, buf1, LI-1, LJ);
+        }
+        _li_up_and_write(gctr, buf, LI, LJ, nao);
+    }
+    return;
+}
+
+__global__
+void type1_cart_ipvip(double *gctr,
+                const int LI, const int LJ,
+                const int *ao_loc, const int nao,
+                const int *tasks, const int ntasks,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const int task_id = blockIdx.x;
+    if (task_id >= ntasks){
+        return;
+    }
+
+    const int ish = tasks[task_id];
+    const int jsh = tasks[task_id + ntasks];
+    const int ksh = tasks[task_id + 2*ntasks];
+
+    const int ioff = ao_loc[ish];
+    const int joff = ao_loc[jsh];
+    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
+    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
+
+    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
+    constexpr int nfj1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
+    __shared__ double buf1[nfi1_max*nfj1_max];
+    type1_cart_kernel<1,1>(
+        buf1, LI+1, LJ+1, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+
+    constexpr int nfi_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
+    __shared__ double buf[3*nfi_max*nfj1_max];
+    for (int i = threadIdx.x; i < 3*nfi_max*nfj1_max; i+=blockDim.x){
+        buf[i] = 0.0;
+    }
+    __syncthreads();
+    _li_down(buf, buf1, LI, LJ+1);
+    if (LI > 0){
+        type1_cart_kernel<0,1>(
+            buf1, LI-1, LJ+1, 
+            ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
+        __syncthreads();
+        _li_up(buf, buf1, LI, LJ+1);
+    }
+    _lj_down_and_write(gctr, buf, LI, LJ, nao);
+
+    if (LJ > 0){
+        for (int i = threadIdx.x; i < 3*nfi_max*nfj1_max; i+=blockDim.x){
+            buf[i] = 0.0;
+        }
+        __syncthreads();
+        type1_cart_kernel<1,0>(
+            buf1, LI+1, LJ-1, 
+            ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
+        __syncthreads();
+        _li_down(buf, buf1, LI, LJ-1);
+        if (LI > 0){
+            type1_cart_kernel<0,0>(
+                buf1, LI-1, LJ-1, 
+                ish, jsh, ksh, 
+                ecpbas, ecploc, 
+                atm, bas, env);
+            __syncthreads();
+            _li_up(buf, buf1, LI, LJ-1);
+        }
+        _lj_up_and_write(gctr, buf, LI, LJ, nao);
+    }
+    return;
+}

--- a/gpu4pyscf/lib/ecp/ecp_type2.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2.cu
@@ -173,7 +173,6 @@ void type2_facs_omega(double* __restrict__ omega, double *r){
         if constexpr (LI+LC >= 7)  {type2_ang_nuc_l<7>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
         if constexpr (LI+LC >= 9)  {type2_ang_nuc_l<9>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
     }
-    __syncthreads();
 }
 
 
@@ -238,7 +237,7 @@ void type2_ang(double * __restrict__ facs, double *rca, double *omega){
 
     constexpr int NF = (LI+1)*(LI+2)/2;
     double fi[NF*3];
-    cache_fac(fi, LI, rca);
+    cache_fac<LI>(fi, rca);
 
     // i,j,k,ijkmn->(i+j+k)pmn
     for (int pmn = threadIdx.x; pmn < nfi*LIC1; pmn+=blockDim.x){
@@ -357,7 +356,6 @@ void type2_cart(double * __restrict__ gctr,
         double *prad = rad_all + p*LIC1*LJC1;
         for (int i = 0; i <= LI+LC; i++){
         for (int j = 0; j <= LJ+LC; j++){
-            __syncthreads();
             block_reduce(radi[i]*radj[j]*ur, prad+i*LJC1+j);
         }}
         ur *= root;

--- a/gpu4pyscf/lib/ecp/ecp_type2.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2.cu
@@ -197,9 +197,9 @@ void type2_ang(double * __restrict__ facs, const int LI, const int LC, double *r
         const int iz = _cart_pow_z[p];
         const int ix = LI - iy - iz;
 
-        double *fx = fi + (ix+1)*ix/2;
-        double *fy = fi + (iy+1)*iy/2 + nfi;
-        double *fz = fi + (iz+1)*iz/2 + nfi*2;
+        const int ix_off = (ix+1)*ix/2;
+        const int iy_off = (iy+1)*iy/2 + nfi;
+        const int iz_off = (iz+1)*iz/2 + nfi*2;
 
         double ang_pmn[AO_LMAX_IP+1];
         for (int i = 0; i < AO_LMAX_IP+1; i++){
@@ -210,7 +210,7 @@ void type2_ang(double * __restrict__ facs, const int LI, const int LC, double *r
         for (int j = 0; j <= iy; j++){
         for (int k = 0; k <= iz; k++){
             const int ijk = i+j+k;
-            const double fac = fx[i] * fy[j] * fz[k];
+            const double fac = fi[i+ix_off] * fi[j+iy_off] * fi[k+iz_off];
             const int LI_i = LI-i;
             const int ioff = (LI_i)*(LI_i+1)*(LI_i+2)/6;
             const int joff = (LI_i-j)*(LI_i-j+1)/2;
@@ -247,9 +247,9 @@ void type2_ang(double * __restrict__ facs, double *rca, double *omega){
         const int iz = _cart_pow_z[p];
         const int ix = LI - iy - iz;
 
-        double *fx = fi + (ix+1)*ix/2;
-        double *fy = fi + (iy+1)*iy/2 + nfi;
-        double *fz = fi + (iz+1)*iz/2 + nfi*2;
+        const int ix_off = (ix+1)*ix/2;
+        const int iy_off = (iy+1)*iy/2 + nfi;
+        const int iz_off = (iz+1)*iz/2 + nfi*2;
 
         double ang_pmn[LI+1];
         for (int i = 0; i < LI+1; i++){
@@ -260,7 +260,7 @@ void type2_ang(double * __restrict__ facs, double *rca, double *omega){
         for (int j = 0; j <= iy; j++){
         for (int k = 0; k <= iz; k++){
             const int ijk = i+j+k;
-            const double fac = fx[i] * fy[j] * fz[k];
+            const double fac = fi[i+ix_off] * fi[j+iy_off] * fi[k+iz_off];
             const int LI_i = LI-i;
             const int ioff = (LI_i)*(LI_i+1)*(LI_i+2)/6;
             const int joff = (LI_i-j)*(LI_i-j+1)/2;

--- a/gpu4pyscf/lib/ecp/ecp_type2.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2.cu
@@ -30,7 +30,7 @@ void type2_facs_rad(double* facs, const int LIC, const int np, const double rca,
     for (int ip = 0; ip < np; ip++){
         const double ka = 2.0 * ai[ip] * rca;
         const double ar2 = ai[ip] * r2;
-        
+
         double buf[AO_LMAX+ECP_LMAX+order+1];
         if (ar2 > EXPCUTOFF + 6.0){
             for (int j = 0; j <= LIC; j++){
@@ -205,7 +205,7 @@ void type2_ang(double * __restrict__ facs, const int LI, const int LC, double *r
         for (int i = 0; i < AO_LMAX_IP+1; i++){
             ang_pmn[i] = 0.0;
         }
-        
+
         for (int i = 0; i <= ix; i++){
         for (int j = 0; j <= iy; j++){
         for (int k = 0; k <= iz; k++){
@@ -224,7 +224,6 @@ void type2_ang(double * __restrict__ facs, const int LI, const int LC, double *r
             facs[i*nfi*LIC1 + p*LIC1 + m] = ang_pmn[i];
         }
     }
-    __syncthreads();
 }
 
 template <int LI, int LC> __device__
@@ -256,7 +255,7 @@ void type2_ang(double * __restrict__ facs, double *rca, double *omega){
         for (int i = 0; i < LI+1; i++){
             ang_pmn[i] = 0.0;
         }
-        
+
         for (int i = 0; i <= ix; i++){
         for (int j = 0; j <= iy; j++){
         for (int k = 0; k <= iz; k++){
@@ -275,7 +274,6 @@ void type2_ang(double * __restrict__ facs, double *rca, double *omega){
             facs[i*nfi*LIC1 + p*LIC1 + m] = ang_pmn[i];
         }
     }
-    __syncthreads();
 }
 
 template <int LI, int LJ, int LC> __global__
@@ -334,7 +332,7 @@ void type2_cart(double * __restrict__ gctr,
     const double dca = norm3d(rca[0], rca[1], rca[2]);
     double radi[LIC1];
     type2_facs_rad<0>(radi, LI+LC, npi, dca, ci, ai);
-    
+
     const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
     double radj[LJC1];
     type2_facs_rad<0>(radj, LJ+LC, npj, dcb, cj, aj);
@@ -347,7 +345,7 @@ void type2_cart(double * __restrict__ gctr,
     for (int kbas = ecploc[ksh]; kbas < ecploc[ksh+1]; kbas++){
         ur += rad_part(kbas, ecpbas, env);
     }
-    
+
     double root = 0.0;
     if (threadIdx.x < NGAUSS){
         root = r128[threadIdx.x];
@@ -474,7 +472,7 @@ void type2_cart(double * __restrict__ gctr,
     double radi[AO_LMAX+ECP_LMAX+1];
     const double dca = norm3d(rca[0], rca[1], rca[2]);
     type2_facs_rad<0>(radi, LI+LC, npi, dca, ci, ai);
-    
+
     double radj[AO_LMAX+ECP_LMAX+1];
     const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
     type2_facs_rad<0>(radj, LJ+LC, npj, dcb, cj, aj);
@@ -512,7 +510,7 @@ void type2_cart(double * __restrict__ gctr,
         type2_ang(angi, LI, LC, rca, omegai+m);
         type2_ang(angj, LJ, LC, rcb, omegaj+m);
         __syncthreads();
-        
+
         for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
             const int i = ij%nfi;
             const int j = ij/nfi;
@@ -537,7 +535,7 @@ void type2_cart(double * __restrict__ gctr,
         }
         __syncthreads();
     }
-    
+
     const int ioff = ao_loc[ish];
     const int joff = ao_loc[jsh];
     double *gctr_ij = gctr + ioff + joff*nao;
@@ -551,6 +549,6 @@ void type2_cart(double * __restrict__ gctr,
             atomicAdd(gctr_ji + i*nao + j, tmp);
         }
     }
-    
+
     return;
 }

--- a/gpu4pyscf/lib/ecp/ecp_type2.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2.cu
@@ -110,7 +110,72 @@ void type2_facs_omega(double* __restrict__ omega, const int LI, const int LC, do
         if (LI+LC >= 7)  {type2_ang_nuc_l<7>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
         if (LI+LC >= 9)  {type2_ang_nuc_l<9>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
     }
+    __syncthreads();
 }
+
+template <int LI, int LC> __device__
+void type2_facs_omega(double* __restrict__ omega, double *r){
+    double unitr[3];
+    if (r[0]*r[0] + r[1]*r[1] + r[2]*r[2] < 1e-16){
+        unitr[0] = 0;
+        unitr[1] = 0;
+        unitr[2] = 0;
+    } else {
+        double norm_r = -rnorm3d(r[0], r[1], r[2]);
+        unitr[0] = r[0] * norm_r;
+        unitr[1] = r[1] * norm_r;
+        unitr[2] = r[2] * norm_r;
+    }
+
+    // LC + (i+j+k) + (LI + LC) needs to be even
+    // When i+j+k + LC is even
+    for (int n = threadIdx.x; n < (LI+1)*(LI+1)*(LI+1); n+=blockDim.x){
+        const int i = n/(LI+1)/(LI+1);
+        const int j = n/(LI+1)%(LI+1);
+        const int k = n%(LI+1);
+        if (i+j+k > LI || (i+j+k+LC)%2 == 1){
+            continue;
+        }
+
+        const int LI_i = LI-i;
+        const int ioff = (LI_i)*(LI_i+1)*(LI_i+2)/6;
+        const int joff = (LI_i-j)*(LI_i-j+1)/2;
+        constexpr int blk = (LI+LC+2)/2 * (LC*2+1);
+        double *pomega = omega + (ioff+joff+k)*blk;
+
+        //for (int lmb = need_even; lmb <= LI+LC; lmb+=2){
+        if constexpr (LI+LC >= 0)  {type2_ang_nuc_l<0>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 2)  {type2_ang_nuc_l<2>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 4)  {type2_ang_nuc_l<4>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 6)  {type2_ang_nuc_l<6>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 8)  {type2_ang_nuc_l<8>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 10) {type2_ang_nuc_l<10>(pomega, LC, i, j, k, unitr); pomega+=(2*LC+1);}
+    }
+
+    // When i+j+k + LC is odd
+    for (int n = threadIdx.x; n < (LI+1)*(LI+1)*(LI+1); n+=blockDim.x){
+        const int i = n/(LI+1)/(LI+1);
+        const int j = n/(LI+1)%(LI+1);
+        const int k = n%(LI+1);
+        if (i+j+k > LI || (i+j+k+LC)%2 == 0){
+            continue;
+        }
+        const int LI_i = LI-i;
+        const int ioff = (LI_i)*(LI_i+1)*(LI_i+2)/6;
+        const int joff = (LI_i-j)*(LI_i-j+1)/2;
+        constexpr int blk = (LI+LC+2)/2 * (LC*2+1);
+        double *pomega = omega + (ioff+joff+k)*blk;
+
+        //for (int lmb = need_even; lmb <= LI+LC; lmb+=2){
+        if constexpr (LI+LC >= 1)  {type2_ang_nuc_l<1>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 3)  {type2_ang_nuc_l<3>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 5)  {type2_ang_nuc_l<5>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 7)  {type2_ang_nuc_l<7>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+        if constexpr (LI+LC >= 9)  {type2_ang_nuc_l<9>(pomega, LC, i, j, k, unitr);  pomega+=(2*LC+1);}
+    }
+    __syncthreads();
+}
+
 
 __device__
 void type2_ang(double * __restrict__ facs, const int LI, const int LC, double *rca, double *omega){
@@ -151,7 +216,6 @@ void type2_ang(double * __restrict__ facs, const int LI, const int LC, double *r
             const int ioff = (LI_i)*(LI_i+1)*(LI_i+2)/6;
             const int joff = (LI_i-j)*(LI_i-j+1)/2;
             double *pomega = omega + (ioff+joff+k)*BLK;
-
             if ((LC+ijk)%2 == m%2){
                 ang_pmn[ijk] += fac * pomega[m/2*LCC1];
             }
@@ -161,6 +225,58 @@ void type2_ang(double * __restrict__ facs, const int LI, const int LC, double *r
             facs[i*nfi*LIC1 + p*LIC1 + m] = ang_pmn[i];
         }
     }
+    __syncthreads();
+}
+
+template <int LI, int LC> __device__
+void type2_ang(double * __restrict__ facs, double *rca, double *omega){
+    constexpr int LI1 = LI+1;
+    constexpr int nfi = LI1*(LI1+1)/2;
+    constexpr int LCC1 = (2*LC+1);
+    constexpr int LIC1 = LI+LC+1;
+    constexpr int BLK = (LIC1+1)/2 * LCC1;
+
+    constexpr int NF = (LI+1)*(LI+2)/2;
+    double fi[NF*3];
+    cache_fac(fi, LI, rca);
+
+    // i,j,k,ijkmn->(i+j+k)pmn
+    for (int pmn = threadIdx.x; pmn < nfi*LIC1; pmn+=blockDim.x){
+        const int m = pmn/nfi;
+        const int p = pmn%nfi;
+
+        const int iy = _cart_pow_y[p];
+        const int iz = _cart_pow_z[p];
+        const int ix = LI - iy - iz;
+
+        double *fx = fi + (ix+1)*ix/2;
+        double *fy = fi + (iy+1)*iy/2 + nfi;
+        double *fz = fi + (iz+1)*iz/2 + nfi*2;
+
+        double ang_pmn[LI+1];
+        for (int i = 0; i < LI+1; i++){
+            ang_pmn[i] = 0.0;
+        }
+        
+        for (int i = 0; i <= ix; i++){
+        for (int j = 0; j <= iy; j++){
+        for (int k = 0; k <= iz; k++){
+            const int ijk = i+j+k;
+            const double fac = fx[i] * fy[j] * fz[k];
+            const int LI_i = LI-i;
+            const int ioff = (LI_i)*(LI_i+1)*(LI_i+2)/6;
+            const int joff = (LI_i-j)*(LI_i-j+1)/2;
+            double *pomega = omega + (ioff+joff+k)*BLK;
+            if ((LC+ijk)%2 == m%2){
+                ang_pmn[ijk] += fac * pomega[m/2*LCC1];
+            }
+        }}}
+
+        for (int i = 0; i <= LI; i++){
+            facs[i*nfi*LIC1 + p*LIC1 + m] = ang_pmn[i];
+        }
+    }
+    __syncthreads();
 }
 
 template <int LI, int LJ, int LC> __global__
@@ -202,11 +318,11 @@ void type2_cart(double * __restrict__ gctr,
     constexpr int BLKI = (LIC1+1)/2 * LCC1;
     constexpr int BLKJ = (LJC1+1)/2 * LCC1;
 
-    __shared__ double omegai[LI1*(LI1+1)*(LI1+2)/6 * BLKI]; // up to 12600 Bytes
+    __shared__ double omegai[LI1*(LI1+1)*(LI1+2)/6 * BLKI];
     __shared__ double omegaj[LJ1*(LJ1+1)*(LJ1+2)/6 * BLKJ];
 
-    type2_facs_omega(omegai, LI, LC, rca);
-    type2_facs_omega(omegaj, LJ, LC, rcb);
+    type2_facs_omega<LI, LC>(omegai, rca);
+    type2_facs_omega<LJ, LC>(omegaj, rcb);
     __syncthreads();
 
     const int npi = bas[NPRIM_OF+ish*BAS_SLOTS];
@@ -216,11 +332,12 @@ void type2_cart(double * __restrict__ gctr,
     const double *ci = env + bas[PTR_COEFF+ish*BAS_SLOTS];
     const double *cj = env + bas[PTR_COEFF+jsh*BAS_SLOTS];
 
-    double radi[LIC1];
-    double radj[LJC1];
     const double dca = norm3d(rca[0], rca[1], rca[2]);
-    const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
+    double radi[LIC1];
     type2_facs_rad<0>(radi, LI+LC, npi, dca, ci, ai);
+    
+    const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
+    double radj[LJC1];
     type2_facs_rad<0>(radj, LJ+LC, npj, dcb, cj, aj);
 
     __shared__ double rad_all[(LI+LJ+1) * LIC1 * LJC1];
@@ -240,6 +357,7 @@ void type2_cart(double * __restrict__ gctr,
         double *prad = rad_all + p*LIC1*LJC1;
         for (int i = 0; i <= LI+LC; i++){
         for (int j = 0; j <= LJ+LC; j++){
+            __syncthreads();
             block_reduce(radi[i]*radj[j]*ur, prad+i*LJC1+j);
         }}
         ur *= root;
@@ -249,12 +367,12 @@ void type2_cart(double * __restrict__ gctr,
     constexpr int nfi = (LI+1) * (LI+2) / 2;
     constexpr int nfj = (LJ+1) * (LJ+2) / 2;
 
-    __shared__ double angi[LI1*nfi*LIC1]; // up to 5400 Bytes, further compression
+    __shared__ double angi[LI1*nfi*LIC1];
     __shared__ double angj[LJ1*nfj*LJC1];
 
     const double fac = 16.0 * M_PI * M_PI * _common_fac[LI] * _common_fac[LJ];
 
-    constexpr int nreg = (NF_MAX*NF_MAX + THREADS - 1)/THREADS;
+    constexpr int nreg = (nfi*nfj + THREADS - 1)/THREADS;
     double reg_gctr[nreg];
     for (int i = 0; i < nreg; i++){
         reg_gctr[i] = 0.0;
@@ -262,8 +380,8 @@ void type2_cart(double * __restrict__ gctr,
 
     // (k+l)pq,kimp,ljmq->ij
     for (int m = 0; m < LCC1; m++){
-        type2_ang(angi, LI, LC, rca, omegai+m);
-        type2_ang(angj, LJ, LC, rcb, omegaj+m);
+        type2_ang<LI, LC>(angi, rca, omegai+m);
+        type2_ang<LJ, LC>(angj, rcb, omegaj+m);
         __syncthreads();
         for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
             const int i = ij%nfi;
@@ -356,10 +474,11 @@ void type2_cart(double * __restrict__ gctr,
     const double *cj = env + bas[PTR_COEFF+jsh*BAS_SLOTS];
 
     double radi[AO_LMAX+ECP_LMAX+1];
-    double radj[AO_LMAX+ECP_LMAX+1];
     const double dca = norm3d(rca[0], rca[1], rca[2]);
-    const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
     type2_facs_rad<0>(radi, LI+LC, npi, dca, ci, ai);
+    
+    double radj[AO_LMAX+ECP_LMAX+1];
+    const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
     type2_facs_rad<0>(radj, LJ+LC, npj, dcb, cj, aj);
 
     double root = 0.0;

--- a/gpu4pyscf/lib/ecp/ecp_type2_ip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2_ip.cu
@@ -101,6 +101,7 @@ void type2_cart_unrolled_kernel(double *gctr,
     for (int m = 0; m < 2*LC+1; m++){
         type2_ang<LI, LC>(angi, rca, omegai+m);
         type2_ang<LJ, LC>(angj, rcb, omegaj+m);
+        __syncthreads();
         for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
             const int i = ij%nfi;
             const int j = ij/nfi;
@@ -169,7 +170,7 @@ void type2_cart_kernel(double *gctr,
 
     const double dca = norm3d(rca[0], rca[1], rca[2]);
     const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
-
+    
     double radi[AO_LMAX+ECP_LMAX+orderi+1];
     type2_facs_rad<orderi>(radi, LI+LC, npi, dca, ci, ai);
     double radj[AO_LMAX+ECP_LMAX+orderj+1];
@@ -269,18 +270,16 @@ void type2_cart_ip1(double *gctr,
     constexpr int nfi1 = (LI+2) * (LI+3)/2;
     __shared__ double buf[nfi1*nfj];
     type2_cart_unrolled_kernel<1,0,LI+1,LJ,LC>(
-        buf, ish, jsh, ksh,
-        ecpbas, ecploc,
+        buf, ish, jsh, ksh, 
+        ecpbas, ecploc, 
         atm, bas, env);
-    __syncthreads();
     _li_down(gctr_smem, buf, LI, LJ);
     __syncthreads();
     if constexpr (LI > 0){
         type2_cart_unrolled_kernel<0,0,LI-1,LJ,LC>(
-            buf, ish, jsh, ksh,
-            ecpbas, ecploc,
+            buf, ish, jsh, ksh, 
+            ecpbas, ecploc, 
             atm, bas, env);
-        __syncthreads();
         _li_up(gctr_smem, buf, LI, LJ);
         __syncthreads();
     }
@@ -330,20 +329,18 @@ void type2_cart_ip1_general(double *gctr,
     constexpr int NFJ_MAX = (AO_LMAX+1)*(AO_LMAX+2)/2;
     __shared__ double buf[NFI_MAX*NFJ_MAX];
     type2_cart_kernel<1,0>(
-        buf, LI+1, LJ, LC,
-        ish, jsh, ksh,
-        ecpbas, ecploc,
+        buf, LI+1, LJ, LC, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
         atm, bas, env);
-    __syncthreads();
     _li_down(gctr_smem, buf, LI, LJ);
     __syncthreads();
     if (LI > 0){
         type2_cart_kernel<0,0>(
-            buf, LI-1, LJ, LC,
-            ish, jsh, ksh,
-            ecpbas, ecploc,
+            buf, LI-1, LJ, LC, 
+            ish, jsh, ksh, 
+            ecpbas, ecploc, 
             atm, bas, env);
-        __syncthreads();
         _li_up(gctr_smem, buf, LI, LJ);
         __syncthreads();
     }

--- a/gpu4pyscf/lib/ecp/ecp_type2_ip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2_ip.cu
@@ -15,6 +15,119 @@
  */
 
 
+template <int orderi, int orderj, int LI, int LJ, int LC> __device__
+void type2_cart_unrolled_kernel(double *gctr,
+                const int ish, const int jsh, const int ksh,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const double *ri = env + atm[PTR_COORD+bas[ATOM_OF+ish*BAS_SLOTS]*ATM_SLOTS];
+    const double *rj = env + atm[PTR_COORD+bas[ATOM_OF+jsh*BAS_SLOTS]*ATM_SLOTS];
+
+    const int atm_id = ecpbas[ATOM_OF+ecploc[ksh]*BAS_SLOTS];
+    const double *rc = env + atm[PTR_COORD+atm_id*ATM_SLOTS];
+
+    double rca[3], rcb[3];
+    rca[0] = rc[0] - ri[0];
+    rca[1] = rc[1] - ri[1];
+    rca[2] = rc[2] - ri[2];
+    rcb[0] = rc[0] - rj[0];
+    rcb[1] = rc[1] - rj[1];
+    rcb[2] = rc[2] - rj[2];
+
+    constexpr int LI1 = LI+1;
+    constexpr int LJ1 = LJ+1;
+    constexpr int LIC1 = LI+LC+1;
+    constexpr int LJC1 = LJ+LC+1;
+    constexpr int LCC1 = (2*LC+1);
+
+    constexpr int BLKI = (LIC1+1)/2 * LCC1;
+    constexpr int BLKJ = (LJC1+1)/2 * LCC1;
+
+    __shared__ double omegai[LI1*(LI1+1)*(LI1+2)/6 * BLKI];
+    __shared__ double omegaj[LJ1*(LJ1+1)*(LJ1+2)/6 * BLKJ];
+
+    type2_facs_omega<LI, LC>(omegai, rca);
+    type2_facs_omega<LJ, LC>(omegaj, rcb);
+    __syncthreads();
+
+    __shared__ double rad_all[(LI+LJ+1)*LIC1*LJC1];
+    set_shared_memory(rad_all, (LI+LJ+1)*LIC1*LJC1);
+
+    const int npi = bas[NPRIM_OF+ish*BAS_SLOTS];
+    const double *ai = env + bas[PTR_EXP+ish*BAS_SLOTS];
+    const double *ci = env + bas[PTR_COEFF+ish*BAS_SLOTS];
+    const double dca = norm3d(rca[0], rca[1], rca[2]);
+    double radi[LIC1+orderi];
+    type2_facs_rad<orderi>(radi, LI+LC, npi, dca, ci, ai);
+
+    const int npj = bas[NPRIM_OF+jsh*BAS_SLOTS];
+    const double *aj = env + bas[PTR_EXP+jsh*BAS_SLOTS];
+    const double *cj = env + bas[PTR_COEFF+jsh*BAS_SLOTS];
+    const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
+    double radj[LJC1+orderj];
+    type2_facs_rad<orderj>(radj, LJ+LC, npj, dcb, cj, aj);
+
+    double ur = 0.0;
+    // Each ECP shell has multiple powers and primitive basis
+    for (int kbas = ecploc[ksh]; kbas < ecploc[ksh+1]; kbas++){
+        ur += rad_part(kbas, ecpbas, env);
+    }
+    double ur_tmp = ur;
+    for (int p = 0; p <= LI+LJ; p++){
+        double *prad = rad_all + p*(LI+LC+1)*(LJ+LC+1);
+        for (int i = 0; i <= LI+LC; i++){
+        for (int j = 0; j <= LJ+LC; j++){
+            block_reduce(radi[i]*radj[j]*ur_tmp, prad+i*(LJ+LC+1)+j);
+        }}
+        const int ir = threadIdx.x;
+        ur_tmp *= r128[ir];
+    }
+    __syncthreads();
+
+    constexpr int nfi = (LI+1) * (LI+2) / 2;
+    constexpr int nfj = (LJ+1) * (LJ+2) / 2;
+
+    __shared__ double angi[LI1*nfi*LIC1];
+    __shared__ double angj[LJ1*nfj*LJC1];
+
+    const double fac = 16.0 * M_PI * M_PI * _common_fac[LI] * _common_fac[LJ];
+
+    for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
+        gctr[ij] = 0.0;
+    }
+
+    // (k+l)pq,kimp,ljmq->ij
+    for (int m = 0; m < 2*LC+1; m++){
+        type2_ang<LI, LC>(angi, rca, omegai+m);
+        type2_ang<LJ, LC>(angj, rcb, omegaj+m);
+        __syncthreads();
+        for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
+            const int i = ij%nfi;
+            const int j = ij/nfi;
+            double s = 0;
+            for (int k = 0; k <= LI; k++){
+            for (int l = 0; l <= LJ; l++){
+                double *pangi = angi + k*nfi*LIC1 + i*LIC1;
+                double *pangj = angj + l*nfj*LJC1 + j*LJC1;
+                double *prad = rad_all + (k+l)*LIC1*LJC1;
+
+                double reg_angi[LIC1+orderi];
+                double reg_angj[LJC1+orderj];
+                for (int p = 0; p < LIC1; p++){reg_angi[p] = pangi[p];}
+                for (int q = 0; q < LJC1; q++){reg_angj[q] = pangj[q];}
+                for (int p = 0; p < LIC1; p++){
+                for (int q = 0; q < LJC1; q++){
+                    s += prad[p*LJC1+q] * reg_angi[p] * reg_angj[q];
+                }}
+            }}
+            gctr[ij] += fac*s;
+            //atomicAdd(gctr+ij, fac*s);
+        }
+        __syncthreads();
+    }
+}
+
 template <int orderi, int orderj> __device__
 void type2_cart_kernel(double *gctr,
                 const int LI, const int LJ, const int LC,
@@ -55,11 +168,12 @@ void type2_cart_kernel(double *gctr,
     const double *ci = env + bas[PTR_COEFF+ish*BAS_SLOTS];
     const double *cj = env + bas[PTR_COEFF+jsh*BAS_SLOTS];
 
-    double radi[AO_LMAX+ECP_LMAX+orderi+1];
-    double radj[AO_LMAX+ECP_LMAX+orderj+1];
     const double dca = norm3d(rca[0], rca[1], rca[2]);
     const double dcb = norm3d(rcb[0], rcb[1], rcb[2]);
+    
+    double radi[AO_LMAX+ECP_LMAX+orderi+1];
     type2_facs_rad<orderi>(radi, LI+LC, npi, dca, ci, ai);
+    double radj[AO_LMAX+ECP_LMAX+orderj+1];
     type2_facs_rad<orderj>(radj, LJ+LC, npj, dcb, cj, aj);
 
     double ur = 0.0;
@@ -124,8 +238,68 @@ void type2_cart_kernel(double *gctr,
     }
 }
 
-__global__
+// Unrolling case
+template <int LI, int LJ, int LC> __global__
 void type2_cart_ip1(double *gctr,
+                const int *ao_loc, const int nao,
+                const int *tasks, const int ntasks,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const int task_id = blockIdx.x;
+    if (task_id >= ntasks){
+        return;
+    }
+
+    const int ish = tasks[task_id];
+    const int jsh = tasks[task_id + ntasks];
+    const int ksh = tasks[task_id + 2*ntasks];
+    const int ioff = ao_loc[ish];
+    const int joff = ao_loc[jsh];
+    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
+    gctr += 3*ecp_id*nao*nao + ioff*nao + joff;
+
+    constexpr int nfi = (LI+1) * (LI+2) / 2;
+    constexpr int nfj = (LJ+1) * (LJ+2) / 2;
+    __shared__ double gctr_smem[nfi*nfj*3];
+    for (int ij = threadIdx.x; ij < nfi*nfj*3; ij+=blockDim.x){
+        gctr_smem[ij] = 0.0;
+    }
+    __syncthreads();
+
+    constexpr int nfi1 = (LI+2) * (LI+3)/2;
+    __shared__ double buf[nfi1*nfj];
+    type2_cart_unrolled_kernel<1,0,LI+1,LJ,LC>(
+        buf, ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+    _li_down(gctr_smem, buf, LI, LJ);
+    if constexpr (LI > 0){
+        type2_cart_unrolled_kernel<0,0,LI-1,LJ,LC>(
+            buf, ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
+        __syncthreads();
+        _li_up(gctr_smem, buf, LI, LJ);
+    }
+
+    for (int ij = threadIdx.x; ij < nfi*nfj; ij+=blockDim.x){
+        const int i = ij%nfi;
+        const int j = ij/nfi;
+        double *gx = gctr;
+        double *gy = gctr +   nao*nao;
+        double *gz = gctr + 2*nao*nao;
+        atomicAdd(gx + i*nao + j, gctr_smem[ij]);
+        atomicAdd(gy + i*nao + j, gctr_smem[ij+nfi*nfj]);
+        atomicAdd(gz + i*nao + j, gctr_smem[ij+2*nfi*nfj]);
+    }
+    return;
+}
+
+
+__global__
+void type2_cart_ip1_general(double *gctr,
                 const int LI, const int LJ, const int LC,
                 const int *ao_loc, const int nao,
                 const int *tasks, const int ntasks,
@@ -151,16 +325,22 @@ void type2_cart_ip1(double *gctr,
     }
     __syncthreads();
 
-    const int orderi = 1;
-    const int orderj = 0;
-    constexpr int NFI_MAX = (AO_LMAX+orderi+1)*(AO_LMAX+orderi+2)/2;
-    constexpr int NFJ_MAX = (AO_LMAX+orderj+1)*(AO_LMAX+orderj+2)/2;
+    constexpr int NFI_MAX = (AO_LMAX+2)*(AO_LMAX+3)/2;
+    constexpr int NFJ_MAX = (AO_LMAX+1)*(AO_LMAX+2)/2;
     __shared__ double buf[NFI_MAX*NFJ_MAX];
-    type2_cart_kernel<1,0>(buf, LI+1, LJ, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
+    type2_cart_kernel<1,0>(
+        buf, LI+1, LJ, LC, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
     __syncthreads();
     _li_down(gctr_smem, buf, LI, LJ);
     if (LI > 0){
-        type2_cart_kernel<0,0>(buf, LI-1, LJ, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
+        type2_cart_kernel<0,0>(
+            buf, LI-1, LJ, LC, 
+            ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
         __syncthreads();
         _li_up(gctr_smem, buf, LI, LJ);
     }
@@ -176,123 +356,6 @@ void type2_cart_ip1(double *gctr,
         atomicAdd(gx + i*nao + j, gctr_smem[ij]);
         atomicAdd(gy + i*nao + j, gctr_smem[ij+nfi*nfj]);
         atomicAdd(gz + i*nao + j, gctr_smem[ij+2*nfi*nfj]);
-    }
-    return;
-}
-
-
-__global__
-void type2_cart_ipipv(double *gctr,
-                const int LI, const int LJ, const int LC,
-                const int *ao_loc, const int nao,
-                const int *tasks, const int ntasks,
-                const int *ecpbas, const int *ecploc,
-                const int *atm, const int *bas, const double *env)
-{
-    const int task_id = blockIdx.x;
-    if (task_id >= ntasks){
-        return;
-    }
-
-    const int ish = tasks[task_id];
-    const int jsh = tasks[task_id + ntasks];
-    const int ksh = tasks[task_id + 2*ntasks];
-
-    const int ioff = ao_loc[ish];
-    const int joff = ao_loc[jsh];
-    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
-    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
-
-    constexpr int nfi2_max = (AO_LMAX+3)*(AO_LMAX+4)/2;
-    constexpr int nfj_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
-    __shared__ double buf1[nfi2_max*nfj_max];
-    type2_cart_kernel<2,0>(buf1, LI+2, LJ, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-    __syncthreads();
-
-    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
-    extern __shared__ double smem[];
-    double *buf = smem;
-    set_shared_memory(buf, 3*nfi1_max*nfj_max);
-    _li_down(buf, buf1, LI+1, LJ);
-    _li_down_and_write(gctr, buf, LI, LJ, nao);
-
-    type2_cart_kernel<1,0>(buf1, LI, LJ, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-    __syncthreads();
-    set_shared_memory(buf, 3*nfi1_max*nfj_max);
-    _li_up(buf, buf1, LI+1, LJ);
-    _li_down_and_write(gctr, buf, LI, LJ, nao);
-
-    if (LI > 0){
-        set_shared_memory(buf, 3*nfi1_max*nfj_max);
-        _li_down(buf, buf1, LI-1, LJ);
-        _li_up_and_write(gctr, buf, LI, LJ, nao);
-        if (LI > 1){
-            type2_cart_kernel<0,0>(buf1, LI-2, LJ, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-            __syncthreads();
-            set_shared_memory(buf, 3*nfi1_max*nfj_max);
-            _li_up(buf, buf1, LI-1, LJ);
-            _li_up_and_write(gctr, buf, LI, LJ, nao);
-        }
-    }
-    return;
-}
-
-__global__
-void type2_cart_ipvip(double *gctr,
-                const int LI, const int LJ, const int LC,
-                const int *ao_loc, const int nao,
-                const int *tasks, const int ntasks,
-                const int *ecpbas, const int *ecploc,
-                const int *atm, const int *bas, const double *env)
-{
-    const int task_id = blockIdx.x;
-    if (task_id >= ntasks){
-        return;
-    }
-
-    const int ish = tasks[task_id];
-    const int jsh = tasks[task_id + ntasks];
-    const int ksh = tasks[task_id + 2*ntasks];
-
-    const int ioff = ao_loc[ish];
-    const int joff = ao_loc[jsh];
-    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
-    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
-
-    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
-    constexpr int nfj1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
-    __shared__ double buf1[nfi1_max*nfj1_max];
-    type2_cart_kernel<1,1>(buf1, LI+1, LJ+1, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-    __syncthreads();
-
-    constexpr int nfi_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
-    extern __shared__ double smem[];
-    double *buf = smem;
-    set_shared_memory(buf, 3*nfi_max*nfj1_max);
-    _li_down(buf, buf1, LI, LJ+1);
-    _lj_down_and_write(gctr, buf, LI, LJ, nao);
-
-    if (LI > 0){
-        type2_cart_kernel<0,1>(buf1, LI-1, LJ+1, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-        __syncthreads();
-        set_shared_memory(buf, 3*nfi_max*nfj1_max);
-        _li_up(buf, buf1, LI, LJ+1);
-        _lj_down_and_write(gctr, buf, LI, LJ, nao);
-    }
-
-    if (LJ > 0){
-        type2_cart_kernel<1,0>(buf1, LI+1, LJ-1, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-        __syncthreads();
-        set_shared_memory(buf, 3*nfi_max*nfj1_max);
-        _li_down(buf, buf1, LI, LJ-1);
-         _lj_up_and_write(gctr, buf, LI, LJ, nao);
-        if (LI > 0){
-            type2_cart_kernel<0,0>(buf1, LI-1, LJ-1, LC, ish, jsh, ksh, ecpbas, ecploc, atm, bas, env);
-            __syncthreads();
-            set_shared_memory(buf, 3*nfi_max*nfj1_max);
-            _li_up(buf, buf1, LI, LJ-1);
-            _lj_up_and_write(gctr, buf, LI, LJ, nao);
-        }
     }
     return;
 }

--- a/gpu4pyscf/lib/ecp/ecp_type2_ipip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2_ipip.cu
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021-2025 The PySCF Developers. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+__global__
+void type2_cart_ipipv(double *gctr,
+                const int LI, const int LJ, const int LC,
+                const int *ao_loc, const int nao,
+                const int *tasks, const int ntasks,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const int task_id = blockIdx.x;
+    if (task_id >= ntasks){
+        return;
+    }
+
+    const int ish = tasks[task_id];
+    const int jsh = tasks[task_id + ntasks];
+    const int ksh = tasks[task_id + 2*ntasks];
+
+    const int ioff = ao_loc[ish];
+    const int joff = ao_loc[jsh];
+    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
+    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
+
+    constexpr int nfi2_max = (AO_LMAX+3)*(AO_LMAX+4)/2;
+    constexpr int nfj_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
+    __shared__ double buf1[nfi2_max*nfj_max];
+    type2_cart_kernel<2,0>(
+        buf1, LI+2, LJ, LC, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+
+    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
+    extern __shared__ double smem[];
+    double *buf = smem;
+    set_shared_memory(buf, 3*nfi1_max*nfj_max);
+    _li_down(buf, buf1, LI+1, LJ);
+    _li_down_and_write(gctr, buf, LI, LJ, nao);
+
+    type2_cart_kernel<1,0>(
+        buf1, LI, LJ, LC, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+    set_shared_memory(buf, 3*nfi1_max*nfj_max);
+    _li_up(buf, buf1, LI+1, LJ);
+    _li_down_and_write(gctr, buf, LI, LJ, nao);
+
+    if (LI > 0){
+        set_shared_memory(buf, 3*nfi1_max*nfj_max);
+        _li_down(buf, buf1, LI-1, LJ);
+        _li_up_and_write(gctr, buf, LI, LJ, nao);
+        if (LI > 1){
+            type2_cart_kernel<0,0>(
+                buf1, LI-2, LJ, LC, 
+                ish, jsh, ksh, 
+                ecpbas, ecploc, 
+                atm, bas, env);
+            __syncthreads();
+            set_shared_memory(buf, 3*nfi1_max*nfj_max);
+            _li_up(buf, buf1, LI-1, LJ);
+            _li_up_and_write(gctr, buf, LI, LJ, nao);
+        }
+    }
+    return;
+}
+
+__global__
+void type2_cart_ipvip(double *gctr,
+                const int LI, const int LJ, const int LC,
+                const int *ao_loc, const int nao,
+                const int *tasks, const int ntasks,
+                const int *ecpbas, const int *ecploc,
+                const int *atm, const int *bas, const double *env)
+{
+    const int task_id = blockIdx.x;
+    if (task_id >= ntasks){
+        return;
+    }
+
+    const int ish = tasks[task_id];
+    const int jsh = tasks[task_id + ntasks];
+    const int ksh = tasks[task_id + 2*ntasks];
+
+    const int ioff = ao_loc[ish];
+    const int joff = ao_loc[jsh];
+    const int ecp_id = ecpbas[ECP_ATOM_ID+ecploc[ksh]*BAS_SLOTS];
+    gctr += ioff*nao + joff + 9*ecp_id*nao*nao;
+
+    constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
+    constexpr int nfj1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
+    __shared__ double buf1[nfi1_max*nfj1_max];
+    type2_cart_kernel<1,1>(
+        buf1, LI+1, LJ+1, LC, 
+        ish, jsh, ksh, 
+        ecpbas, ecploc, 
+        atm, bas, env);
+    __syncthreads();
+
+    constexpr int nfi_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
+    extern __shared__ double smem[];
+    double *buf = smem;
+    set_shared_memory(buf, 3*nfi_max*nfj1_max);
+    _li_down(buf, buf1, LI, LJ+1);
+    _lj_down_and_write(gctr, buf, LI, LJ, nao);
+
+    if (LI > 0){
+        type2_cart_kernel<0,1>(
+            buf1, LI-1, LJ+1, LC, 
+            ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
+        __syncthreads();
+        set_shared_memory(buf, 3*nfi_max*nfj1_max);
+        _li_up(buf, buf1, LI, LJ+1);
+        _lj_down_and_write(gctr, buf, LI, LJ, nao);
+    }
+    
+    if (LJ > 0){
+        type2_cart_kernel<1,0>(
+            buf1, LI+1, LJ-1, LC, 
+            ish, jsh, ksh, 
+            ecpbas, ecploc, 
+            atm, bas, env);
+        __syncthreads();
+        set_shared_memory(buf, 3*nfi_max*nfj1_max);
+        _li_down(buf, buf1, LI, LJ-1);
+         _lj_up_and_write(gctr, buf, LI, LJ, nao);
+        if (LI > 0){
+            type2_cart_kernel<0,0>(
+                buf1, LI-1, LJ-1, LC, 
+                ish, jsh, ksh, 
+                ecpbas, ecploc, 
+                atm, bas, env);
+            __syncthreads();
+            set_shared_memory(buf, 3*nfi_max*nfj1_max);
+            _li_up(buf, buf1, LI, LJ-1);
+            _lj_up_and_write(gctr, buf, LI, LJ, nao);
+        }
+    }
+    return;
+}

--- a/gpu4pyscf/lib/ecp/ecp_type2_ipip.cu
+++ b/gpu4pyscf/lib/ecp/ecp_type2_ipip.cu
@@ -41,42 +41,46 @@ void type2_cart_ipipv(double *gctr,
     constexpr int nfj_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
     __shared__ double buf1[nfi2_max*nfj_max];
     type2_cart_kernel<2,0>(
-        buf1, LI+2, LJ, LC, 
-        ish, jsh, ksh, 
-        ecpbas, ecploc, 
+        buf1, LI+2, LJ, LC,
+        ish, jsh, ksh,
+        ecpbas, ecploc,
         atm, bas, env);
-    __syncthreads();
 
     constexpr int nfi1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
     extern __shared__ double smem[];
     double *buf = smem;
     set_shared_memory(buf, 3*nfi1_max*nfj_max);
     _li_down(buf, buf1, LI+1, LJ);
+    __syncthreads();
     _li_down_and_write(gctr, buf, LI, LJ, nao);
+    __syncthreads();
 
     type2_cart_kernel<1,0>(
-        buf1, LI, LJ, LC, 
-        ish, jsh, ksh, 
-        ecpbas, ecploc, 
+        buf1, LI, LJ, LC,
+        ish, jsh, ksh,
+        ecpbas, ecploc,
         atm, bas, env);
-    __syncthreads();
     set_shared_memory(buf, 3*nfi1_max*nfj_max);
     _li_up(buf, buf1, LI+1, LJ);
+    __syncthreads();
     _li_down_and_write(gctr, buf, LI, LJ, nao);
+    __syncthreads();
 
     if (LI > 0){
         set_shared_memory(buf, 3*nfi1_max*nfj_max);
         _li_down(buf, buf1, LI-1, LJ);
+        __syncthreads();
         _li_up_and_write(gctr, buf, LI, LJ, nao);
+        __syncthreads();
         if (LI > 1){
             type2_cart_kernel<0,0>(
-                buf1, LI-2, LJ, LC, 
-                ish, jsh, ksh, 
-                ecpbas, ecploc, 
+                buf1, LI-2, LJ, LC,
+                ish, jsh, ksh,
+                ecpbas, ecploc,
                 atm, bas, env);
-            __syncthreads();
             set_shared_memory(buf, 3*nfi1_max*nfj_max);
             _li_up(buf, buf1, LI-1, LJ);
+            __syncthreads();
             _li_up_and_write(gctr, buf, LI, LJ, nao);
         }
     }
@@ -109,51 +113,54 @@ void type2_cart_ipvip(double *gctr,
     constexpr int nfj1_max = (AO_LMAX+2)*(AO_LMAX+3)/2;
     __shared__ double buf1[nfi1_max*nfj1_max];
     type2_cart_kernel<1,1>(
-        buf1, LI+1, LJ+1, LC, 
-        ish, jsh, ksh, 
-        ecpbas, ecploc, 
+        buf1, LI+1, LJ+1, LC,
+        ish, jsh, ksh,
+        ecpbas, ecploc,
         atm, bas, env);
-    __syncthreads();
 
     constexpr int nfi_max = (AO_LMAX+1)*(AO_LMAX+2)/2;
     extern __shared__ double smem[];
     double *buf = smem;
     set_shared_memory(buf, 3*nfi_max*nfj1_max);
     _li_down(buf, buf1, LI, LJ+1);
+    __syncthreads();
     _lj_down_and_write(gctr, buf, LI, LJ, nao);
-
+    __syncthreads();
     if (LI > 0){
         type2_cart_kernel<0,1>(
-            buf1, LI-1, LJ+1, LC, 
-            ish, jsh, ksh, 
-            ecpbas, ecploc, 
+            buf1, LI-1, LJ+1, LC,
+            ish, jsh, ksh,
+            ecpbas, ecploc,
             atm, bas, env);
-        __syncthreads();
         set_shared_memory(buf, 3*nfi_max*nfj1_max);
         _li_up(buf, buf1, LI, LJ+1);
+        __syncthreads();
         _lj_down_and_write(gctr, buf, LI, LJ, nao);
+        __syncthreads();
     }
-    
+
     if (LJ > 0){
         type2_cart_kernel<1,0>(
-            buf1, LI+1, LJ-1, LC, 
-            ish, jsh, ksh, 
-            ecpbas, ecploc, 
+            buf1, LI+1, LJ-1, LC,
+            ish, jsh, ksh,
+            ecpbas, ecploc,
             atm, bas, env);
-        __syncthreads();
         set_shared_memory(buf, 3*nfi_max*nfj1_max);
         _li_down(buf, buf1, LI, LJ-1);
-         _lj_up_and_write(gctr, buf, LI, LJ, nao);
+        __syncthreads();
+        _lj_up_and_write(gctr, buf, LI, LJ, nao);
+        __syncthreads();
         if (LI > 0){
             type2_cart_kernel<0,0>(
-                buf1, LI-1, LJ-1, LC, 
-                ish, jsh, ksh, 
-                ecpbas, ecploc, 
+                buf1, LI-1, LJ-1, LC,
+                ish, jsh, ksh,
+                ecpbas, ecploc,
                 atm, bas, env);
-            __syncthreads();
             set_shared_memory(buf, 3*nfi_max*nfj1_max);
             _li_up(buf, buf1, LI, LJ-1);
+            __syncthreads();
             _lj_up_and_write(gctr, buf, LI, LJ, nao);
+            __syncthreads();
         }
     }
     return;

--- a/gpu4pyscf/lib/ecp/nr_ecp_driver.cu
+++ b/gpu4pyscf/lib/ecp/nr_ecp_driver.cu
@@ -197,7 +197,7 @@ int ECP_ip_cart(double *gctr,
             cudaError_t err = cudaFuncSetAttribute(
                 type2_cart_ip1_general,
                 cudaFuncAttributeMaxDynamicSharedMemorySize,
-                (dynamic_smem_size+1024)*sizeof(double));
+                dynamic_smem_size*sizeof(double));
 
             if (err != cudaSuccess) {
                 fprintf(stderr, "CUDA Error in cudaFuncSetAttribute %s: %s\n", __func__, cudaGetErrorString(err));
@@ -272,7 +272,7 @@ int ECP_ipipv_cart(double *gctr,
 
         cudaError_t err = cudaFuncSetAttribute(type2_cart_ipipv,
                                          cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                         (dynamic_smem_size+1024)*sizeof(double));
+                                         dynamic_smem_size*sizeof(double));
         if (err != cudaSuccess) {
             fprintf(stderr, "CUDA Error in cudaFuncSetAttribute %s: %s\n", __func__, cudaGetErrorString(err));
             return 1;
@@ -345,7 +345,7 @@ int ECP_ipvip_cart(double *gctr,
         cudaError_t err = cudaFuncSetAttribute(
             type2_cart_ipvip,
             cudaFuncAttributeMaxDynamicSharedMemorySize,
-            (dynamic_smem_size+1024)*sizeof(double));
+            dynamic_smem_size*sizeof(double));
         if (err != cudaSuccess) {
             fprintf(stderr, "CUDA Error in cudaFuncSetAttribute %s: %s\n", __func__, cudaGetErrorString(err));
             return 1;

--- a/gpu4pyscf/qmmm/pbc/itrf.py
+++ b/gpu4pyscf/qmmm/pbc/itrf.py
@@ -513,7 +513,7 @@ def get_hcore_mm(scf_grad, mol=None):
         g_qm += int1e_grids_ip1(mol, coords, charges = charges, charge_exponents = expnts)
     elif mm_mol.charge_model == 'point' and len(coords) != 0:
         raise RuntimeError("Not tested yet")
-        max_memory = self.max_memory - lib.current_memory()[0]
+        max_memory = scf_grad.max_memory - lib.current_memory()[0]
         blksize = int(min(max_memory*1e6/8/nao**2/3, 200))
         blksize = max(blksize, 1)
         coords = coords.get()

--- a/gpu4pyscf/qmmm/pbc/itrf.py
+++ b/gpu4pyscf/qmmm/pbc/itrf.py
@@ -1018,29 +1018,12 @@ class QMMMGrad:
             return (qm_multipole_grad + qm_ewovrl_grad + qm_ewg_grad).get(), \
                    (mm_ewovrl_grad + mm_ewg_grad).get()
 
-    def get_hcore(self, mol=None):
+    def get_hcore(self, mol=None, exclude_ecp=False):
         if mol is None:
             mol = self.mol
         cput0 = (logger.process_clock(), logger.perf_counter())
         def calculate_h1e(self, h1_gpu):
-            h1 = super().get_hcore(mol)
-            h1_gpu[:] = cp.asarray(h1)
-            return
-
-        g_qm_orig = cp.empty([3, mol.nao, mol.nao])
-        with lib.call_in_background(calculate_h1e) as calculate_hs:
-            calculate_hs(self, g_qm_orig)
-            g_qm = get_hcore_mm(self)
-
-        logger.timer(self, 'get_hcore', *cput0)
-        return g_qm_orig + g_qm
-
-    def get_hcore_no_ecp(self, mol=None):
-        if mol is None:
-            mol = self.mol
-        cput0 = (logger.process_clock(), logger.perf_counter())
-        def calculate_h1e(self, h1_gpu):
-            h1 = super().get_hcore_no_ecp(mol)
+            h1 = super().get_hcore(mol, exclude_ecp=exclude_ecp)
             h1_gpu[:] = cp.asarray(h1)
             return
 


### PR DESCRIPTION
- Increase maximum AO slice from 128 to 256
- Unroll ECP gradient kernel
- Replace get_dh1e with int1e_grid kernel
- Prevent recalculating ECP gradient in gradient

Overall, the wall time of wb97x-3c gradient is reduced from 15 s to 9 s.