### PR TITLE
MD-J engine for hf_lowmem by default

### DIFF
--- a/gpu4pyscf/dft/rks_lowmem.py
+++ b/gpu4pyscf/dft/rks_lowmem.py
@@ -185,15 +185,17 @@ class RKS(rks.RKS):
         dm_tril = dm_tril.get()
         e1 = float(h1e.dot(dm_tril) * 2)
         ecoul = float(vhf.vj.dot(dm_tril))
-        exc = vhf.exc
+        exc = float(vhf.exc)
         if vhf.vk is not None:
             exc -= float(vhf.vk.dot(dm_tril))
-        e2 = ecoul + exc
+        vtmp = h1e * 2
+        vtmp += vhf.vj
+        e_tot = float(vtmp.dot(dm_tril)) + exc
         self.scf_summary['e1'] = e1
         self.scf_summary['coul'] = ecoul
         self.scf_summary['exc'] = exc
         logger.debug(self, 'E1 = %s  Ecoul = %s  Exc = %s', e1, ecoul, exc)
-        return e1+e2, e2
+        return e_tot, e2
 
     def to_cpu(self):
         raise NotImplementedError

--- a/gpu4pyscf/dft/rks_lowmem.py
+++ b/gpu4pyscf/dft/rks_lowmem.py
@@ -195,7 +195,7 @@ class RKS(rks.RKS):
         self.scf_summary['coul'] = ecoul
         self.scf_summary['exc'] = exc
         logger.debug(self, 'E1 = %s  Ecoul = %s  Exc = %s', e1, ecoul, exc)
-        return e_tot, e2
+        return e_tot, e_tot-e1
 
     def to_cpu(self):
         raise NotImplementedError

--- a/gpu4pyscf/lib/gvhf-md/md_contract_j.cu
+++ b/gpu4pyscf/lib/gvhf-md/md_contract_j.cu
@@ -545,6 +545,7 @@ void md_j_kernel(RysIntEnvVars envs, JKMatrix jk, MDBoundsInfo bounds,
                 Rt[0] = gamma_inc[sq_id+order*nsq_per_block];
             }
             for (int n = 1; n <= order; ++n) {
+                __syncthreads();
                 // swap input and output
                 double *tmp = buf;
                 buf = Rt;
@@ -597,7 +598,6 @@ void md_j_kernel(RysIntEnvVars envs, JKMatrix jk, MDBoundsInfo bounds,
                     }
                     break;
                 default:
-                    __syncthreads();
                     iter_Rt_n(Rt, buf, xpq, ypq, zpq, n, nsq_per_block, gout_id, gout_stride);
                 }
             }

--- a/gpu4pyscf/scf/hf_lowmem.py
+++ b/gpu4pyscf/scf/hf_lowmem.py
@@ -325,10 +325,13 @@ class RHF(hf.RHF):
         dm_tril = dm_tril.get()
         e1 = float(h1e.dot(dm_tril) * 2)
         e_coul = float(vhf.dot(dm_tril))
+        vtmp = h1e * 2
+        vtmp += vhf
+        e_tot = float(vtmp.dot(dm_tril))
         self.scf_summary['e1'] = e1
         self.scf_summary['e2'] = e_coul
         logger.debug(self, 'E1 = %s  E_coul = %s', e1, e_coul)
-        return e1+e_coul, e_coul
+        return e_tot, e_coul
 
     def to_cpu(self):
         raise NotImplementedError

--- a/gpu4pyscf/scf/j_engine.py
+++ b/gpu4pyscf/scf/j_engine.py
@@ -20,6 +20,7 @@ import ctypes
 import math
 import numpy as np
 import cupy as cp
+from collections import Counter
 from pyscf import lib
 from pyscf.gto import ATOM_OF, ANG_OF, NPRIM_OF, PTR_EXP, PTR_COEFF
 from pyscf.scf import _vhf
@@ -27,9 +28,9 @@ from gpu4pyscf.lib.cupy_helper import (
     load_library, condense, dist_matrix, transpose_sum, hermi_triu, asarray)
 from gpu4pyscf.__config__ import num_devices, shm_size
 from gpu4pyscf.lib import logger
+from gpu4pyscf.lib import multi_gpu
 from gpu4pyscf.scf import jk
-from gpu4pyscf.scf.jk import (
-    _make_pair_qd_cond, RysIntEnvVars, _scale_sp_ctr_coeff, _nearest_power2)
+from gpu4pyscf.scf.jk import RysIntEnvVars, _scale_sp_ctr_coeff, _nearest_power2
 from gpu4pyscf.gto.mole import group_basis
 
 __all__ = [
@@ -54,9 +55,6 @@ def get_j(mol, dm, hermi=1, vhfopt=None, verbose=None):
         vhfopt = _VHFOpt(mol).build()
 
     nao_orig = mol.nao
-    sorted_mol = vhfopt.sorted_mol
-    prim_mol = vhfopt.prim_mol
-    nao = sorted_mol.nao
     dm = cp.asarray(dm, order='C')
     dms = dm.reshape(-1,nao_orig,nao_orig)
     dms = vhfopt.apply_coeff_C_mat_CT(dms)
@@ -66,153 +64,9 @@ def get_j(mol, dm, hermi=1, vhfopt=None, verbose=None):
         dms = transpose_sum(dms)
     else:
         dms *= 2.
-
-    p2c_mapping = vhfopt.prim_to_ctr_mapping
-    ao_loc = sorted_mol.ao_loc
-    dm_cond = cp.log(condense('absmax', dms, ao_loc) + 1e-300).astype(np.float32)
-    log_max_dm = float(dm_cond.max())
-    log_cutoff = math.log(vhfopt.direct_scf_tol)
-    q_cutoff = log_cutoff - log_max_dm
-    dm_cond = dm_cond[p2c_mapping[:,None],p2c_mapping]
-
-    l_counts = np.bincount(prim_mol._bas[:,ANG_OF])
-    n_groups = len(l_counts)
-    l_ctr_bas_loc = np.cumsum(np.append(0, l_counts))
-    l_symb = lib.param.ANGULAR
-    q_cond = vhfopt.q_cond
-    pair_mappings = _make_pair_qd_cond(prim_mol, l_ctr_bas_loc, q_cond, dm_cond, q_cutoff)
-    dm_cond = None
-
-    pair_lst = []
-    task_offsets = {} # the pair_loc offsets for each ij pair
-    p0 = p1 = 0
-    for i in range(n_groups):
-        for j in range(i+1):
-            pair_ij_mapping = pair_mappings[i,j][0]
-            pair_lst.append(pair_ij_mapping)
-            p0, p1 = p1, p1 + pair_ij_mapping.size
-            task_offsets[i,j] = p0
-    pair_lst = cp.asarray(cp.hstack(pair_lst), dtype=np.int32)
-
-    ls = cp.asarray(prim_mol._bas[:,ANG_OF], dtype=np.int32)
-    ll = ls[:,None] + ls
-    ll = ll.ravel()[pair_lst] # drops the pairs that do not contribute to integrals
-    xyz_size = (ll+1)*(ll+2)*(ll+3)//6
-    pair_loc_on_gpu = cp.cumsum(cp.append(np.int32(0), xyz_size.ravel()), dtype=np.int32)
-    xyz_size = None
-
-    pair_lst = np.asarray(pair_lst.get(), dtype=np.int32)
-    pair_loc = pair_loc_on_gpu.get()
-    dms = dms.get()
-    dm_xyz = np.zeros(pair_loc[-1])
-    # Must use this modified _env to ensure the consistency with GPU kernel
-    # In this _env, normalization coefficients for s and p funcitons are scaled.
-    _env = _scale_sp_ctr_coeff(prim_mol)
-    libvhf_md.Et_dot_dm(
-        dm_xyz.ctypes, dms.ctypes, ao_loc.ctypes, pair_loc.ctypes,
-        pair_lst.ctypes, ctypes.c_int(len(pair_lst)),
-        p2c_mapping.ctypes,
-        ctypes.c_int(prim_mol.nbas), ctypes.c_int(sorted_mol.nbas),
-        prim_mol._bas.ctypes, _env.ctypes)
-    dm_xyz = asarray(dm_xyz)
-
-    _atm_gpu = cp.asarray(prim_mol._atm)
-    _bas_gpu = cp.asarray(prim_mol._bas)
-    _env_gpu = cp.asarray(_env)
-    rys_envs = RysIntEnvVars(
-        prim_mol.natm, prim_mol.nbas,
-        _atm_gpu.data.ptr, _bas_gpu.data.ptr, _env_gpu.data.ptr, 0,
-    )
-
-    err = libvhf_md.init_mdj_constant(ctypes.c_int(SHM_SIZE))
-    if err != 0:
-        raise RuntimeError('CUDA kernel initialization')
-    vj_xyz = cp.zeros_like(dm_xyz)
-    t1 = t2 = log.timer_debug1('q_cond and dm_cond', *cput0)
-
-    timing_collection = {}
-    kern_counts = 0
-    kern = libvhf_md.MD_build_j
-
-    for i in range(n_groups):
-        for j in range(i+1):
-            ij_shls = (l_ctr_bas_loc[i], l_ctr_bas_loc[i+1],
-                       l_ctr_bas_loc[j], l_ctr_bas_loc[j+1])
-            pair_ij_mapping, qd_ij_addrs = pair_mappings[i,j][:2]
-            pair_ij_loc = pair_loc_on_gpu[task_offsets[i,j]:]
-            if len(pair_ij_mapping) == 0:
-                continue
-            for k in range(i+1):
-                for l in range(k+1):
-                    if i == k and j < l: continue
-                    llll = f'({l_symb[i]}{l_symb[j]}|{l_symb[k]}{l_symb[l]})'
-                    kl_shls = (l_ctr_bas_loc[k], l_ctr_bas_loc[k+1],
-                               l_ctr_bas_loc[l], l_ctr_bas_loc[l+1])
-                    pair_kl_mapping, qd_kl_addrs = pair_mappings[k,l][:2]
-                    pair_kl_loc = pair_loc_on_gpu[task_offsets[k,l]:]
-                    if len(pair_kl_mapping) == 0:
-                        continue
-                    scheme = _md_j_engine_quartets_scheme((i, j, k, l))
-                    err = kern(
-                        ctypes.cast(vj_xyz.data.ptr, ctypes.c_void_p),
-                        ctypes.cast(dm_xyz.data.ptr, ctypes.c_void_p),
-                        ctypes.c_int(n_dm), ctypes.c_int(nao),
-                        rys_envs, (ctypes.c_int*5)(*scheme),
-                        (ctypes.c_int*8)(*ij_shls, *kl_shls),
-                        ctypes.c_int(pair_ij_mapping.size),
-                        ctypes.c_int(pair_kl_mapping.size),
-                        ctypes.cast(pair_ij_mapping.data.ptr, ctypes.c_void_p),
-                        ctypes.cast(pair_kl_mapping.data.ptr, ctypes.c_void_p),
-                        ctypes.cast(pair_ij_loc.data.ptr, ctypes.c_void_p),
-                        ctypes.cast(pair_kl_loc.data.ptr, ctypes.c_void_p),
-                        (ctypes.c_void_p*6)(*qd_ij_addrs),
-                        (ctypes.c_void_p*6)(*qd_kl_addrs),
-                        ctypes.cast(q_cond.data.ptr, ctypes.c_void_p),
-                        ctypes.c_float(log_cutoff),
-                        prim_mol._atm.ctypes, ctypes.c_int(prim_mol.natm),
-                        prim_mol._bas.ctypes, ctypes.c_int(prim_mol.nbas), _env.ctypes)
-                    if err != 0:
-                        raise RuntimeError(f'MD_build_j kernel for {llll} failed')
-                    if log.verbose >= logger.DEBUG1:
-                        ntasks = pair_ij_mapping.size * pair_kl_mapping.size
-                        t1, t1p = log.timer_debug1(f'processing {llll}, scheme={scheme} tasks ~= {ntasks}', *t1), t1
-                        if llll not in timing_collection:
-                            timing_collection[llll] = 0
-                        timing_collection[llll] += t1[1] - t1p[1]
-                        kern_counts += 1
-
-    if log.verbose >= logger.DEBUG1:
-        log.debug1('kernel launches %d', kern_counts)
-        for llll, t in timing_collection.items():
-            log.debug1('%s wall time %.2f', llll, t)
-        cp.cuda.Stream.null.synchronize()
-        log.timer_debug1('cuda kernel', *t2)
-
-    vj_xyz = vj_xyz.get()
-    vj = np.zeros_like(dms)
-    libvhf_md.jengine_dot_Et(
-        vj.ctypes, vj_xyz.ctypes, ao_loc.ctypes, pair_loc.ctypes,
-        pair_lst.ctypes, ctypes.c_int(len(pair_lst)),
-        p2c_mapping.ctypes,
-        ctypes.c_int(prim_mol.nbas), ctypes.c_int(sorted_mol.nbas),
-        prim_mol._bas.ctypes, _env.ctypes)
+    vj = vhfopt.get_j(dms, log)
     #:vj = cp.einsum('pi,npq,qj->nij', vhfopt.coeff, cp.asarray(vj), vhfopt.coeff)
-    vj = transpose_sum(asarray(vj))
     vj = vhfopt.apply_coeff_CT_mat_C(vj)
-
-    h_shls = vhfopt.h_shls
-    if h_shls:
-        mol = vhfopt.sorted_mol
-        log.debug3('Integrals for %s functions on CPU',
-                   lib.param.ANGULAR[LMAX+1])
-        scripts = ['ji->s2kl']
-        shls_excludes = [0, h_shls[0]] * 4
-        vs_h = _vhf.direct_mapdm('int2e_cart', 's8', scripts,
-                                 dms, 1, mol._atm, mol._bas, mol._env,
-                                 shls_excludes=shls_excludes)
-        vj1 = asarray(vs_h[0])
-        vj += hermi_triu(vj1)
-
     vj = vj.reshape(dm.shape)
     log.timer('vj', *cput0)
     return vj
@@ -309,6 +163,228 @@ class _VHFOpt(jk._VHFOpt):
             raise NotImplementedError
         log.timer('Initialize q_cond', *cput0)
         return self
+
+    def get_j(self, dms, verbose):
+        log = logger.new_logger(self.mol, verbose)
+        sorted_mol = self.sorted_mol
+        prim_mol = self.prim_mol
+        p2c_mapping = self.prim_to_ctr_mapping
+        ao_loc = sorted_mol.ao_loc
+        n_dm, nao = dms.shape[:2]
+        assert nao == ao_loc[-1]
+        dm_cond = cp.log(condense('absmax', dms, ao_loc) + 1e-300).astype(np.float32)
+        log_max_dm = float(dm_cond.max())
+        log_cutoff = math.log(self.direct_scf_tol)
+        q_cutoff = log_cutoff - log_max_dm
+        dm_cond = dm_cond[p2c_mapping[:,None],p2c_mapping]
+
+        l_counts = np.bincount(prim_mol._bas[:,ANG_OF])
+        n_groups = len(l_counts)
+        l_ctr_bas_loc = np.cumsum(np.append(0, l_counts))
+        l_symb = lib.param.ANGULAR
+        q_cond = self.q_cond
+        pair_mappings = _make_pair_qd_cond(prim_mol, l_ctr_bas_loc, q_cond, dm_cond, q_cutoff)
+        dm_cond = None
+
+        pair_lst = []
+        task_offsets = {} # the pair_loc offsets for each ij pair
+        p0 = p1 = 0
+        for i in range(n_groups):
+            for j in range(i+1):
+                pair_ij_mapping = pair_mappings[i,j][0]
+                pair_lst.append(pair_ij_mapping)
+                p0, p1 = p1, p1 + pair_ij_mapping.size
+                task_offsets[i,j] = p0
+        pair_lst = cp.asarray(cp.hstack(pair_lst), dtype=np.int32)
+
+        ls = cp.asarray(prim_mol._bas[:,ANG_OF], dtype=np.int32)
+        ll = ls[:,None] + ls
+        ll = ll.ravel()[pair_lst] # drops the pairs that do not contribute to integrals
+        xyz_size = (ll+1)*(ll+2)*(ll+3)//6
+        pair_loc_on_gpu = cp.cumsum(cp.append(np.int32(0), xyz_size.ravel()), dtype=np.int32)
+        xyz_size = None
+
+        pair_lst = np.asarray(pair_lst.get(), dtype=np.int32)
+        pair_loc = pair_loc_on_gpu.get()
+        dms = dms.get()
+        dm_xyz = np.zeros(pair_loc[-1])
+        # Must use this modified _env to ensure the consistency with GPU kernel
+        # In this _env, normalization coefficients for s and p funcitons are scaled.
+        _env = _scale_sp_ctr_coeff(prim_mol)
+        libvhf_md.Et_dot_dm(
+            dm_xyz.ctypes, dms.ctypes, ao_loc.ctypes, pair_loc.ctypes,
+            pair_lst.ctypes, ctypes.c_int(len(pair_lst)),
+            p2c_mapping.ctypes,
+            ctypes.c_int(prim_mol.nbas), ctypes.c_int(sorted_mol.nbas),
+            prim_mol._bas.ctypes, _env.ctypes)
+
+        tasks = []
+        for i in range(n_groups):
+            for j in range(i+1):
+                for k in range(i+1):
+                    for l in range(k+1):
+                        if i == k and j < l: continue
+                        tasks.append((i,j,k,l))
+        schemes = {t: _md_j_engine_quartets_scheme(t) for t in tasks}
+
+        def proc(dm_xyz):
+            device_id = cp.cuda.device.get_device_id()
+            stream = cp.cuda.stream.get_current_stream()
+            log = logger.new_logger(self.mol, verbose)
+            t0 = log.init_timer()
+            dm_xyz = asarray(dm_xyz) # transfer to current device
+            vj_xyz = cp.zeros_like(dm_xyz)
+            _atm_gpu = cp.asarray(prim_mol._atm)
+            _bas_gpu = cp.asarray(prim_mol._bas)
+            _env_gpu = cp.asarray(_env)
+            rys_envs = RysIntEnvVars(
+                prim_mol.natm, prim_mol.nbas,
+                _atm_gpu.data.ptr, _bas_gpu.data.ptr, _env_gpu.data.ptr, 0,
+            )
+
+            err = libvhf_md.init_mdj_constant(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError('CUDA kernel initialization')
+
+            _pair_mappings = pair_mappings
+            if num_devices > 1:
+                # Ensure the precomputation copied to each device
+                _pair_mappings = {}
+                for task, (pair_idx, _, qd) in pair_mappings.items():
+                    qd = [cp.asarray(x) for x in qd]
+                    addrs = [ctypes.cast(x.data.ptr, ctypes.c_void_p) for x in qd]
+                    _pair_mappings[task] = (cp.asarray(pair_idx), addrs, qd)
+            t1 = log.timer_debug1(f'q_cond on Device {device_id}', *t0)
+
+            timing_collection = {}
+            kern_counts = 0
+            kern = libvhf_md.MD_build_j
+
+            while tasks:
+                try:
+                    task = tasks.pop()
+                except IndexError:
+                    break
+
+                i, j, k, l = task
+                shls_slice = l_ctr_bas_loc[[i, i+1, j, j+1, k, k+1, l, l+1]]
+                pair_ij_mapping, qd_ij_addrs = _pair_mappings[i,j][:2]
+                pair_kl_mapping, qd_kl_addrs = _pair_mappings[k,l][:2]
+                if len(pair_ij_mapping) == 0 or len(pair_kl_mapping) == 0:
+                    continue
+                pair_ij_loc = pair_loc_on_gpu[task_offsets[i,j]:]
+                pair_kl_loc = pair_loc_on_gpu[task_offsets[k,l]:]
+                scheme = schemes[task]
+                err = kern(
+                    ctypes.cast(vj_xyz.data.ptr, ctypes.c_void_p),
+                    ctypes.cast(dm_xyz.data.ptr, ctypes.c_void_p),
+                    ctypes.c_int(n_dm), ctypes.c_int(nao),
+                    rys_envs, (ctypes.c_int*5)(*scheme),
+                    (ctypes.c_int*8)(*shls_slice),
+                    ctypes.c_int(pair_ij_mapping.size),
+                    ctypes.c_int(pair_kl_mapping.size),
+                    ctypes.cast(pair_ij_mapping.data.ptr, ctypes.c_void_p),
+                    ctypes.cast(pair_kl_mapping.data.ptr, ctypes.c_void_p),
+                    ctypes.cast(pair_ij_loc.data.ptr, ctypes.c_void_p),
+                    ctypes.cast(pair_kl_loc.data.ptr, ctypes.c_void_p),
+                    (ctypes.c_void_p*6)(*qd_ij_addrs),
+                    (ctypes.c_void_p*6)(*qd_kl_addrs),
+                    ctypes.cast(q_cond.data.ptr, ctypes.c_void_p),
+                    ctypes.c_float(log_cutoff),
+                    prim_mol._atm.ctypes, ctypes.c_int(prim_mol.natm),
+                    prim_mol._bas.ctypes, ctypes.c_int(prim_mol.nbas), _env.ctypes)
+
+                llll = f'({l_symb[i]}{l_symb[j]}|{l_symb[k]}{l_symb[l]})'
+                if err != 0:
+                    raise RuntimeError(f'MD_build_j kernel for {llll} failed')
+
+                if log.verbose >= logger.DEBUG1:
+                    ntasks = pair_ij_mapping.size * pair_kl_mapping.size
+                    t1, t1p = log.timer_debug1(f'processing {llll}, scheme={scheme} tasks ~= {ntasks}', *t1), t1
+                    if llll not in timing_collection:
+                        timing_collection[llll] = 0
+                    timing_collection[llll] += t1[1] - t1p[1]
+                    kern_counts += 1
+                if num_devices > 1:
+                    stream.synchronize()
+            return vj_xyz, kern_counts, timing_collection
+
+        results = multi_gpu.run(proc, args=(dm_xyz,), non_blocking=True)
+        kern_counts = 0
+        timing_collection = Counter()
+        vj_dist = []
+        for vj, counts, t_counter in results:
+            kern_counts += counts
+            timing_collection += t_counter
+            vj_dist.append(vj)
+
+        if log.verbose >= logger.DEBUG1:
+            log.debug1('kernel launches %d', kern_counts)
+            for llll, t in timing_collection.items():
+                log.debug1('%s wall time %.2f', llll, t)
+
+        vj_xyz = multi_gpu.array_reduce(vj_dist, inplace=True)
+        vj_xyz = vj_xyz.get()
+        vj = np.zeros_like(dms)
+        libvhf_md.jengine_dot_Et(
+            vj.ctypes, vj_xyz.ctypes, ao_loc.ctypes, pair_loc.ctypes,
+            pair_lst.ctypes, ctypes.c_int(len(pair_lst)),
+            p2c_mapping.ctypes,
+            ctypes.c_int(prim_mol.nbas), ctypes.c_int(sorted_mol.nbas),
+            prim_mol._bas.ctypes, _env.ctypes)
+        vj = transpose_sum(asarray(vj))
+
+        h_shls = self.h_shls
+        if h_shls:
+            mol = self.sorted_mol
+            log.debug3('Integrals for %s functions on CPU',
+                       lib.param.ANGULAR[LMAX+1])
+            scripts = ['ji->s2kl']
+            shls_excludes = [0, h_shls[0]] * 4
+            vs_h = _vhf.direct_mapdm('int2e_cart', 's8', scripts,
+                                     dms, 1, mol._atm, mol._bas, mol._env,
+                                     shls_excludes=shls_excludes)
+            vj1 = asarray(vs_h[0])
+            vj += hermi_triu(vj1)
+        return vj
+
+def _make_pair_qd_cond(mol, l_ctr_bas_loc, q_cond, dm_cond, cutoff):
+    n_groups = len(l_ctr_bas_loc) - 1
+    pair_mappings = {}
+    nbas = mol.nbas
+    for i in range(n_groups):
+        for j in range(i+1):
+            ish0, ish1 = l_ctr_bas_loc[i], l_ctr_bas_loc[i+1]
+            jsh0, jsh1 = l_ctr_bas_loc[j], l_ctr_bas_loc[j+1]
+            sub_q = q_cond[ish0:ish1,jsh0:jsh1]
+            mask = sub_q > cutoff
+            if i == j:
+                mask = cp.tril(mask)
+            t_ij = (cp.arange(ish0, ish1, dtype=np.int32)[:,None] * nbas +
+                    cp.arange(jsh0, jsh1, dtype=np.int32))
+            sub_q = sub_q[mask]
+            idx = cp.argsort(sub_q)[::-1]
+
+            # qd_tile_max is the product of q_cond and dm_cond within each batch
+            sub_q += dm_cond[ish0:ish1,jsh0:jsh1][mask]
+            qd_tile_max = cp.zeros((sub_q.size+31) & 0xffffffe0, # 32-element aligned
+                                   dtype=np.float32)
+            qd_tile_max[:sub_q.size] = sub_q[idx]
+            qd_tile2_max = qd_tile_max.reshape(-1,2).max(axis=1)
+            qd_tile4_max = qd_tile2_max.reshape(-1,2).max(axis=1)
+            qd_tile8_max = qd_tile4_max.reshape(-1,2).max(axis=1)
+            qd_tile16_max = qd_tile8_max.reshape(-1,2).max(axis=1)
+            qd_tile32_max = qd_tile16_max.reshape(-1,2).max(axis=1)
+            qd_tile_addrs = (ctypes.cast(qd_tile_max.data.ptr, ctypes.c_void_p),
+                             ctypes.cast(qd_tile2_max.data.ptr, ctypes.c_void_p),
+                             ctypes.cast(qd_tile4_max.data.ptr, ctypes.c_void_p),
+                             ctypes.cast(qd_tile8_max.data.ptr, ctypes.c_void_p),
+                             ctypes.cast(qd_tile16_max.data.ptr, ctypes.c_void_p),
+                             ctypes.cast(qd_tile32_max.data.ptr, ctypes.c_void_p))
+            qd_batch_max = (qd_tile_max, qd_tile2_max, qd_tile4_max, qd_tile8_max,
+                            qd_tile16_max, qd_tile32_max)
+            pair_mappings[i,j] = (t_ij[mask][idx], qd_tile_addrs, qd_batch_max)
+    return pair_mappings
 
 def _md_j_engine_quartets_scheme(ls, shm_size=SHM_SIZE):
     li, lj, lk, ll = ls

--- a/gpu4pyscf/scf/jk.py
+++ b/gpu4pyscf/scf/jk.py
@@ -508,6 +508,8 @@ class _VHFOpt:
                 shls_slice = l_ctr_bas_loc[[i, i+1, j, j+1, k, k+1, l, l+1]]
                 tile_ij_mapping = tile_mappings[i,j]
                 tile_kl_mapping = tile_mappings[k,l]
+                if len(tile_ij_mapping) == 0 or len(tile_kl_mapping) == 0:
+                    continue
                 scheme = schemes[task]
                 err = kern(
                     vj_ptr, vk_ptr, ctypes.cast(dms.data.ptr, ctypes.c_void_p),


### PR DESCRIPTION
* The MD-J engine is called by default in the hf_lowmem and rks_lowmem when computing the Coulomb matrix.
* Supports multiple GPUs for MD-J engine