### PR TITLE
Reduce resource for GDFTcontract_rho_gga_kernel to support 50xx gpus

### DIFF
--- a/gpu4pyscf/lib/gdft/contract_rho.cuh
+++ b/gpu4pyscf/lib/gdft/contract_rho.cuh
@@ -15,7 +15,7 @@
  */
 
 #define BLKSIZEX        32
-#define BLKSIZEY        32
+#define BLKSIZEY        16
 
 __global__
 void GDFTcontract_rho_kernel(double *rho, double *bra, double *ket, int ngrids, int nao);


### PR DESCRIPTION
Mirror Issue #440 , thanks for the detailed info. I've reproduced it on rtx 5080 + cuda 12.8.
Based on investigation of the available registers/shared memory of 50xx gpus and compute capability 12.0, we don't think our kernel actually required too much resources, it is more likely a problem from cuda compiler or runtime.