### PR TITLE
Improve numerical stability for multigrid v2

### DIFF
--- a/gpu4pyscf/lib/multigrid/multigrid_v2/screening.cuh
+++ b/gpu4pyscf/lib/multigrid/multigrid_v2/screening.cuh
@@ -25,6 +25,8 @@
 #include "utils.cuh"
 
 #define EIJ_CUTOFF 60
+#define BLOCK_DIM_XYZ 4
+#define EXP_OVERFLOW 400 
 
 namespace gpu4pyscf::gpbc::multi_grid {
 
@@ -78,14 +80,14 @@ template <int angular>
 __device__ double gaussian_summation_cutoff(const double exponent,
                                             const double prefactor_in_log,
                                             const double threshold_in_log) {
-// rho[r-Rp] = ci*cj * exp(-theta*(ri-rj)**2) * r**lij * exp(-aij*r**2)
-//           ~= ovlp * r**lij * exp(-aij*r**2)
-// log(ovlp) ~= log(ci*cj) - theta*(ri-rj)**2
-//           ~= log_cicj + prefactor_in_log
-// radius can be solved using fixed iteration
-// radius = (log(ovlp/precision * radius**(lij+l_inc)) / aij)**.5
-// where l_inc = 0 (LDA), 1 (GGA), 2 (MGGA)
-  constexpr double log_r = 2.302585092994046; // log(10)
+  // rho[r-Rp] = ci*cj * exp(-theta*(ri-rj)**2) * r**lij * exp(-aij*r**2)
+  //           ~= ovlp * r**lij * exp(-aij*r**2)
+  // log(ovlp) ~= log(ci*cj) - theta*(ri-rj)**2
+  //           ~= log_cicj + prefactor_in_log
+  // radius can be solved using fixed iteration
+  // radius = (log(ovlp/precision * radius**(lij+l_inc)) / aij)**.5
+  // where l_inc = 0 (LDA), 1 (GGA), 2 (MGGA)
+  constexpr double log_r = 2.302585092994046;                // log(10)
   const double log_of_doubled_exponents = log(2 * exponent); // for derivative
   const double log_aij = log(exponent) * 1.5;
   constexpr int l_inc = 1; // TODO: input l_inc for LDA or Coulomb potential
@@ -94,9 +96,10 @@ __device__ double gaussian_summation_cutoff(const double exponent,
   //    ~ (2*ai)^((li+3)/4) * ~1
   // approximate log(ci * cj) by the larger normalization coefficient ~= log(ci)
   // TODO: consider the basis contraction coefficients
-  double log_cicj = (angular+3)*.25 * log_of_doubled_exponents;
+  double log_cicj = (angular + 3) * .25 * log_of_doubled_exponents;
 
-  double approximated_log_of_sum = (angular + l_inc) * log_r + log_of_doubled_exponents;
+  double approximated_log_of_sum =
+      (angular + l_inc) * log_r + log_of_doubled_exponents;
   approximated_log_of_sum += prefactor_in_log + log_cicj - threshold_in_log;
   if (approximated_log_of_sum < 0) {
     approximated_log_of_sum = 0;
@@ -133,7 +136,7 @@ __global__ void count_non_trivial_pairs_kernel(
       j_image = j_shell_image_index - j_shell_index * n_images;
     }
   }
- 
+
   const int i_shell = is_valid_pair ? i_shells[i_shell_index] : 0;
   const int j_shell = is_valid_pair ? j_shells[j_shell_index] : 0;
 
@@ -350,14 +353,38 @@ __global__ void screen_gaussian_pairs_kernel(
   }
 }
 
-__global__ void count_pairs_on_blocks_kernel(int *n_pairs_per_block,
-                                             const int *pairs_to_blocks_begin,
-                                             const int *pairs_to_blocks_end,
-                                             const int n_pairs) {
+__global__ void count_pairs_on_blocks_kernel(
+    int *n_pairs_per_block, int *n_unstable_pairs_per_block,
+    const int *pairs_to_blocks_begin, const int *pairs_to_blocks_end,
+    const int n_pairs, const int *non_trivial_pairs, const int *i_shells,
+    const int *j_shells, const int n_j_shells, const int *image_indices,
+    const double *vectors_to_neighboring_images, const int n_images,
+    const int mesh_a, const int mesh_b, const int mesh_c, const int *atm,
+    const int *bas, const double *env) {
   const int block_index =
       blockIdx.x + blockIdx.y * gridDim.x + blockIdx.z * gridDim.x * gridDim.y;
+  const int a_start = blockIdx.x * BLOCK_DIM_XYZ;
+  const int b_start = blockIdx.y * BLOCK_DIM_XYZ;
+  const int c_start = blockIdx.z * BLOCK_DIM_XYZ;
+
+  const double da_squared =
+      distance_squared(dxyz_dabc[0], dxyz_dabc[1], dxyz_dabc[2]);
+  const double db_squared =
+      distance_squared(dxyz_dabc[3], dxyz_dabc[4], dxyz_dabc[5]);
+  const double dc_squared =
+      distance_squared(dxyz_dabc[6], dxyz_dabc[7], dxyz_dabc[8]);
+
+  const double start_position_x =
+      dxyz_dabc[0] * a_start + dxyz_dabc[3] * b_start + dxyz_dabc[6] * c_start;
+  const double start_position_y =
+      dxyz_dabc[1] * a_start + dxyz_dabc[4] * b_start + dxyz_dabc[7] * c_start;
+  const double start_position_z =
+      dxyz_dabc[2] * a_start + dxyz_dabc[5] * b_start + dxyz_dabc[8] * c_start;
+
   int count = 0;
+  int unstable_count = 0;
   constexpr int n_threads = 256;
+
   for (int i_pair = threadIdx.x; i_pair < n_pairs; i_pair += blockDim.x) {
     const int begin_block_a = pairs_to_blocks_begin[i_pair];
     const int end_block_a = pairs_to_blocks_end[i_pair];
@@ -368,16 +395,85 @@ __global__ void count_pairs_on_blocks_kernel(int *n_pairs_per_block,
     if (blockIdx.x >= begin_block_c && blockIdx.x <= end_block_c &&
         blockIdx.y >= begin_block_b && blockIdx.y <= end_block_b &&
         blockIdx.z >= begin_block_a && blockIdx.z <= end_block_a) {
-      count++;
+
+      const int image_index = image_indices[i_pair];
+      const int image_index_i = image_index / n_images;
+      const int image_index_j = image_index % n_images;
+
+      const int shell_pair_index = non_trivial_pairs[i_pair];
+      const int i_shell_index = shell_pair_index / n_j_shells;
+      const int j_shell_index = shell_pair_index % n_j_shells;
+      const int i_shell = i_shells[i_shell_index];
+      const int j_shell = j_shells[j_shell_index];
+
+      const double i_exponent = env[bas(PTR_EXP, i_shell)];
+      const int i_coord_offset = atm(PTR_COORD, bas(ATOM_OF, i_shell));
+      const double i_x = env[i_coord_offset] +
+                         vectors_to_neighboring_images[image_index_i * 3];
+      const double i_y = env[i_coord_offset + 1] +
+                         vectors_to_neighboring_images[image_index_i * 3 + 1];
+      const double i_z = env[i_coord_offset + 2] +
+                         vectors_to_neighboring_images[image_index_i * 3 + 2];
+
+      const double j_exponent = env[bas(PTR_EXP, j_shell)];
+      const int j_coord_offset = atm(PTR_COORD, bas(ATOM_OF, j_shell));
+      const double j_x = env[j_coord_offset] +
+                         vectors_to_neighboring_images[image_index_j * 3];
+      const double j_y = env[j_coord_offset + 1] +
+                         vectors_to_neighboring_images[image_index_j * 3 + 1];
+      const double j_z = env[j_coord_offset + 2] +
+                         vectors_to_neighboring_images[image_index_j * 3 + 2];
+
+      const double ij_exponent = i_exponent + j_exponent;
+      const double ij_exponent_in_prefactor =
+          i_exponent * j_exponent / ij_exponent *
+          distance_squared(i_x - j_x, i_y - j_y, i_z - j_z);
+
+      const double pair_x = (i_exponent * i_x + j_exponent * j_x) / ij_exponent;
+      const double pair_y = (i_exponent * i_y + j_exponent * j_y) / ij_exponent;
+      const double pair_z = (i_exponent * i_z + j_exponent * j_z) / ij_exponent;
+
+      const double x0 = start_position_x - pair_x;
+      const double y0 = start_position_y - pair_y;
+      const double z0 = start_position_z - pair_z;
+      const double cross_term_a_exponent =
+          -ij_exponent *
+          (2 * (dxyz_dabc[0] * x0 + dxyz_dabc[1] * y0 + dxyz_dabc[2] * z0) +
+           da_squared);
+      const double cross_term_b_exponent =
+          -ij_exponent *
+          (2 * (dxyz_dabc[3] * x0 + dxyz_dabc[4] * y0 + dxyz_dabc[5] * z0) +
+           db_squared);
+      const double cross_term_c_exponent =
+          -ij_exponent *
+          (2 * (dxyz_dabc[6] * x0 + dxyz_dabc[7] * y0 + dxyz_dabc[8] * z0) +
+           dc_squared);
+
+      if (cross_term_a_exponent <= EXP_OVERFLOW &&
+          cross_term_b_exponent <= EXP_OVERFLOW &&
+          cross_term_c_exponent <= EXP_OVERFLOW) {
+        count++;
+      } else {
+        unstable_count++;
+      }
     }
   }
   count = cub::BlockReduce<int, n_threads,
                            cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY>()
               .Sum(count);
+  __syncthreads();
+  unstable_count = cub::BlockReduce<int, n_threads,
+                                    cub::BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY>()
+                       .Sum(unstable_count);
   if (threadIdx.x == 0) {
     n_pairs_per_block[block_index] = count;
+    n_unstable_pairs_per_block[block_index] = unstable_count;
     if (count > 0) {
       atomicAdd(n_pairs_per_block + gridDim.x * gridDim.y * gridDim.z, 1);
+    }
+    if (unstable_count > 0) {
+      atomicAdd(n_unstable_pairs_per_block + gridDim.x * gridDim.y * gridDim.z,
+                1);
     }
   }
 }
@@ -386,13 +482,36 @@ __global__ void put_pairs_on_blocks_kernel(
     int *pairs_on_blocks, const int *accumulated_n_pairs_per_block,
     const int *sorted_block_index, const int *pairs_to_blocks_begin,
     const int *pairs_to_blocks_end, const int n_blocks_a, const int n_blocks_b,
-    const int n_blocks_c, const int n_pairs) {
+    const int n_blocks_c, const int n_pairs, const int *non_trivial_pairs,
+    const int *i_shells, const int *j_shells, const int n_j_shells,
+    const int *image_indices, const double *vectors_to_neighboring_images,
+    const int n_images, const int mesh_a, const int mesh_b, const int mesh_c,
+    const int *atm, const int *bas, const double *env) {
   const int block_index = sorted_block_index[blockIdx.x];
   const int n_blocks_bc = n_blocks_b * n_blocks_c;
   const int block_a_index = block_index / n_blocks_bc;
   const int block_bc_index = block_index % n_blocks_bc;
   const int block_b_index = block_bc_index / n_blocks_c;
   const int block_c_index = block_bc_index % n_blocks_c;
+
+  const int a_start = block_a_index * BLOCK_DIM_XYZ;
+  const int b_start = block_b_index * BLOCK_DIM_XYZ;
+  const int c_start = block_c_index * BLOCK_DIM_XYZ;
+
+  const double start_position_x =
+      dxyz_dabc[0] * a_start + dxyz_dabc[3] * b_start + dxyz_dabc[6] * c_start;
+  const double start_position_y =
+      dxyz_dabc[1] * a_start + dxyz_dabc[4] * b_start + dxyz_dabc[7] * c_start;
+  const double start_position_z =
+      dxyz_dabc[2] * a_start + dxyz_dabc[5] * b_start + dxyz_dabc[8] * c_start;
+
+  const double da_squared =
+      distance_squared(dxyz_dabc[0], dxyz_dabc[1], dxyz_dabc[2]);
+  const double db_squared =
+      distance_squared(dxyz_dabc[3], dxyz_dabc[4], dxyz_dabc[5]);
+  const double dc_squared =
+      distance_squared(dxyz_dabc[6], dxyz_dabc[7], dxyz_dabc[8]);
+
   constexpr int n_threads = 256;
   int stored_pair_index[4];
   int valid_pairs[4];
@@ -421,8 +540,72 @@ __global__ void put_pairs_on_blocks_kernel(
       if (block_c_index >= begin_block_c && block_c_index <= end_block_c &&
           block_b_index >= begin_block_b && block_b_index <= end_block_b &&
           block_a_index >= begin_block_a && block_a_index <= end_block_a) {
-        stored_pair_index[i] = i_pair;
-        valid_pairs[i] = 1;
+        const int image_index = image_indices[i_pair];
+        const int image_index_i = image_index / n_images;
+        const int image_index_j = image_index % n_images;
+
+        const int shell_pair_index = non_trivial_pairs[i_pair];
+        const int i_shell_index = shell_pair_index / n_j_shells;
+        const int j_shell_index = shell_pair_index % n_j_shells;
+        const int i_shell = i_shells[i_shell_index];
+        const int j_shell = j_shells[j_shell_index];
+
+        const double i_exponent = env[bas(PTR_EXP, i_shell)];
+        const int i_coord_offset = atm(PTR_COORD, bas(ATOM_OF, i_shell));
+        const double i_x = env[i_coord_offset] +
+                           vectors_to_neighboring_images[image_index_i * 3];
+        const double i_y = env[i_coord_offset + 1] +
+                           vectors_to_neighboring_images[image_index_i * 3 + 1];
+        const double i_z = env[i_coord_offset + 2] +
+                           vectors_to_neighboring_images[image_index_i * 3 + 2];
+
+        const double j_exponent = env[bas(PTR_EXP, j_shell)];
+        const int j_coord_offset = atm(PTR_COORD, bas(ATOM_OF, j_shell));
+        const double j_x = env[j_coord_offset] +
+                           vectors_to_neighboring_images[image_index_j * 3];
+        const double j_y = env[j_coord_offset + 1] +
+                           vectors_to_neighboring_images[image_index_j * 3 + 1];
+        const double j_z = env[j_coord_offset + 2] +
+                           vectors_to_neighboring_images[image_index_j * 3 + 2];
+
+        const double ij_exponent = i_exponent + j_exponent;
+        const double ij_exponent_in_prefactor =
+            i_exponent * j_exponent / ij_exponent *
+            distance_squared(i_x - j_x, i_y - j_y, i_z - j_z);
+
+        const double pair_x =
+            (i_exponent * i_x + j_exponent * j_x) / ij_exponent;
+        const double pair_y =
+            (i_exponent * i_y + j_exponent * j_y) / ij_exponent;
+        const double pair_z =
+            (i_exponent * i_z + j_exponent * j_z) / ij_exponent;
+
+        const double x0 = start_position_x - pair_x;
+        const double y0 = start_position_y - pair_y;
+        const double z0 = start_position_z - pair_z;
+
+        const double cross_term_a_exponent =
+            -ij_exponent *
+            (2 * (dxyz_dabc[0] * x0 + dxyz_dabc[1] * y0 + dxyz_dabc[2] * z0) +
+             da_squared);
+        const double cross_term_b_exponent =
+            -ij_exponent *
+            (2 * (dxyz_dabc[3] * x0 + dxyz_dabc[4] * y0 + dxyz_dabc[5] * z0) +
+             db_squared);
+        const double cross_term_c_exponent =
+            -ij_exponent *
+            (2 * (dxyz_dabc[6] * x0 + dxyz_dabc[7] * y0 + dxyz_dabc[8] * z0) +
+             dc_squared);
+        if (cross_term_a_exponent <= EXP_OVERFLOW &&
+            cross_term_b_exponent <= EXP_OVERFLOW &&
+            cross_term_c_exponent <= EXP_OVERFLOW) {
+          stored_pair_index[i] = i_pair;
+          valid_pairs[i] = 1;
+        } else {
+          // TODO: store as unstable pair
+          stored_pair_index[i] = -2;
+          valid_pairs[i] = 0;
+        }
       } else {
         stored_pair_index[i] = -2;
         valid_pairs[i] = 0;


### PR DESCRIPTION
This PR aims to (slightly) improve numerical stability for the recursion relation of gaussian pairs in multigrid v2 by the following two changes:

1. screen out the pairs at blocks where the recursion factors go too large
2. distribute the pair_prefactor into the components of gaussian

The screened subblock of pairs should be re-calculated via explicit gaussian calculation instead of RR, which should be introduced in later PRs.

Note that a lot of actual changes introduced in this PR is mainly due to the format changes - it would be helpful to have a `.clang-format` file fixed for all contributors.