### PR TITLE
3-center integrals contraction with density matrix and auxiliary vectors

### DIFF
--- a/gpu4pyscf/df/int3c2e_bdiv.py
+++ b/gpu4pyscf/df/int3c2e_bdiv.py
@@ -29,6 +29,8 @@ from gpu4pyscf.lib.cupy_helper import (
 from gpu4pyscf.gto.mole import group_basis, PTR_BAS_COORD
 from gpu4pyscf.scf.jk import g_pair_idx, _nearest_power2, _scale_sp_ctr_coeff, SHM_SIZE
 from gpu4pyscf.gto.mole import basis_seg_contraction, extract_pgto_params, cart2sph_by_l
+from gpu4pyscf.scf.jk import libvhf_rys
+from gpu4pyscf.scf.j_engine import libvhf_md
 
 __all__ = [
     'aux_e2',

--- a/gpu4pyscf/df/int3c2e_bdiv.py
+++ b/gpu4pyscf/df/int3c2e_bdiv.py
@@ -577,7 +577,7 @@ class Int3c2eOpt:
             nfj = nf[j]
             if i == j: # the diagonal blocks
                 ish, jsh = divmod(bas_ij_idx, nbas)
-                idx = np.where(ish == jsh)[0]
+                idx = cp.where(ish == jsh)[0].get()
                 addr = offset + idx[:,None] * (nfi*nfi) + np.arange(nfi*nfi)
                 diag.append(addr.ravel())
             offset += bas_ij_idx.size * nfi * nfj

--- a/gpu4pyscf/df/int3c2e_bdiv.py
+++ b/gpu4pyscf/df/int3c2e_bdiv.py
@@ -416,7 +416,7 @@ class Int3c2eOpt:
         preferred_blksizes = nsp_lookup[0,li,lj]
         pair_ij_offsets = []
         for shl_pair0, shl_pair1, blksize in zip(
-            self.shl_pair_offsets[:-1], self.shl_pair_offsets[1:], preferred_blksizes):
+                self.shl_pair_offsets[:-1], self.shl_pair_offsets[1:], preferred_blksizes):
             pair_ij_offsets.append(
                 np.arange(shl_pair0, shl_pair1, blksize, dtype=np.int32))
         pair_ij_offsets.append(self.shl_pair_offsets[-1])

--- a/gpu4pyscf/df/j_engine_3c2e.py
+++ b/gpu4pyscf/df/j_engine_3c2e.py
@@ -1,0 +1,209 @@
+# Copyright 2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ctypes
+import math
+import numpy as np
+import cupy as cp
+from pyscf import lib
+from pyscf.gto.mole import ANG_OF, PTR_EXP, conc_env
+from pyscf.scf import _vhf
+from gpu4pyscf.lib import logger
+from gpu4pyscf.lib.cupy_helper import asarray
+from gpu4pyscf.gto.mole import group_basis, PTR_BAS_COORD
+from gpu4pyscf.scf.jk import (
+    apply_coeff_C_mat_CT, _scale_sp_ctr_coeff, _nearest_power2, SHM_SIZE)
+from gpu4pyscf.gto.mole import basis_seg_contraction
+from gpu4pyscf.df.int3c2e_bdiv_1 import (
+    Int3c2eEnvVars, _conc_locs, LMAX, L_AUX_MAX, THREADS)
+from gpu4pyscf.scf.j_engine import libvhf_md, _to_primitive_bas
+
+libvhf_md.MD_int3c2e_init(SHM_SIZE)
+
+def contract_int3c2e_dm(mol, auxmol, dm):
+    int3c2e_opt = Int3c2eOpt(mol, auxmol).build()
+    return int3c2e_opt.contract_dm(dm)
+
+class Int3c2eOpt:
+    def __init__(self, mol, auxmol):
+        self.mol = mol
+        self.auxmol = auxmol
+        self.sorted_mol = None
+
+    def build(self, cutoff=1e-14):
+        mol = self.mol
+        log = logger.new_logger(mol)
+        cput0 = log.init_timer()
+        sorted_mol, ao_idx, l_ctr_pad_counts, uniq_l_ctr, l_ctr_counts = \
+                group_basis(mol, 1, sparse_coeff=True)
+        self.sorted_mol = sorted_mol
+        self.ao_idx = ao_idx
+        self.l_ctr_pad_counts = l_ctr_pad_counts
+        self.uniq_l_ctr = uniq_l_ctr
+        self.l_ctr_offsets = np.append(0, np.cumsum(l_ctr_counts))
+        # very high angular momentum basis are processed on CPU
+        lmax = uniq_l_ctr[:,0].max()
+        assert lmax <= LMAX
+
+        prim_mol, self.prim_to_ctr_mapping = _to_primitive_bas(sorted_mol)
+        self.prim_mol = prim_mol
+
+        #q_cond = _estimate_q_cond(prim_mol).get()
+        nbas = prim_mol.nbas
+        ao_loc = prim_mol.ao_loc
+        q_cond = np.empty((nbas,nbas))
+        intor = prim_mol._add_suffix('int2e')
+        _vhf.libcvhf.CVHFnr_int2e_q_cond(
+            getattr(_vhf.libcvhf, intor), lib.c_null_ptr(),
+            q_cond.ctypes, ao_loc.ctypes,
+            prim_mol._atm.ctypes, ctypes.c_int(prim_mol.natm),
+            prim_mol._bas.ctypes, ctypes.c_int(prim_mol.nbas),
+            prim_mol._env.ctypes)
+        q_cond = np.log(q_cond + 1e-300).astype(np.float32)
+        log.timer('Initialize q_cond', *cput0)
+
+        auxmol, coeff, uniq_l_ctr_aux, l_ctr_aux_counts = group_basis(self.auxmol, tile=1)
+        self.sorted_auxmol = auxmol
+        self.uniq_l_ctr_aux = uniq_l_ctr_aux
+        self.l_ctr_aux_offsets = np.append(0, np.cumsum(l_ctr_aux_counts))
+        self.aux_coeff = coeff.get()
+
+        _atm_cpu, _bas_cpu, _env_cpu = conc_env(
+            prim_mol._atm, prim_mol._bas, _scale_sp_ctr_coeff(prim_mol),
+            auxmol._atm, auxmol._bas, _scale_sp_ctr_coeff(auxmol))
+        #NOTE: PTR_BAS_COORD is not updated in conc_env()
+        off = _bas_cpu[prim_mol.nbas,PTR_EXP] - auxmol._bas[0,PTR_EXP]
+        _bas_cpu[prim_mol.nbas:,PTR_BAS_COORD] += off
+        self._atm = _atm_cpu
+        self._bas = _bas_cpu
+        self._env = _env_cpu
+
+        _atm = cp.array(_atm_cpu, dtype=np.int32)
+        _bas = cp.array(_bas_cpu, dtype=np.int32)
+        _env = cp.array(_env_cpu, dtype=np.float64)
+        ao_loc = cp.asarray(_conc_locs(ao_loc, auxmol.ao_loc), dtype=np.int32)
+        log_cutoff = math.log(cutoff)
+        self.int3c2e_envs = Int3c2eEnvVars.new(
+            prim_mol.natm, prim_mol.nbas, _atm, _bas, _env, ao_loc, log_cutoff)
+
+        l_counts = np.bincount(prim_mol._bas[:,ANG_OF])[:LMAX+1]
+        n_groups = len(l_counts)
+        bas_offsets = np.cumsum(np.append(0, l_counts))
+        ij_tasks = ((i, j) for i in range(n_groups) for j in range(i+1))
+        # The effective shell pair = ish*nbas+jsh
+        shl_pair_idx = []
+        nbas = mol.nbas
+        for i, j in ij_tasks:
+            ish0, ish1 = bas_offsets[i], bas_offsets[i+1]
+            jsh0, jsh1 = bas_offsets[j], bas_offsets[j+1]
+            mask = q_cond[ish0:ish1,jsh0:jsh1] > log_cutoff
+            if i == j:
+                mask = np.tril(mask)
+            t_ij = (np.arange(ish0, ish1, dtype=np.int32)[:,None] * nbas +
+                    np.arange(jsh0, jsh1, dtype=np.int32))
+            pair_idx = t_ij[mask]
+            if pair_idx.size > 0:
+                shl_pair_idx.append(pair_idx)
+
+        # the bas_ij_idx offset for each blockIdx.x
+        self.shl_pair_offsets = np.cumsum(
+            [0] + [x.size for x in shl_pair_idx], dtype=np.int32)
+        self.shl_pair_idx = shl_pair_idx = np.hstack(shl_pair_idx)
+        ls = np.asarray(prim_mol._bas[:,ANG_OF], dtype=np.int32)
+        ll = ls[:,None] + ls
+        ll = ll.ravel()[shl_pair_idx]
+        xyz_size = (ll+1)*(ll+2)*(ll+3)//6
+        self.pair_loc = np.cumsum(np.append(np.int32(0), xyz_size.ravel()), dtype=np.int32)
+        return self
+
+    def contract_dm(self, dm):
+        if self.sorted_mol is None:
+            self.build()
+        log = logger.new_logger(self.mol)
+        t0 = log.init_timer()
+        int3c2e_envs = self.int3c2e_envs
+        _atm_cpu = self._atm
+        _bas_cpu = self._bas
+        _env_cpu = self._env
+        sorted_mol = self.sorted_mol
+        ao_loc = sorted_mol.ao_loc
+        aux_loc = self.sorted_auxmol.ao_loc
+        naux = aux_loc[-1]
+        prim_mol = self.prim_mol
+
+        nsp_lookup = np.empty([L_AUX_MAX+1]*3, dtype=np.int32)
+        idx = np.arange(L_AUX_MAX+1)
+        nf = (idx + 1) * (idx + 2) // 2
+        shm_size = 0
+        for lk in range(L_AUX_MAX+1):
+            for li in range(lk+1):
+                for lj in range(li+1):
+                    nfk = nf[lk]
+                    order = li + lj + lk
+                    nf3ijkl = (order+1)*(order+2)*(order+3) // 6
+                    unit = order+1 + nf3ijkl + nf3ijkl*order//(order+3)
+                    nsp_per_block = (SHM_SIZE - nfk*8) //(unit*8) // 4
+                    nsp_per_block = min(THREADS, _nearest_power2(nsp_per_block))
+                    nsp_lookup[lk,li,lj] = nsp_per_block
+                    shm_size = max(shm_size, nsp_per_block*4 * unit*8 + nfk*8)
+        z, y, x = np.sort(np.meshgrid(idx, idx, idx), axis=0)
+        nsp_lookup = nsp_lookup[x, y, z]
+        nsp_lookup = cp.asarray(nsp_lookup[:,:LMAX+1,:LMAX+1], dtype=np.int32)
+
+        # Adjust the number of shell-pairs in each group for better balance.
+        shl_pair_idx_cpu = np.asarray(self.shl_pair_idx, dtype=np.int32)
+        shl_pair_idx = asarray(self.shl_pair_idx, dtype=np.int32)
+        pair_ij_offsets = cp.asarray(self.shl_pair_offsets, dtype=np.int32)
+        sp_blocks = len(pair_ij_offsets) - 1
+        log.debug1('sp_blocks = %d, ksh_blocks = %d', sp_blocks)
+
+        dm = cp.asarray(dm)
+        assert dm.ndim == 2
+        n_dm = 1
+        dm = apply_coeff_C_mat_CT(dm, self.mol, sorted_mol, self.uniq_l_ctr,
+                                  self.l_ctr_offsets, self.ao_idx)
+        dm_cpu = dm.get()
+        dm_xyz_size = self.pair_loc[-1]
+        dm_xyz = np.zeros((n_dm, dm_xyz_size))
+        _env = _scale_sp_ctr_coeff(prim_mol)
+        libvhf_md.Et_dot_dm(
+            dm_xyz.ctypes, dm_cpu.ctypes,
+            ctypes.c_int(n_dm), ctypes.c_int(dm_xyz_size),
+            ao_loc.ctypes, self.pair_loc.ctypes,
+            shl_pair_idx_cpu.ctypes, ctypes.c_int(len(shl_pair_idx_cpu)),
+            self.prim_to_ctr_mapping.ctypes,
+            ctypes.c_int(prim_mol.nbas), ctypes.c_int(sorted_mol.nbas),
+            prim_mol._bas.ctypes, _env.ctypes)
+        dm_xyz = asarray(dm_xyz)
+        pair_loc = asarray(self.pair_loc)
+
+        vj_aux = cp.zeros(naux)
+        err = libvhf_md.contract_int3c2e_dm(
+            ctypes.cast(vj_aux.data.ptr, ctypes.c_void_p),
+            ctypes.cast(dm_xyz.data.ptr, ctypes.c_void_p),
+            ctypes.c_int(n_dm), ctypes.c_int(naux),
+            ctypes.byref(int3c2e_envs), ctypes.c_int(shm_size),
+            ctypes.c_int(sp_blocks),
+            ctypes.c_int(self.sorted_auxmol.nbas),
+            ctypes.cast(pair_ij_offsets.data.ptr, ctypes.c_void_p),
+            ctypes.cast(shl_pair_idx.data.ptr, ctypes.c_void_p),
+            ctypes.cast(pair_loc.data.ptr, ctypes.c_void_p),
+            ctypes.cast(nsp_lookup.data.ptr, ctypes.c_void_p),
+            _atm_cpu.ctypes, ctypes.c_int(sorted_mol.natm),
+            _bas_cpu.ctypes, ctypes.c_int(sorted_mol.nbas), _env_cpu.ctypes)
+        if err != 0:
+            raise RuntimeError('contract_int3c2e_dm kernel failed')
+        if log.verbose >= logger.DEBUG1:
+            log.timer_debug1('processing contract_int3c2e_dm', *t0)
+        return vj_aux

--- a/gpu4pyscf/df/tests/test_df_int3c2e.py
+++ b/gpu4pyscf/df/tests/test_df_int3c2e.py
@@ -1,4 +1,5 @@
 import pytest
+import numpy as np
 import cupy as cp
 import pyscf
 from pyscf.df import incore
@@ -147,3 +148,32 @@ def test_group_blocks():
     assert int3c2e_bdiv.group_blocks([0, 1, 3, 4], 3) == [0, 2, 3]
     with pytest.raises(RuntimeError):
         int3c2e_bdiv.group_blocks([0, 4, 9, 14], 3)
+
+def test_contract_int3c2e():
+    from gpu4pyscf.df.j_engine_3c2e import contract_int3c2e_dm
+    from gpu4pyscf.df.int3c2e_bdiv import contract_int3c2e_auxvec
+    mol = pyscf.M(
+        atom = '''
+        O   0.000   -0.    0.1174
+        H  -0.757    8.   -0.4696
+        H   0.757    4.   -0.4696
+        C   1.      1.    0.
+        ''',
+        basis='ccpvtz')
+    auxmol = mol.copy()
+    auxmol.basis = ('weigend', [[3, [2, 1, .5], [1, .2, 1]]])
+    auxmol.build(0, 0)
+    np.random.seed(10)
+    nao = mol.nao
+    dm = np.random.rand(nao,nao)
+    dm = dm.dot(dm.T)
+    eri3c = incore.aux_e2(mol, auxmol)
+
+    dat = contract_int3c2e_dm(mol, auxmol, dm)
+    ref = np.einsum('ijP,ji->P', eri3c, dm)
+    assert abs(dat.get() - ref).max() < 1e-9
+
+    auxvec = np.random.rand(auxmol.nao)
+    dat = contract_int3c2e_auxvec(mol, auxmol, auxvec)
+    ref = np.einsum('ijP,P->ij', eri3c, auxvec)
+    assert abs(dat.get() - ref).max() < 1e-9

--- a/gpu4pyscf/gto/mole.py
+++ b/gpu4pyscf/gto/mole.py
@@ -293,7 +293,6 @@ def group_basis(mol, tile=1, group_size=None, return_bas_mapping=False,
         else:
             return mol, coeff, uniq_l_ctr, l_ctr_counts
     else:
-        n_cartesian = sum([(l+1)*(l+2)//2 for l in mol._bas[:,ANG_OF]])
         l_ctr_offsets = np.cumsum(l_ctr_counts)[:-1]
         if_pad_bas_per_l_ctr = np.split(if_pad_bas, l_ctr_offsets)
         l_ctr_pad_counts = np.array([np.sum(if_pad) for if_pad in if_pad_bas_per_l_ctr])

--- a/gpu4pyscf/gto/mole.py
+++ b/gpu4pyscf/gto/mole.py
@@ -205,9 +205,11 @@ def group_basis(mol, tile=1, group_size=None, return_bas_mapping=False,
     # mapping between the basis shells of the two types of mol instatnce,
     # ignoring general contraction. Enabling `allow_replica` will produce
     # replicated segment-contracted shells for general contracted shells.
-    allow_replica = sparse_coeff
-    mol, coeff = basis_seg_contraction(
-        mol, allow_replica=allow_replica, sparse_coeff=sparse_coeff)
+    if sparse_coeff:
+        mol, coeff = basis_seg_contraction(
+            mol, allow_replica=True, sparse_coeff=sparse_coeff)
+    else:
+        mol, coeff = basis_seg_contraction(mol, sparse_coeff=sparse_coeff)
 
     # Sort basis according to angular momentum and contraction patterns so
     # as to group the basis functions to blocks in GPU kernel.
@@ -292,7 +294,6 @@ def group_basis(mol, tile=1, group_size=None, return_bas_mapping=False,
             return mol, coeff, uniq_l_ctr, l_ctr_counts
     else:
         n_cartesian = sum([(l+1)*(l+2)//2 for l in mol._bas[:,ANG_OF]])
-        assert n_cartesian < 32768
         l_ctr_offsets = np.cumsum(l_ctr_counts)[:-1]
         if_pad_bas_per_l_ctr = np.split(if_pad_bas, l_ctr_offsets)
         l_ctr_pad_counts = np.array([np.sum(if_pad) for if_pad in if_pad_bas_per_l_ctr])

--- a/gpu4pyscf/gto/mole.py
+++ b/gpu4pyscf/gto/mole.py
@@ -175,16 +175,39 @@ def sort_atoms(mol):
 
     return [x for heavy_list in full_path for x in heavy_list]
 
-def group_basis(mol, tile=1, group_size=None, return_bas_mapping=False, sparse_coeff=False):
-    '''Group basis functions according to their [l, nprim] patterns.
+def group_basis(mol, tile=1, group_size=None, return_bas_mapping=False,
+                sparse_coeff=False):
+    '''Group and sort basis functions according to their [l, nprim] patterns.
 
-    bas_mapping is the index that transforms _bas from sorted_mol to mol:
-    mol._bas = sorted_mol._bas[bas_mapping]
+    Kwargs:
+        tile (int):
+            Align the number of basis shells in each group to a multiple of tile.
+            Basis functions with zero contraction coefficients may be padded to
+            preserve alignment. Default is 1.
+        group_size (int):
+            Maximum number of basis shells within each group. Be default, no
+            limit is applied.
+        return_bas_mapping (bool):
+            bas_mapping is an index array that can transform _bas from
+            sorted_mol to mol: mol._bas = sorted_mol._bas[bas_mapping]
+        sparse_coeff (bool):
+            One-to-one mapping between the sorted_mol and mol is assumed.
+            The array of mapping indices instead of a single transformation
+            matrix is returned if this option is specified.
     '''
     from gpu4pyscf.lib import logger
     original_mol = mol
 
-    mol, coeff = basis_seg_contraction(mol, sparse_coeff = sparse_coeff)
+    # When sparse_coeff is enabled, an array of AO mapping indices will be
+    # returned which can facilitate the transformation of the integral matrix
+    # between sorted_mol and mol using fancy-indexing, without applying the
+    # expensive C.T.dot(mat).dot(C). This fast transformation assumes one-one
+    # mapping between the basis shells of the two types of mol instatnce,
+    # ignoring general contraction. Enabling `allow_replica` will produce
+    # replicated segment-contracted shells for general contracted shells.
+    allow_replica = sparse_coeff
+    mol, coeff = basis_seg_contraction(
+        mol, allow_replica=allow_replica, sparse_coeff=sparse_coeff)
 
     # Sort basis according to angular momentum and contraction patterns so
     # as to group the basis functions to blocks in GPU kernel.

--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -1007,7 +1007,6 @@ def condense(opname, a, loc_x, loc_y=None):
     '''
     assert opname in ('sum', 'max', 'min', 'abssum', 'absmax', 'norm')
     assert a.dtype == np.float64
-    a = cupy.asarray(a, order='C')
     assert a.ndim >= 2
     if loc_y is None:
         loc_y = loc_x
@@ -1021,6 +1020,7 @@ def condense(opname, a, loc_x, loc_y=None):
     else:
         nx, ny = a.shape[-2:]
         a = a.reshape(-1, nx, ny)
+    a = cupy.asarray(a, order='C')
     loc_x = cupy.asarray(loc_x, cupy.int32)
     loc_y = cupy.asarray(loc_y, cupy.int32)
     nloc_x = loc_x.size - 1
@@ -1103,7 +1103,7 @@ void {fn_name}(double *out, double *a, int *loc_x, int *loc_y,
 
     kernel = _kernel_registery[fn_name]
     out = cupy.zeros((nloc_x, nloc_y))
-    blocks = ((nloc_x+15)//16, (nloc_y+15)//16)
+    blocks = ((nloc_y+15)//16, (nloc_x+15)//16)
     threads = (16, 16)
     kernel(blocks, threads, (out, a, loc_x, loc_y, nloc_x, nloc_y, counts))
     cupy.cuda.Stream.null.synchronize()

--- a/gpu4pyscf/lib/gint-rys/CMakeLists.txt
+++ b/gpu4pyscf/lib/gint-rys/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --ptxas-options=-v")# -maxrregcount=12
 add_library(gint_rys SHARED
   gint_driver.cu fill_int3c2e.cu unrolled_int3c2e.cu
   fill_int3c2e_bdiv.cu
-  rys_roots_dat.cu
+  rys_roots_dat.cu rys_constant.cu
 )
 
 set_target_properties(gint_rys PROPERTIES

--- a/gpu4pyscf/lib/gint-rys/fill_int3c2e_bdiv.cu
+++ b/gpu4pyscf/lib/gint-rys/fill_int3c2e_bdiv.cu
@@ -21,6 +21,7 @@
 
 #include "gvhf-rys/vhf.cuh"
 //#include "gvhf-rys/rys_roots.cu"
+#include "gvhf-rys/rys_contract_k.cuh"
 #include "int3c2e.cuh"
 
 #define GOUT_WIDTH      54
@@ -73,14 +74,6 @@ void int3c2e_bdiv_kernel(double *out, Int3c2eEnvVars envs, BDiv3c2eBounds bounds
     }
     __syncthreads();
     int lij = li + lj;
-    int *idx_ij = c_g_pair_idx + c_g_pair_offsets[li*LMAX1+lj];
-    int *idy_ij = idx_ij + nfij;
-    int *idz_ij = idx_ij + nfij * 2;
-    int lk_offset = lk * (lk + 1) * (lk + 2) / 2;
-    int *idx_k = c_g_cart_idx + lk_offset;
-    int *idy_k = idx_k + nfk;
-    int *idz_k = idx_k + nfk * 2;
-
     int nst_per_block = blockDim.x;
     if (lij + lk > 2) {
         nst_per_block = bounds.nst_lookup[(lk*LMAX1+lj)*LMAX1+li];
@@ -93,14 +86,25 @@ void int3c2e_bdiv_kernel(double *out, Int3c2eEnvVars envs, BDiv3c2eBounds bounds
     if (omega < 0) {
         nroots *= 2;
     }
-    int gx_len = g_size * nst_per_block;
-    extern __shared__ double rw_buffer[];
-    double *rw = rw_buffer + st_id;
-    double *gx = rw_buffer + nst_per_block * nroots*2 + st_id;
-    double *gy = gx + gx_len;
-    double *gz = gy + gx_len;
-    double *Rpq = gz + gx_len;
-    double *rjri = Rpq + nst_per_block * 3;
+    extern __shared__ double shared_memory[];
+    double *rjri = shared_memory + st_id;
+    double *Rpq = shared_memory + nst_per_block * 3 + st_id;
+    double *rw = shared_memory + nst_per_block * 6 + st_id;
+    double *gx = shared_memory + nst_per_block * (nroots*2+6) + st_id;
+    int *idx_i = (int*)(shared_memory + nst_per_block*(g_size*3+nroots*2+6));
+    int *idx_j = idx_i + nfi * 3;
+    int *idx_k = idx_j + nfj * 3;
+    if (thread_id < nfi * 3) {
+        idx_i[thread_id] = lex_xyz_address(li, thread_id) * nst_per_block;
+        idx_i[thread_id] += (thread_id % 3) * nst_per_block * g_size;
+    }
+    if (thread_id < nfj * 3) {
+        idx_j[thread_id] = lex_xyz_address(lj, thread_id) * stride_j * nst_per_block;
+    }
+    if (thread_id < nfk * 3) {
+        idx_k[thread_id] = lex_xyz_address(lk, thread_id) * stride_k * nst_per_block;
+    }
+
     double gout[GOUT_WIDTH];
     int naux = bounds.naux;
     double *out_local = out + bounds.ao_pair_loc[sp_block_id] * naux;
@@ -173,7 +177,7 @@ void int3c2e_bdiv_kernel(double *out, Int3c2eEnvVars envs, BDiv3c2eBounds bounds
                     double fac = PI_FAC * cijk / (aij*ak*sqrt(aij+ak));
                     double theta_ij = ai * aj_aij;
                     double Kab = theta_ij * rjri[3*nst_per_block];
-                    gy[0] = fac * exp(-Kab);
+                    gx[g_size*nst_per_block] = fac * exp(-Kab);
                     Rpq[0*nst_per_block] = xpq;
                     Rpq[1*nst_per_block] = ypq;
                     Rpq[2*nst_per_block] = zpq;
@@ -186,7 +190,7 @@ void int3c2e_bdiv_kernel(double *out, Int3c2eEnvVars envs, BDiv3c2eBounds bounds
                 for (int irys = 0; irys < nroots; ++irys) {
                     __syncthreads();
                     if (gout_id == 0) {
-                        gz[0] = rw[(irys*2+1)*nst_per_block];
+                        gx[g_size*nst_per_block*2] = rw[(irys*2+1)*nst_per_block];
                     }
                     double rt = rw[ irys*2   *nst_per_block];
                     double rt_aa = rt / (aij + ak);
@@ -281,13 +285,15 @@ void int3c2e_bdiv_kernel(double *out, Int3c2eEnvVars envs, BDiv3c2eBounds bounds
 #pragma unroll
                     for (int n = 0; n < GOUT_WIDTH; ++n) {
                         int ijk = gout_start + n*gout_stride+gout_id;
-                        int k  = ijk % nfk;
                         int ij = ijk / nfk;
                         if (ij >= nfij) break;
-                        int addrx = (idx_ij[ij] + idx_k[k] * stride_k) * nst_per_block;
-                        int addry = (idy_ij[ij] + idy_k[k] * stride_k) * nst_per_block;
-                        int addrz = (idz_ij[ij] + idz_k[k] * stride_k) * nst_per_block;
-                        gout[n] += gx[addrx] * gy[addry] * gz[addrz];
+                        int k = ijk % nfk;
+                        int i = ij % nfi;
+                        int j = ij / nfi;
+                        int addrx = idx_i[i*3+0] + idx_i[j*3+0] + idx_i[k*3+0];
+                        int addry = idx_i[i*3+1] + idx_i[j*3+1] + idx_i[k*3+1];
+                        int addrz = idx_i[i*3+2] + idx_i[j*3+2] + idx_i[k*3+2];
+                        gout[n] += gx[addrx] * gx[addry] * gx[addrz];
                     }
                 }
             }

--- a/gpu4pyscf/lib/gint-rys/int3c2e.cuh
+++ b/gpu4pyscf/lib/gint-rys/int3c2e.cuh
@@ -21,8 +21,8 @@
 #ifndef HAVE_DEFINED_INT3CENVVAS_H
 #define HAVE_DEFINED_INT3CENVVAS_H
 typedef struct {
-    uint16_t natm;
-    uint16_t nbas;
+    int natm;
+    int nbas;
     int *atm;
     int *bas;
     double *env;

--- a/gpu4pyscf/lib/gint-rys/rys_constant.cu
+++ b/gpu4pyscf/lib/gint-rys/rys_constant.cu
@@ -1,0 +1,1 @@
+#include "gvhf-rys/rys_constant.cu"

--- a/gpu4pyscf/lib/gvhf-md/CMakeLists.txt
+++ b/gpu4pyscf/lib/gvhf-md/CMakeLists.txt
@@ -3,6 +3,7 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --ptxas-options=-v")# -maxrregcount=12
 add_library(gvhf_md SHARED
   md_contract_j.cu unrolled_md_j.cu unrolled_md_j_4dm.cu
   md_indices.cu md_j_driver.cu md_pairdata.c 
+  contract_int3c2e.cu
 )
 
 #option(BUILD_SHARED_LIBS "build shared libraries" 1)

--- a/gpu4pyscf/lib/gvhf-md/contract_int3c2e.cu
+++ b/gpu4pyscf/lib/gvhf-md/contract_int3c2e.cu
@@ -27,6 +27,7 @@
 #include "gvhf-md/md_j.cuh"
 
 #define RT2_MAX 9
+#define THREADS 256
 
 extern __constant__ uint16_t c_Rt_idx[];
 extern __constant__ int8_t c_Rt_tuv_fac[];
@@ -62,150 +63,477 @@ inline void iter_Rt_n(double *out, double *Rt, double rx, double ry, double rz, 
     }
 }
 
+/*
+Et_base is generated using the recursion
+def get_E_tensor(l):
+    Et = np.zeros((l+1, l+1))
+    pow_a = np.zeros((l+1, l+1), dtype=int)
+    Et[0,0] = 1
+    for i in range(1, l+1):
+        Et[i,0] = Et[i-1,1]
+        pow_a[i,0] = pow_a[i-1,1]
+        for t in range(1, l+1):
+            Et[i,t] = i/(2*t)*Et[i-1,t-1]
+            pow_a[i,t] = pow_a[i-1,t-1] + 1
+
+    for i, (ix, iy, iz) in enumerate((ix, iy, l-ix-iy) for ix in reversed(range(l+1)) for iy in reversed(range(l+1-ix))):
+        for n, (t, u, v) in enumerate((t, u, v) for t in range(l+1) for u in range(l+1-t) for v in range(l+1-t-u)):
+            if Et[ix,t] * Et[iy,u] * Et[iz,v] != 0:
+                a_idx = pow_a[ix,t] + pow_a[iy,u] + pow_a[iz,v] - 1
+                if a_idx >= 0:
+                    print(f'out[{i}] += Rt[{n}] * aa[{a_idx}] * {Et[ix,t] * Et[iy,u] * Et[iz,v]};')
+                else:
+                    print(f'out[{i}] += Rt[{n}] * {Et[ix,t] * Et[iy,u] * Et[iz,v]};')
+ */
+template <int L> __device__ inline
+void _dot_Et(double *out, double *Rt, double ai)
+{
+    double aa[L+1];
+    aa[0] = 1 / ai;
+#pragma unroll
+    for (int n = 1; n < L; n++) {
+        aa[n] = aa[n-1] * aa[0];
+    }
+    if (L == 0) {
+        out[0] += Rt[0];
+    } else if (L == 1) {
+        out[0] += Rt[3] * aa[0] * 0.5;
+        out[1] += Rt[2] * aa[0] * 0.5;
+        out[2] += Rt[1] * aa[0] * 0.5;
+    } else if (L == 2) {
+        out[0] += Rt[0] * aa[0] * 0.5;
+        out[0] += Rt[9] * aa[1] * 0.25;
+        out[1] += Rt[8] * aa[1] * 0.25;
+        out[2] += Rt[7] * aa[1] * 0.25;
+        out[3] += Rt[0] * aa[0] * 0.5;
+        out[3] += Rt[5] * aa[1] * 0.25;
+        out[4] += Rt[4] * aa[1] * 0.25;
+        out[5] += Rt[0] * aa[0] * 0.5;
+        out[5] += Rt[2] * aa[1] * 0.25;
+    } else if (L == 3) {
+        out[0] += Rt[10] * aa[1] * 0.75;
+        out[0] += Rt[19] * aa[2] * 0.125;
+        out[1] += Rt[4] * aa[1] * 0.25;
+        out[1] += Rt[18] * aa[2] * 0.125;
+        out[2] += Rt[1] * aa[1] * 0.25;
+        out[2] += Rt[17] * aa[2] * 0.125;
+        out[3] += Rt[10] * aa[1] * 0.25;
+        out[3] += Rt[15] * aa[2] * 0.125;
+        out[4] += Rt[14] * aa[2] * 0.125;
+        out[5] += Rt[10] * aa[1] * 0.25;
+        out[5] += Rt[12] * aa[2] * 0.125;
+        out[6] += Rt[4] * aa[1] * 0.75;
+        out[6] += Rt[9] * aa[2] * 0.125;
+        out[7] += Rt[1] * aa[1] * 0.25;
+        out[7] += Rt[8] * aa[2] * 0.125;
+        out[8] += Rt[4] * aa[1] * 0.25;
+        out[8] += Rt[6] * aa[2] * 0.125;
+        out[9] += Rt[1] * aa[1] * 0.75;
+        out[9] += Rt[3] * aa[2] * 0.125;
+    } else if (L == 4) {
+        out[0] += Rt[0] * aa[1] * 0.75;
+        out[0] += Rt[25] * aa[2] * 0.75;
+        out[0] += Rt[34] * aa[3] * 0.0625;
+        out[1] += Rt[19] * aa[2] * 0.375;
+        out[1] += Rt[33] * aa[3] * 0.0625;
+        out[2] += Rt[16] * aa[2] * 0.375;
+        out[2] += Rt[32] * aa[3] * 0.0625;
+        out[3] += Rt[0] * aa[1] * 0.25;
+        out[3] += Rt[9] * aa[2] * 0.125;
+        out[3] += Rt[25] * aa[2] * 0.125;
+        out[3] += Rt[30] * aa[3] * 0.0625;
+        out[4] += Rt[6] * aa[2] * 0.125;
+        out[4] += Rt[29] * aa[3] * 0.0625;
+        out[5] += Rt[0] * aa[1] * 0.25;
+        out[5] += Rt[2] * aa[2] * 0.125;
+        out[5] += Rt[25] * aa[2] * 0.125;
+        out[5] += Rt[27] * aa[3] * 0.0625;
+        out[6] += Rt[19] * aa[2] * 0.375;
+        out[6] += Rt[24] * aa[3] * 0.0625;
+        out[7] += Rt[16] * aa[2] * 0.125;
+        out[7] += Rt[23] * aa[3] * 0.0625;
+        out[8] += Rt[19] * aa[2] * 0.125;
+        out[8] += Rt[21] * aa[3] * 0.0625;
+        out[9] += Rt[16] * aa[2] * 0.375;
+        out[9] += Rt[18] * aa[3] * 0.0625;
+        out[10] += Rt[0] * aa[1] * 0.75;
+        out[10] += Rt[9] * aa[2] * 0.75;
+        out[10] += Rt[14] * aa[3] * 0.0625;
+        out[11] += Rt[6] * aa[2] * 0.375;
+        out[11] += Rt[13] * aa[3] * 0.0625;
+        out[12] += Rt[0] * aa[1] * 0.25;
+        out[12] += Rt[2] * aa[2] * 0.125;
+        out[12] += Rt[9] * aa[2] * 0.125;
+        out[12] += Rt[11] * aa[3] * 0.0625;
+        out[13] += Rt[6] * aa[2] * 0.375;
+        out[13] += Rt[8] * aa[3] * 0.0625;
+        out[14] += Rt[0] * aa[1] * 0.75;
+        out[14] += Rt[2] * aa[2] * 0.75;
+        out[14] += Rt[4] * aa[3] * 0.0625;
+    } else if (L == 5) {
+        out[0] += Rt[21] * aa[2] * 1.875;
+        out[0] += Rt[46] * aa[3] * 0.625;
+        out[0] += Rt[55] * aa[4] * 0.03125;
+        out[1] += Rt[6] * aa[2] * 0.375;
+        out[1] += Rt[40] * aa[3] * 0.375;
+        out[1] += Rt[54] * aa[4] * 0.03125;
+        out[2] += Rt[1] * aa[2] * 0.375;
+        out[2] += Rt[37] * aa[3] * 0.375;
+        out[2] += Rt[53] * aa[4] * 0.03125;
+        out[3] += Rt[21] * aa[2] * 0.375;
+        out[3] += Rt[30] * aa[3] * 0.1875;
+        out[3] += Rt[46] * aa[3] * 0.0625;
+        out[3] += Rt[51] * aa[4] * 0.03125;
+        out[4] += Rt[27] * aa[3] * 0.1875;
+        out[4] += Rt[50] * aa[4] * 0.03125;
+        out[5] += Rt[21] * aa[2] * 0.375;
+        out[5] += Rt[23] * aa[3] * 0.1875;
+        out[5] += Rt[46] * aa[3] * 0.0625;
+        out[5] += Rt[48] * aa[4] * 0.03125;
+        out[6] += Rt[6] * aa[2] * 0.375;
+        out[6] += Rt[15] * aa[3] * 0.0625;
+        out[6] += Rt[40] * aa[3] * 0.1875;
+        out[6] += Rt[45] * aa[4] * 0.03125;
+        out[7] += Rt[1] * aa[2] * 0.125;
+        out[7] += Rt[12] * aa[3] * 0.0625;
+        out[7] += Rt[37] * aa[3] * 0.0625;
+        out[7] += Rt[44] * aa[4] * 0.03125;
+        out[8] += Rt[6] * aa[2] * 0.125;
+        out[8] += Rt[8] * aa[3] * 0.0625;
+        out[8] += Rt[40] * aa[3] * 0.0625;
+        out[8] += Rt[42] * aa[4] * 0.03125;
+        out[9] += Rt[1] * aa[2] * 0.375;
+        out[9] += Rt[3] * aa[3] * 0.0625;
+        out[9] += Rt[37] * aa[3] * 0.1875;
+        out[9] += Rt[39] * aa[4] * 0.03125;
+        out[10] += Rt[21] * aa[2] * 0.375;
+        out[10] += Rt[30] * aa[3] * 0.375;
+        out[10] += Rt[35] * aa[4] * 0.03125;
+        out[11] += Rt[27] * aa[3] * 0.1875;
+        out[11] += Rt[34] * aa[4] * 0.03125;
+        out[12] += Rt[21] * aa[2] * 0.125;
+        out[12] += Rt[23] * aa[3] * 0.0625;
+        out[12] += Rt[30] * aa[3] * 0.0625;
+        out[12] += Rt[32] * aa[4] * 0.03125;
+        out[13] += Rt[27] * aa[3] * 0.1875;
+        out[13] += Rt[29] * aa[4] * 0.03125;
+        out[14] += Rt[21] * aa[2] * 0.375;
+        out[14] += Rt[23] * aa[3] * 0.375;
+        out[14] += Rt[25] * aa[4] * 0.03125;
+        out[15] += Rt[6] * aa[2] * 1.875;
+        out[15] += Rt[15] * aa[3] * 0.625;
+        out[15] += Rt[20] * aa[4] * 0.03125;
+        out[16] += Rt[1] * aa[2] * 0.375;
+        out[16] += Rt[12] * aa[3] * 0.375;
+        out[16] += Rt[19] * aa[4] * 0.03125;
+        out[17] += Rt[6] * aa[2] * 0.375;
+        out[17] += Rt[8] * aa[3] * 0.1875;
+        out[17] += Rt[15] * aa[3] * 0.0625;
+        out[17] += Rt[17] * aa[4] * 0.03125;
+        out[18] += Rt[1] * aa[2] * 0.375;
+        out[18] += Rt[3] * aa[3] * 0.0625;
+        out[18] += Rt[12] * aa[3] * 0.1875;
+        out[18] += Rt[14] * aa[4] * 0.03125;
+        out[19] += Rt[6] * aa[2] * 0.375;
+        out[19] += Rt[8] * aa[3] * 0.375;
+        out[19] += Rt[10] * aa[4] * 0.03125;
+        out[20] += Rt[1] * aa[2] * 1.875;
+        out[20] += Rt[3] * aa[3] * 0.625;
+        out[20] += Rt[5] * aa[4] * 0.03125;
+    } else if (L == 6) {
+        out[0] += Rt[0] * aa[2] * 1.875;
+        out[0] += Rt[49] * aa[3] * 2.8125;
+        out[0] += Rt[74] * aa[4] * 0.46875;
+        out[0] += Rt[83] * aa[5] * 0.015625;
+        out[1] += Rt[34] * aa[3] * 0.9375;
+        out[1] += Rt[68] * aa[4] * 0.3125;
+        out[1] += Rt[82] * aa[5] * 0.015625;
+        out[2] += Rt[29] * aa[3] * 0.9375;
+        out[2] += Rt[65] * aa[4] * 0.3125;
+        out[2] += Rt[81] * aa[5] * 0.015625;
+        out[3] += Rt[0] * aa[2] * 0.375;
+        out[3] += Rt[13] * aa[3] * 0.1875;
+        out[3] += Rt[49] * aa[3] * 0.375;
+        out[3] += Rt[58] * aa[4] * 0.1875;
+        out[3] += Rt[74] * aa[4] * 0.03125;
+        out[3] += Rt[79] * aa[5] * 0.015625;
+        out[4] += Rt[8] * aa[3] * 0.1875;
+        out[4] += Rt[55] * aa[4] * 0.1875;
+        out[4] += Rt[78] * aa[5] * 0.015625;
+        out[5] += Rt[0] * aa[2] * 0.375;
+        out[5] += Rt[2] * aa[3] * 0.1875;
+        out[5] += Rt[49] * aa[3] * 0.375;
+        out[5] += Rt[51] * aa[4] * 0.1875;
+        out[5] += Rt[74] * aa[4] * 0.03125;
+        out[5] += Rt[76] * aa[5] * 0.015625;
+        out[6] += Rt[34] * aa[3] * 0.5625;
+        out[6] += Rt[43] * aa[4] * 0.09375;
+        out[6] += Rt[68] * aa[4] * 0.09375;
+        out[6] += Rt[73] * aa[5] * 0.015625;
+        out[7] += Rt[29] * aa[3] * 0.1875;
+        out[7] += Rt[40] * aa[4] * 0.09375;
+        out[7] += Rt[65] * aa[4] * 0.03125;
+        out[7] += Rt[72] * aa[5] * 0.015625;
+        out[8] += Rt[34] * aa[3] * 0.1875;
+        out[8] += Rt[36] * aa[4] * 0.09375;
+        out[8] += Rt[68] * aa[4] * 0.03125;
+        out[8] += Rt[70] * aa[5] * 0.015625;
+        out[9] += Rt[29] * aa[3] * 0.5625;
+        out[9] += Rt[31] * aa[4] * 0.09375;
+        out[9] += Rt[65] * aa[4] * 0.09375;
+        out[9] += Rt[67] * aa[5] * 0.015625;
+        out[10] += Rt[0] * aa[2] * 0.375;
+        out[10] += Rt[13] * aa[3] * 0.375;
+        out[10] += Rt[22] * aa[4] * 0.03125;
+        out[10] += Rt[49] * aa[3] * 0.1875;
+        out[10] += Rt[58] * aa[4] * 0.1875;
+        out[10] += Rt[63] * aa[5] * 0.015625;
+        out[11] += Rt[8] * aa[3] * 0.1875;
+        out[11] += Rt[19] * aa[4] * 0.03125;
+        out[11] += Rt[55] * aa[4] * 0.09375;
+        out[11] += Rt[62] * aa[5] * 0.015625;
+        out[12] += Rt[0] * aa[2] * 0.125;
+        out[12] += Rt[2] * aa[3] * 0.0625;
+        out[12] += Rt[13] * aa[3] * 0.0625;
+        out[12] += Rt[15] * aa[4] * 0.03125;
+        out[12] += Rt[49] * aa[3] * 0.0625;
+        out[12] += Rt[51] * aa[4] * 0.03125;
+        out[12] += Rt[58] * aa[4] * 0.03125;
+        out[12] += Rt[60] * aa[5] * 0.015625;
+        out[13] += Rt[8] * aa[3] * 0.1875;
+        out[13] += Rt[10] * aa[4] * 0.03125;
+        out[13] += Rt[55] * aa[4] * 0.09375;
+        out[13] += Rt[57] * aa[5] * 0.015625;
+        out[14] += Rt[0] * aa[2] * 0.375;
+        out[14] += Rt[2] * aa[3] * 0.375;
+        out[14] += Rt[4] * aa[4] * 0.03125;
+        out[14] += Rt[49] * aa[3] * 0.1875;
+        out[14] += Rt[51] * aa[4] * 0.1875;
+        out[14] += Rt[53] * aa[5] * 0.015625;
+        out[15] += Rt[34] * aa[3] * 0.9375;
+        out[15] += Rt[43] * aa[4] * 0.3125;
+        out[15] += Rt[48] * aa[5] * 0.015625;
+        out[16] += Rt[29] * aa[3] * 0.1875;
+        out[16] += Rt[40] * aa[4] * 0.1875;
+        out[16] += Rt[47] * aa[5] * 0.015625;
+        out[17] += Rt[34] * aa[3] * 0.1875;
+        out[17] += Rt[36] * aa[4] * 0.09375;
+        out[17] += Rt[43] * aa[4] * 0.03125;
+        out[17] += Rt[45] * aa[5] * 0.015625;
+        out[18] += Rt[29] * aa[3] * 0.1875;
+        out[18] += Rt[31] * aa[4] * 0.03125;
+        out[18] += Rt[40] * aa[4] * 0.09375;
+        out[18] += Rt[42] * aa[5] * 0.015625;
+        out[19] += Rt[34] * aa[3] * 0.1875;
+        out[19] += Rt[36] * aa[4] * 0.1875;
+        out[19] += Rt[38] * aa[5] * 0.015625;
+        out[20] += Rt[29] * aa[3] * 0.9375;
+        out[20] += Rt[31] * aa[4] * 0.3125;
+        out[20] += Rt[33] * aa[5] * 0.015625;
+        out[21] += Rt[0] * aa[2] * 1.875;
+        out[21] += Rt[13] * aa[3] * 2.8125;
+        out[21] += Rt[22] * aa[4] * 0.46875;
+        out[21] += Rt[27] * aa[5] * 0.015625;
+        out[22] += Rt[8] * aa[3] * 0.9375;
+        out[22] += Rt[19] * aa[4] * 0.3125;
+        out[22] += Rt[26] * aa[5] * 0.015625;
+        out[23] += Rt[0] * aa[2] * 0.375;
+        out[23] += Rt[2] * aa[3] * 0.1875;
+        out[23] += Rt[13] * aa[3] * 0.375;
+        out[23] += Rt[15] * aa[4] * 0.1875;
+        out[23] += Rt[22] * aa[4] * 0.03125;
+        out[23] += Rt[24] * aa[5] * 0.015625;
+        out[24] += Rt[8] * aa[3] * 0.5625;
+        out[24] += Rt[10] * aa[4] * 0.09375;
+        out[24] += Rt[19] * aa[4] * 0.09375;
+        out[24] += Rt[21] * aa[5] * 0.015625;
+        out[25] += Rt[0] * aa[2] * 0.375;
+        out[25] += Rt[2] * aa[3] * 0.375;
+        out[25] += Rt[4] * aa[4] * 0.03125;
+        out[25] += Rt[13] * aa[3] * 0.1875;
+        out[25] += Rt[15] * aa[4] * 0.1875;
+        out[25] += Rt[17] * aa[5] * 0.015625;
+        out[26] += Rt[8] * aa[3] * 0.9375;
+        out[26] += Rt[10] * aa[4] * 0.3125;
+        out[26] += Rt[12] * aa[5] * 0.015625;
+        out[27] += Rt[0] * aa[2] * 1.875;
+        out[27] += Rt[2] * aa[3] * 2.8125;
+        out[27] += Rt[4] * aa[4] * 0.46875;
+        out[27] += Rt[6] * aa[5] * 0.015625;
+    }
+}
+
 template <int LK> __device__ inline
 void unrolled_contract_int3c2e(Int3c2eEnvVars envs, JKMatrix jk, BDiv3c2eBounds bounds,
                                int *pair_ij_loc)
 {
-    int sp_block_id = gridDim.y - blockIdx.y - 1;
-    int ksh = blockIdx.x + envs.nbas;
-    int shl_pair0 = bounds.shl_pair_offsets[sp_block_id];
-    int shl_pair1 = bounds.shl_pair_offsets[sp_block_id+1];
-    int bas_ij0 = bounds.bas_ij_idx[shl_pair0];
-    int nbas = envs.nbas;
-    int *bas = envs.bas;
-    double *env = envs.env;
-    int ish0 = bas_ij0 / nbas;
-    int jsh0 = bas_ij0 % nbas;
-    int li = bas[ANG_OF + ish0*BAS_SLOTS];
-    int lj = bas[ANG_OF + jsh0*BAS_SLOTS];
-    double ck = env[bas[ksh*BAS_SLOTS+PTR_COEFF]] * PI_FAC;
-    double ak = env[bas[ksh*BAS_SLOTS+PTR_EXP]];
-    double *rk = env + bas[ksh*BAS_SLOTS+PTR_BAS_COORD];
-    double xk = rk[0];
-    double yk = rk[1];
-    double zk = rk[2];
     constexpr int lk = LK;
     constexpr int nfk = (lk + 1) * (lk + 2) / 2;
-
-    int lij = li + lj;
-    int order = lij + lk;
-    int nf3ij = (lij+1)*(lij+2)*(lij+3) / 6;
-    int nf3ijkl = (order+1)*(order+2)*(order+3) / 6;
-    double *dm = jk.dm;
-    int *nsp_lookup = bounds.nst_lookup;
-    register int nsp_per_block = nsp_lookup[lij*(L_AUX_MAX+1)+lk];
+    constexpr int nf3k = nfk * (lk + 3) / 3;
+    int sp_block_id = gridDim.y - blockIdx.y - 1;
+    int ksh = blockIdx.x + envs.nbas;
     int thread_id = threadIdx.x;
+    int *bas = envs.bas;
+    double *env = envs.env;
+    __shared__ int shl_pair0, shl_pair1;
+    if (thread_id == 0) {
+        shl_pair0 = bounds.shl_pair_offsets[sp_block_id];
+        shl_pair1 = bounds.shl_pair_offsets[sp_block_id+1];
+    }
+    __syncthreads();
+    int bas_ij0 = bounds.bas_ij_idx[shl_pair0];
+    int ish0 = bas_ij0 / envs.nbas;
+    int jsh0 = bas_ij0 % envs.nbas;
+    int li = bas[ANG_OF + ish0*BAS_SLOTS];
+    int lj = bas[ANG_OF + jsh0*BAS_SLOTS];
+    int lij = li + lj;
+    __shared__ int order, nf3ij, nf3ijkl, kprim;
+    __shared__ double rk[3];
+    if (thread_id == 0) {
+        order = lij + lk;
+        nf3ij = (lij+1)*(lij+2)*(lij+3) / 6;
+        nf3ijkl = (order+1)*(order+2)*(order+3) / 6;
+        kprim = bas[ksh*BAS_SLOTS+NPRIM_OF];
+        int rk_ptr = bas[ksh*BAS_SLOTS+PTR_BAS_COORD];
+        rk[0] = env[rk_ptr+0];
+        rk[1] = env[rk_ptr+1];
+        rk[2] = env[rk_ptr+2];
+    }
+    __syncthreads();
+    int *nsp_lookup = bounds.nst_lookup;
+    int nsp_per_block = nsp_lookup[lij*(L_AUX_MAX+1)+lk];
     int Rt_stride = blockDim.x / nsp_per_block;
     int sp_id = thread_id % nsp_per_block;
     int Rt_id = thread_id / nsp_per_block;
 
     extern __shared__ double phase[];
-    double *gamma_inc = phase + nfk;
-    double *Rt_buf = phase + nfk + (order+1) * nsp_per_block;
+    double *gamma_inc = phase + nf3k;
+    double *Rt_buf = phase + nf3k + (order+1) * nsp_per_block;
     uint16_t *p1_ij = Rt2_kl_ij + Rt2_idx_offsets[lij*RT2_MAX+lk];
     int8_t *efg_phase = c_Rt2_efg_phase + Rt2_idx_offsets[lk];
-    double vj_aux[nfk];
-#pragma unroll
-    for (int n = 0; n < nfk; ++n) {
-        vj_aux[n] = 0;
-    }
-    if (thread_id < nfk) {
+    if (thread_id < nf3k) {
         phase[thread_id] = efg_phase[thread_id];
     }
-
-    for (int pair_ij = shl_pair0+sp_id; pair_ij < shl_pair1+sp_id; pair_ij += nsp_per_block) {
+    for (int kp = 0; kp < kprim; ++kp) {
         __syncthreads();
-        int bas_ij, ij_loc0;
-        if (pair_ij < shl_pair1) {
-            bas_ij = bounds.bas_ij_idx[pair_ij];
-            ij_loc0 = pair_ij_loc[pair_ij];
-        } else {
-            bas_ij = bounds.bas_ij_idx[shl_pair0];
-            ij_loc0 = pair_ij_loc[shl_pair0];
-            ck = 0;
+        __shared__ double ak, ck;
+        if (thread_id == 0) {
+            ck = env[bas[ksh*BAS_SLOTS+PTR_COEFF] + kp] * PI_FAC;
+            ak = env[bas[ksh*BAS_SLOTS+PTR_EXP] + kp];
         }
-        int ish = bas_ij / nbas;
-        int jsh = bas_ij % nbas;
-        double ai = env[bas[ish*BAS_SLOTS+PTR_EXP]];
-        double aj = env[bas[jsh*BAS_SLOTS+PTR_EXP]];
-        double *ri = env + bas[ish*BAS_SLOTS+PTR_BAS_COORD];
-        double *rj = env + bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
-        double aij = ai + aj;
-        double xij = (ai * ri[0] + aj * rj[0]) / aij;
-        double yij = (ai * ri[1] + aj * rj[1]) / aij;
-        double zij = (ai * ri[2] + aj * rj[2]) / aij;
-        double *Rt, *buf;
-        if (order % 2 == 0) {
-            Rt = Rt_buf + sp_id;
-            buf = Rt + nf3ijkl * nsp_per_block;
-        } else {
-            buf = Rt_buf + sp_id;
-            Rt = buf + nf3ijkl * nsp_per_block;
+        double vj_xyz[nf3k];
+#pragma unroll
+        for (int n = 0; n < nf3k; ++n) {
+            vj_xyz[n] = 0;
         }
-        double xpq = xij - xk;
-        double ypq = yij - yk;
-        double zpq = zij - zk;
-        double rr = xpq*xpq + ypq*ypq + zpq*zpq;
-        double theta = aij * ak / (aij + ak);
-        if (Rt_id == 0) {
-            boys_fn(gamma_inc, theta, rr, jk.omega, ck/(aij*ak*sqrt(aij+ak)),
-                    order, sp_id, nsp_per_block);
-            Rt[0] = gamma_inc[sp_id+order*nsp_per_block];
-        }
-        for (int n = 1; n <= order; ++n) {
+        for (int pair_ij = shl_pair0+sp_id; pair_ij < shl_pair1+sp_id; pair_ij += nsp_per_block) {
             __syncthreads();
-            // swap input and output
-            double *tmp = buf;
-            buf = Rt;
-            Rt = tmp;
-            if (Rt_id == 0) {
-                Rt[0] = gamma_inc[sp_id+(order-n)*nsp_per_block];
-            }
-            if (n == 1) {
-                if (Rt_id == 0) {
-                    Rt[1*nsp_per_block] = zpq * buf[0*nsp_per_block];
-                    Rt[2*nsp_per_block] = ypq * buf[0*nsp_per_block];
-                    Rt[3*nsp_per_block] = xpq * buf[0*nsp_per_block];
-                }
-            } else if (n == 2) {
-                if (Rt_id == 0) {
-                    Rt[1*nsp_per_block] = zpq * buf[0*nsp_per_block];
-                    Rt[2*nsp_per_block] = zpq * buf[1*nsp_per_block] + buf[0*nsp_per_block];
-                    Rt[3*nsp_per_block] = ypq * buf[0*nsp_per_block];
-                    Rt[4*nsp_per_block] = ypq * buf[1*nsp_per_block];
-                    Rt[5*nsp_per_block] = ypq * buf[2*nsp_per_block] + buf[0*nsp_per_block];
-                    Rt[6*nsp_per_block] = xpq * buf[0*nsp_per_block];
-                    Rt[7*nsp_per_block] = xpq * buf[1*nsp_per_block];
-                    Rt[8*nsp_per_block] = xpq * buf[2*nsp_per_block];
-                    Rt[9*nsp_per_block] = xpq * buf[3*nsp_per_block] + buf[0*nsp_per_block];
-                }
+            int bas_ij;
+            if (pair_ij < shl_pair1) {
+                bas_ij = bounds.bas_ij_idx[pair_ij];
             } else {
-                iter_Rt_n(Rt, buf, xpq, ypq, zpq, n, nsp_per_block, Rt_id, Rt_stride);
+                bas_ij = bounds.bas_ij_idx[shl_pair0];
+            }
+            int ish = bas_ij / envs.nbas;
+            int jsh = bas_ij % envs.nbas;
+            double ai = env[bas[ish*BAS_SLOTS+PTR_EXP]];
+            double aj = env[bas[jsh*BAS_SLOTS+PTR_EXP]];
+            double *ri = env + bas[ish*BAS_SLOTS+PTR_BAS_COORD];
+            double *rj = env + bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
+            double aij = ai + aj;
+            double xij = (ai * ri[0] + aj * rj[0]) / aij;
+            double yij = (ai * ri[1] + aj * rj[1]) / aij;
+            double zij = (ai * ri[2] + aj * rj[2]) / aij;
+            double *Rt, *buf;
+            if (order % 2 == 0) {
+                Rt = Rt_buf + sp_id;
+                buf = Rt + nf3ijkl * nsp_per_block;
+            } else {
+                buf = Rt_buf + sp_id;
+                Rt = buf + nf3ijkl * nsp_per_block;
+            }
+            double xpq = xij - rk[0];
+            double ypq = yij - rk[1];
+            double zpq = zij - rk[2];
+            double rr = xpq*xpq + ypq*ypq + zpq*zpq;
+            double theta = aij * ak / (aij + ak);
+            if (Rt_id == 0) {
+                double fac = ck/(aij*ak*sqrt(aij+ak));
+                if (pair_ij >= shl_pair1) {
+                    fac = 0;
+                } else if (ish == jsh) {
+                    fac *= .5;
+                }
+                boys_fn(gamma_inc, theta, rr, jk.omega, fac, order, sp_id, nsp_per_block);
+                Rt[0] = gamma_inc[sp_id+order*nsp_per_block];
+            }
+            for (int n = 1; n <= order; ++n) {
+                __syncthreads();
+                // swap input and output
+                double *tmp = buf;
+                buf = Rt;
+                Rt = tmp;
+                if (Rt_id == 0) {
+                    Rt[0] = gamma_inc[sp_id+(order-n)*nsp_per_block];
+                }
+                if (n == 1) {
+                    if (Rt_id == 0) {
+                        Rt[1*nsp_per_block] = zpq * buf[0*nsp_per_block];
+                        Rt[2*nsp_per_block] = ypq * buf[0*nsp_per_block];
+                        Rt[3*nsp_per_block] = xpq * buf[0*nsp_per_block];
+                    }
+                } else if (n == 2) {
+                    if (Rt_id == 0) {
+                        Rt[1*nsp_per_block] = zpq * buf[0*nsp_per_block];
+                        Rt[2*nsp_per_block] = zpq * buf[1*nsp_per_block] + buf[0*nsp_per_block];
+                        Rt[3*nsp_per_block] = ypq * buf[0*nsp_per_block];
+                        Rt[4*nsp_per_block] = ypq * buf[1*nsp_per_block];
+                        Rt[5*nsp_per_block] = ypq * buf[2*nsp_per_block] + buf[0*nsp_per_block];
+                        Rt[6*nsp_per_block] = xpq * buf[0*nsp_per_block];
+                        Rt[7*nsp_per_block] = xpq * buf[1*nsp_per_block];
+                        Rt[8*nsp_per_block] = xpq * buf[2*nsp_per_block];
+                        Rt[9*nsp_per_block] = xpq * buf[3*nsp_per_block] + buf[0*nsp_per_block];
+                    }
+                } else {
+                    iter_Rt_n(Rt, buf, xpq, ypq, zpq, n, nsp_per_block, Rt_id, Rt_stride);
+                }
+            }
+            __syncthreads();
+
+            if (pair_ij < shl_pair1) {
+                int ij_loc0 = pair_ij_loc[pair_ij];
+                double *dm = jk.dm + ij_loc0;
+                Rt = Rt_buf;
+                for (int i = Rt_id; i < nf3ij; i += Rt_stride) {
+                    double dm_ij = dm[i];
+#pragma unroll
+                    for (int k = 0; k < nf3k; k++) {
+                        int off = k * nf3ij;
+                        double s = Rt[sp_id+p1_ij[off+i]*nsp_per_block];
+                        vj_xyz[k] += phase[k] * s * dm_ij;
+                    }
+                }
             }
         }
-        __syncthreads();
 
-        Rt = Rt_buf;
-        for (int i = Rt_id; i < nf3ij; i += Rt_stride) {
-            double dm_ij = dm[ij_loc0+i];
+        double vj_aux[nfk];
 #pragma unroll
-            for (int k = 0; k < nfk; k++) {
-                int off = k * nf3ij;
-                double s = Rt[sp_id+p1_ij[off+i]*nsp_per_block];
-                vj_aux[k] += phase[k] * s * dm_ij;
+        for (int n = 0; n < nfk; ++n) {
+            vj_aux[n] = 0;
+        }
+        _dot_Et<LK>(vj_aux, vj_xyz, ak);
+        int *ao_loc = envs.ao_loc;
+        int k0 = ao_loc[ksh] - ao_loc[bounds.aux_sh_offset];
+        double *vj = jk.vj + k0;
+        typedef cub::BlockReduce<double, THREADS> BlockReduceT;
+        __shared__ typename BlockReduceT::TempStorage temp_storage;
+#pragma unroll
+        for (int k = 0; k < nfk; k++) {
+            vj_aux[k] = BlockReduceT(temp_storage).Sum(vj_aux[k]);
+            if (thread_id == 0) {
+                atomicAdd(vj+k, vj_aux[k]);
             }
         }
-    }
-
-    int *ao_loc = envs.ao_loc;
-    int k0 = ao_loc[ksh] - ao_loc[bounds.aux_sh_offset];
-    double *vj = jk.vj + k0;
-    typedef cub::BlockReduce<double, 256> BlockReduceT;
-    __shared__ typename BlockReduceT::TempStorage temp_storage;
-#pragma unroll
-    for (int k = 0; k < nfk; k++) {
-        double vj_aux_k = BlockReduceT(temp_storage).Sum(vj_aux[k]);
-        atomicAdd(vj+k, vj_aux_k);
     }
 }
 
@@ -241,7 +569,7 @@ int contract_int3c2e_dm(double *vj, double *dm, int n_dm, int naux,
     double omega = env[PTR_RANGE_OMEGA];
     JKMatrix jk = {vj, NULL, dm, 1, 0, omega};
 
-    dim3 threads(256);
+    dim3 threads(THREADS);
     dim3 blocks(nksh, nbatches_shl_pair);
     contract_int3c2e_kernel<<<blocks, threads, shm_size>>>(*envs, jk, bounds, pair_ij_loc);
     cudaError_t err = cudaGetLastError();

--- a/gpu4pyscf/lib/gvhf-md/contract_int3c2e.cu
+++ b/gpu4pyscf/lib/gvhf-md/contract_int3c2e.cu
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2025 The PySCF Developers. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cub/cub.cuh>
+
+#include "gint-rys/int3c2e.cuh"
+#include "gvhf-rys/vhf.cuh"
+#include "gvhf-md/boys.cu"
+#include "gvhf-md/md_j.cuh"
+
+#define RT2_MAX 9
+
+extern __constant__ uint16_t c_Rt_idx[];
+extern __constant__ int8_t c_Rt_tuv_fac[];
+extern __constant__ int8_t c_Rt2_efg_phase[];
+extern __device__ int Rt2_idx_offsets[];
+extern __device__ uint16_t Rt2_kl_ij[];
+
+__device__
+inline void iter_Rt_n(double *out, double *Rt, double rx, double ry, double rz, int l,
+                      int nst_per_block, int gout_id, int gout_stride)
+{
+    int offsets = l*(l+1)*(l+2)*(l+3)/24;
+    uint16_t *p1 = c_Rt_idx + offsets - l;
+    double *pout = out + nst_per_block;
+    for (int v = gout_id; v < l; v += gout_stride) {
+        pout[v*nst_per_block] = rz * Rt[v*nst_per_block] + v * Rt[p1[v]*nst_per_block];
+    }
+    pout += l * nst_per_block;
+    p1 += l;
+    int8_t *tuv_fac = c_Rt_tuv_fac + offsets;
+
+    int n2 = l * (l+1) / 2;
+    for (int i = gout_id; i < n2; i += gout_stride) {
+        pout[i*nst_per_block] = ry * Rt[i*nst_per_block] + tuv_fac[i] * Rt[p1[i]*nst_per_block];
+    }
+    pout += n2 * nst_per_block;
+    p1 += n2;
+    tuv_fac += n2;
+
+    int n3 = n2 * (l+2) / 3;
+    for (int i = gout_id; i < n3; i += gout_stride) {
+        pout[i*nst_per_block] = rx * Rt[i*nst_per_block] + tuv_fac[i] * Rt[p1[i]*nst_per_block];
+    }
+}
+
+template <int LK> __device__ inline
+void unrolled_contract_int3c2e(Int3c2eEnvVars envs, JKMatrix jk, BDiv3c2eBounds bounds,
+                               int *pair_ij_loc)
+{
+    int sp_block_id = gridDim.y - blockIdx.y - 1;
+    int ksh = blockIdx.x + envs.nbas;
+    int shl_pair0 = bounds.shl_pair_offsets[sp_block_id];
+    int shl_pair1 = bounds.shl_pair_offsets[sp_block_id+1];
+    int bas_ij0 = bounds.bas_ij_idx[shl_pair0];
+    int nbas = envs.nbas;
+    int *bas = envs.bas;
+    double *env = envs.env;
+    int ish0 = bas_ij0 / nbas;
+    int jsh0 = bas_ij0 % nbas;
+    int li = bas[ANG_OF + ish0*BAS_SLOTS];
+    int lj = bas[ANG_OF + jsh0*BAS_SLOTS];
+    double ck = env[bas[ksh*BAS_SLOTS+PTR_COEFF]] * PI_FAC;
+    double ak = env[bas[ksh*BAS_SLOTS+PTR_EXP]];
+    double *rk = env + bas[ksh*BAS_SLOTS+PTR_BAS_COORD];
+    double xk = rk[0];
+    double yk = rk[1];
+    double zk = rk[2];
+    constexpr int lk = LK;
+    constexpr int nfk = (lk + 1) * (lk + 2) / 2;
+
+    int lij = li + lj;
+    int order = lij + lk;
+    int nf3ij = (lij+1)*(lij+2)*(lij+3) / 6;
+    int nf3ijkl = (order+1)*(order+2)*(order+3) / 6;
+    double *dm = jk.dm;
+    int *nsp_lookup = bounds.nst_lookup;
+    register int nsp_per_block = nsp_lookup[lij*(L_AUX_MAX+1)+lk];
+    int thread_id = threadIdx.x;
+    int Rt_stride = blockDim.x / nsp_per_block;
+    int sp_id = thread_id % nsp_per_block;
+    int Rt_id = thread_id / nsp_per_block;
+
+    extern __shared__ double phase[];
+    double *gamma_inc = phase + nfk;
+    double *Rt_buf = phase + nfk + (order+1) * nsp_per_block;
+    uint16_t *p1_ij = Rt2_kl_ij + Rt2_idx_offsets[lij*RT2_MAX+lk];
+    int8_t *efg_phase = c_Rt2_efg_phase + Rt2_idx_offsets[lk];
+    double vj_aux[nfk];
+#pragma unroll
+    for (int n = 0; n < nfk; ++n) {
+        vj_aux[n] = 0;
+    }
+    if (thread_id < nfk) {
+        phase[thread_id] = efg_phase[thread_id];
+    }
+
+    for (int pair_ij = shl_pair0+sp_id; pair_ij < shl_pair1+sp_id; pair_ij += nsp_per_block) {
+        __syncthreads();
+        int bas_ij, ij_loc0;
+        if (pair_ij < shl_pair1) {
+            bas_ij = bounds.bas_ij_idx[pair_ij];
+            ij_loc0 = pair_ij_loc[pair_ij];
+        } else {
+            bas_ij = bounds.bas_ij_idx[shl_pair0];
+            ij_loc0 = pair_ij_loc[shl_pair0];
+            ck = 0;
+        }
+        int ish = bas_ij / nbas;
+        int jsh = bas_ij % nbas;
+        double ai = env[bas[ish*BAS_SLOTS+PTR_EXP]];
+        double aj = env[bas[jsh*BAS_SLOTS+PTR_EXP]];
+        double *ri = env + bas[ish*BAS_SLOTS+PTR_BAS_COORD];
+        double *rj = env + bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
+        double aij = ai + aj;
+        double xij = (ai * ri[0] + aj * rj[0]) / aij;
+        double yij = (ai * ri[1] + aj * rj[1]) / aij;
+        double zij = (ai * ri[2] + aj * rj[2]) / aij;
+        double *Rt, *buf;
+        if (order % 2 == 0) {
+            Rt = Rt_buf + sp_id;
+            buf = Rt + nf3ijkl * nsp_per_block;
+        } else {
+            buf = Rt_buf + sp_id;
+            Rt = buf + nf3ijkl * nsp_per_block;
+        }
+        double xpq = xij - xk;
+        double ypq = yij - yk;
+        double zpq = zij - zk;
+        double rr = xpq*xpq + ypq*ypq + zpq*zpq;
+        double theta = aij * ak / (aij + ak);
+        if (Rt_id == 0) {
+            boys_fn(gamma_inc, theta, rr, jk.omega, ck/(aij*ak*sqrt(aij+ak)),
+                    order, sp_id, nsp_per_block);
+            Rt[0] = gamma_inc[sp_id+order*nsp_per_block];
+        }
+        for (int n = 1; n <= order; ++n) {
+            __syncthreads();
+            // swap input and output
+            double *tmp = buf;
+            buf = Rt;
+            Rt = tmp;
+            if (Rt_id == 0) {
+                Rt[0] = gamma_inc[sp_id+(order-n)*nsp_per_block];
+            }
+            if (n == 1) {
+                if (Rt_id == 0) {
+                    Rt[1*nsp_per_block] = zpq * buf[0*nsp_per_block];
+                    Rt[2*nsp_per_block] = ypq * buf[0*nsp_per_block];
+                    Rt[3*nsp_per_block] = xpq * buf[0*nsp_per_block];
+                }
+            } else if (n == 2) {
+                if (Rt_id == 0) {
+                    Rt[1*nsp_per_block] = zpq * buf[0*nsp_per_block];
+                    Rt[2*nsp_per_block] = zpq * buf[1*nsp_per_block] + buf[0*nsp_per_block];
+                    Rt[3*nsp_per_block] = ypq * buf[0*nsp_per_block];
+                    Rt[4*nsp_per_block] = ypq * buf[1*nsp_per_block];
+                    Rt[5*nsp_per_block] = ypq * buf[2*nsp_per_block] + buf[0*nsp_per_block];
+                    Rt[6*nsp_per_block] = xpq * buf[0*nsp_per_block];
+                    Rt[7*nsp_per_block] = xpq * buf[1*nsp_per_block];
+                    Rt[8*nsp_per_block] = xpq * buf[2*nsp_per_block];
+                    Rt[9*nsp_per_block] = xpq * buf[3*nsp_per_block] + buf[0*nsp_per_block];
+                }
+            } else {
+                iter_Rt_n(Rt, buf, xpq, ypq, zpq, n, nsp_per_block, Rt_id, Rt_stride);
+            }
+        }
+        __syncthreads();
+
+        Rt = Rt_buf;
+        for (int i = Rt_id; i < nf3ij; i += Rt_stride) {
+            double dm_ij = dm[ij_loc0+i];
+#pragma unroll
+            for (int k = 0; k < nfk; k++) {
+                int off = k * nf3ij;
+                double s = Rt[sp_id+p1_ij[off+i]*nsp_per_block];
+                vj_aux[k] += phase[k] * s * dm_ij;
+            }
+        }
+    }
+
+    int *ao_loc = envs.ao_loc;
+    int k0 = ao_loc[ksh] - ao_loc[bounds.aux_sh_offset];
+    double *vj = jk.vj + k0;
+    typedef cub::BlockReduce<double, 256> BlockReduceT;
+    __shared__ typename BlockReduceT::TempStorage temp_storage;
+#pragma unroll
+    for (int k = 0; k < nfk; k++) {
+        double vj_aux_k = BlockReduceT(temp_storage).Sum(vj_aux[k]);
+        atomicAdd(vj+k, vj_aux_k);
+    }
+}
+
+__global__ static
+void contract_int3c2e_kernel(Int3c2eEnvVars envs, JKMatrix jk, BDiv3c2eBounds bounds,
+                             int *pair_ij_loc)
+{
+    int ksh = blockIdx.x + envs.nbas;
+    int lk = envs.bas[ANG_OF + ksh*BAS_SLOTS];
+    switch (lk) {
+    case 0: unrolled_contract_int3c2e<0>(envs, jk, bounds, pair_ij_loc); break;
+    case 1: unrolled_contract_int3c2e<1>(envs, jk, bounds, pair_ij_loc); break;
+    case 2: unrolled_contract_int3c2e<2>(envs, jk, bounds, pair_ij_loc); break;
+    case 3: unrolled_contract_int3c2e<3>(envs, jk, bounds, pair_ij_loc); break;
+    case 4: unrolled_contract_int3c2e<4>(envs, jk, bounds, pair_ij_loc); break;
+    case 5: unrolled_contract_int3c2e<5>(envs, jk, bounds, pair_ij_loc); break;
+    case 6: unrolled_contract_int3c2e<6>(envs, jk, bounds, pair_ij_loc); break;
+    }
+}
+
+extern "C" {
+// contract('ijP,ji->P', int3c2e, dm)
+int contract_int3c2e_dm(double *vj, double *dm, int n_dm, int naux,
+                        Int3c2eEnvVars *envs, int shm_size,
+                        int nbatches_shl_pair, int nksh,
+                        int *shl_pair_offsets, int *bas_ij_idx,
+                        int *pair_ij_loc, int *nsp_lookup,
+                        int *atm, int natm, int *bas, int nbas, double *env)
+{
+    BDiv3c2eBounds bounds = {naux, nbas, bas_ij_idx, shl_pair_offsets,
+        NULL, NULL, nsp_lookup};
+
+    double omega = env[PTR_RANGE_OMEGA];
+    JKMatrix jk = {vj, NULL, dm, 1, 0, omega};
+
+    dim3 threads(256);
+    dim3 blocks(nksh, nbatches_shl_pair);
+    contract_int3c2e_kernel<<<blocks, threads, shm_size>>>(*envs, jk, bounds, pair_ij_loc);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in contract_int3c2e_dm, error message = %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+int MD_int3c2e_init(int shm_size)
+{
+    cudaFuncSetAttribute(contract_int3c2e_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+    return 0;
+}
+}

--- a/gpu4pyscf/lib/gvhf-md/md_contract_j.cu
+++ b/gpu4pyscf/lib/gvhf-md/md_contract_j.cu
@@ -585,8 +585,7 @@ void md_j_4dm_kernel(RysIntEnvVars envs, JKMatrix jk, MDBoundsInfo bounds,
                 double rr = xpq*xpq + ypq*ypq + zpq*zpq;
                 double theta = aij * akl / (aij + akl);
                 if (gout_id == 0) {
-                    double omega = env[PTR_RANGE_OMEGA];
-                    boys_fn(gamma_inc, theta, rr, omega, fac/(aij*akl*sqrt(aij+akl)),
+                    boys_fn(gamma_inc, theta, rr, jk.omega, fac/(aij*akl*sqrt(aij+akl)),
                             order, sq_id, nsq_per_block);
                     Rt[0] = gamma_inc[sq_id+order*nsq_per_block];
                 }

--- a/gpu4pyscf/lib/gvhf-rys/CMakeLists.txt
+++ b/gpu4pyscf/lib/gvhf-rys/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(gvhf_rys SHARED
   rys_contract_jk.cu unrolled_rys_jk.cu
   rys_contract_jk_ip1.cu unrolled_rys_jk_ip1.cu unrolled_ejk_ip1.cu
   rys_contract_jk_ip2.cu unrolled_ejk_ip2_type12.cu unrolled_ejk_ip2_type3.cu
+  contract_int3c2e.cu
 )
 
 #option(BUILD_SHARED_LIBS "build shared libraries" 1)

--- a/gpu4pyscf/lib/gvhf-rys/contract_int3c2e.cu
+++ b/gpu4pyscf/lib/gvhf-rys/contract_int3c2e.cu
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2025 The PySCF Developers. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <cuda_runtime.h>
+
+#include "gint/cuda_alloc.cuh"
+#include "gint-rys/int3c2e.cuh"
+#include "vhf.cuh"
+#include "rys_roots.cu"
+#include "rys_contract_k.cuh"
+#include "create_tasks.cu"
+
+#define IJ_WIDTH        50
+
+__global__ static
+void contract_int3c2e_kernel(Int3c2eEnvVars envs, JKMatrix jk, BDiv3c2eBounds bounds)
+{
+    // For better load balance, consume blocks in the reversed order
+    int thread_id = threadIdx.x;
+    int sp_block_id = gridDim.x - blockIdx.x - 1;
+    int ksh_block_id = gridDim.y - blockIdx.y - 1;
+    int shl_pair0 = bounds.shl_pair_offsets[sp_block_id];
+    int shl_pair1 = bounds.shl_pair_offsets[sp_block_id+1];
+    int ksh0 = bounds.ksh_offsets[ksh_block_id];
+    int ksh1 = bounds.ksh_offsets[ksh_block_id+1];
+    int bas_ij0 = bounds.bas_ij_idx[shl_pair0];
+    int nbas = envs.nbas;
+    int *bas = envs.bas;
+    double *env = envs.env;
+    int ish0 = bas_ij0 / nbas;
+    int jsh0 = bas_ij0 % nbas;
+    __shared__ int li, lj, lk, nroots;
+    __shared__ int nfi, nfj, nfk, nfij;
+    __shared__ int iprim, jprim, kprim;
+    __shared__ int stride_j, stride_k, g_size;
+    if (thread_id == 0) {
+        li = bas[ish0*BAS_SLOTS+ANG_OF];
+        lj = bas[jsh0*BAS_SLOTS+ANG_OF];
+        lk = bas[ksh0*BAS_SLOTS+ANG_OF];
+        nroots = (li + lj + lk) / 2 + 1;
+        double omega = jk.omega;
+        if (omega < 0) {
+            nroots *= 2;
+        }
+        nfi = (li + 1) * (li + 2) / 2;
+        nfj = (lj + 1) * (lj + 2) / 2;
+        nfk = (lk + 1) * (lk + 2) / 2;
+        nfij = nfi * nfj;
+        iprim = bas[ish0*BAS_SLOTS+NPRIM_OF];
+        jprim = bas[jsh0*BAS_SLOTS+NPRIM_OF];
+        kprim = bas[ksh0*BAS_SLOTS+NPRIM_OF];
+        stride_j = li + 1;
+        stride_k = stride_j * (lj + 1);
+        g_size = stride_k * (lk + 1);
+    }
+    __syncthreads();
+    register int nsp_per_block = bounds.nst_lookup[(lk*LMAX1+lj)*LMAX1+li];
+    int sp_id = thread_id % nsp_per_block;
+    int gout_id = thread_id / nsp_per_block;
+    int gout_stride = blockDim.x / nsp_per_block;
+
+    extern __shared__ double shared_memory[];
+    double *vj_aux = shared_memory;
+    double *rjri = shared_memory + nfk + sp_id;
+    double *Rpq = shared_memory + nfk + nsp_per_block * 3 + sp_id;
+    double *gx = shared_memory + nfk + nsp_per_block * 6 + sp_id;
+    double *rw = shared_memory + nfk + nsp_per_block * (g_size*3+6) + sp_id;
+    int *idx_i = (int*)(shared_memory + nfk + nsp_per_block*(g_size*3+nroots*2+6));
+    int *idx_j = idx_i + nfi * 3;
+    int *idx_k = idx_j + nfj * 3;
+    if (thread_id < nfi * 3) {
+        idx_i[thread_id] = lex_xyz_address(li, thread_id) * nsp_per_block;
+        idx_i[thread_id] += (thread_id % 3) * nsp_per_block * g_size;
+    }
+    if (thread_id < nfj * 3) {
+        idx_j[thread_id] = lex_xyz_address(lj, thread_id) * stride_j * nsp_per_block;
+    }
+    if (thread_id < nfk * 3) {
+        idx_k[thread_id] = lex_xyz_address(lk, thread_id) * stride_k * nsp_per_block;
+    }
+
+    for (int pair_ij = shl_pair0 + sp_id; pair_ij < shl_pair1; pair_ij += nsp_per_block) {
+        int bas_ij;
+        if (pair_ij < shl_pair1) {
+            bas_ij = bounds.bas_ij_idx[shl_pair0+sp_id];
+        } else {
+            bas_ij = bas_ij0;
+        }
+        int ish = bas_ij / nbas;
+        int jsh = bas_ij % nbas;
+        double *ri = env + bas[ish*BAS_SLOTS+PTR_BAS_COORD];
+        double *rj = env + bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
+        double xjxi = rj[0] - ri[0];
+        double yjyi = rj[1] - ri[1];
+        double zjzi = rj[2] - ri[2];
+        if (gout_id == 0) {
+            rjri[0*nsp_per_block] = xjxi;
+            rjri[1*nsp_per_block] = yjyi;
+            rjri[2*nsp_per_block] = zjzi;
+        }
+        double gout[IJ_WIDTH];
+#pragma unroll
+        for (int n = 0; n < IJ_WIDTH; ++n) { gout[n] = 0; }
+
+        for (int ijp = 0; ijp < iprim*jprim; ++ijp) {
+            __syncthreads();
+            double *expi = env + bas[ish*BAS_SLOTS+PTR_EXP];
+            double *expj = env + bas[jsh*BAS_SLOTS+PTR_EXP];
+            double *ci = env + bas[ish*BAS_SLOTS+PTR_COEFF];
+            double *cj = env + bas[jsh*BAS_SLOTS+PTR_COEFF];
+            int ip = ijp / jprim;
+            int jp = ijp % jprim;
+            double ai = expi[ip];
+            double aj = expj[jp];
+            double aij = ai + aj;
+            double aj_aij = aj / aij;
+            double theta_ij = ai * aj_aij;
+            double xjxi = rjri[0*nsp_per_block];
+            double yjyi = rjri[1*nsp_per_block];
+            double zjzi = rjri[2*nsp_per_block];
+            double rr_ij = xjxi*xjxi + yjyi*yjyi + zjzi*zjzi;
+            double Kab = exp(-theta_ij * rr_ij);
+            double cicj = ci[ip] * cj[jp] * Kab;
+            if (pair_ij >= shl_pair1) {
+                cicj = 0;
+            }
+            gx[0] = PI_FAC * cicj;
+
+            for (int ksh = ksh0; ksh < ksh1; ++ksh) {
+                double *expk = env + bas[ksh*BAS_SLOTS+PTR_EXP];
+                double *ck = env + bas[ksh*BAS_SLOTS+PTR_COEFF];
+                double *rk = env + bas[ksh*BAS_SLOTS+PTR_BAS_COORD];
+                __syncthreads();
+                int *ao_loc = envs.ao_loc;
+                int k0 = ao_loc[ksh0] - ao_loc[bounds.aux_sh_offset];
+                if (thread_id < nfk) {
+                    vj_aux[thread_id] = jk.dm[k0+thread_id];
+                }
+                for (int kp = 0; kp < kprim; ++kp) {
+                    __syncthreads();
+                    double ak = expk[kp];
+                    double xij = ri[0] + (rjri[0*nsp_per_block]) * aj_aij;
+                    double yij = ri[1] + (rjri[1*nsp_per_block]) * aj_aij;
+                    double zij = ri[2] + (rjri[2*nsp_per_block]) * aj_aij;
+                    double xpq = xij - rk[0];
+                    double ypq = yij - rk[1];
+                    double zpq = zij - rk[2];
+                    if (gout_id == 0) {
+                        Rpq[0*nsp_per_block] = xpq;
+                        Rpq[1*nsp_per_block] = ypq;
+                        Rpq[2*nsp_per_block] = zpq;
+                        gx[nsp_per_block*g_size] = ck[kp] / (aij*ak*sqrt(aij+ak));
+                    }
+                    double rr = xpq*xpq + ypq*ypq + zpq*zpq;
+                    double theta = aij * ak / (aij + ak);
+                    rys_roots_rs(nroots, theta, rr, jk.omega, rw, nsp_per_block,
+                                 gout_id, gout_stride);
+                    for (int irys = 0; irys < nroots; ++irys) {
+                        __syncthreads();
+                        if (gout_id == 0) {
+                            gx[nsp_per_block*g_size*2] = rw[(irys*2+1)*nsp_per_block];
+                        }
+                        double rt = rw[irys*2*nsp_per_block];
+                        double rt_aa = rt / (aij + ak);
+                        double s0x, s1x, s2x;
+                        int lij = li + lj;
+                        if (lij > 0) {
+                            double rt_aij = rt_aa * ak;
+                            double b10 = .5/aij * (1 - rt_aij);
+                            __syncthreads();
+                            for (int n = gout_id; n < 3; n += gout_stride) {
+                                double *_gx = gx + n * g_size * nsp_per_block;
+                                double Rpa = (rjri[n*nsp_per_block]) * aj_aij;
+                                double c0x = Rpa - rt_aij * Rpq[n*nsp_per_block];
+                                s0x = _gx[0];
+                                s1x = c0x * s0x;
+                                _gx[nsp_per_block] = s1x;
+                                for (int i = 1; i < lij; ++i) {
+                                    s2x = c0x * s1x + i * b10 * s0x;
+                                    _gx[(i+1)*nsp_per_block] = s2x;
+                                    s0x = s1x;
+                                    s1x = s2x;
+                                }
+                            }
+                        }
+
+                        if (lk > 0) {
+                            double rt_ak = rt_aa * aij;
+                            double b00 = .5 * rt_aa;
+                            double b01 = .5/ak * (1 - rt_ak);
+                            int lij3 = (lij+1)*3;
+                            for (int n = gout_id; n < lij3+gout_id; n += gout_stride) {
+                                __syncthreads();
+                                int i = n / 3;
+                                int _ix = n % 3;
+                                double *_gx = gx + (i + _ix * g_size) * nsp_per_block;
+                                double cpx = rt_ak * Rpq[_ix*nsp_per_block];
+                                if (n < lij3) {
+                                    s0x = _gx[0];
+                                    s1x = cpx * s0x;
+                                    if (i > 0) {
+                                        s1x += i * b00 * _gx[-nsp_per_block];
+                                    }
+                                    _gx[stride_k*nsp_per_block] = s1x;
+                                }
+
+                                for (int k = 1; k < lk; ++k) {
+                                    __syncthreads();
+                                    if (n < lij3) {
+                                        s2x = cpx*s1x + k*b01*s0x;
+                                        if (i > 0) {
+                                            s2x += i * b00 * _gx[(k*stride_k-1)*nsp_per_block];
+                                        }
+                                        _gx[(k*stride_k+stride_k)*nsp_per_block] = s2x;
+                                        s0x = s1x;
+                                        s1x = s2x;
+                                    }
+                                }
+                            }
+                        }
+
+                        if (lj > 0) {
+                            __syncthreads();
+                            if (pair_ij < shl_pair1) {
+                                for (int m = gout_id; m < (lk+1)*3; m += gout_stride) {
+                                    int k = m / 3;
+                                    int _ix = m % 3;
+                                    double xjxi = rjri[_ix*nsp_per_block];
+                                    double *_gx = gx + (_ix*g_size + k*stride_k) * nsp_per_block;
+                                    for (int j = 0; j < lj; ++j) {
+                                        int ij = lij + j*li; // = (lij-j) + j*stride_j;
+                                        s1x = _gx[ij*nsp_per_block];
+                                        for (--ij; ij >= j*stride_j; --ij) {
+                                            s0x = _gx[ij*nsp_per_block];
+                                            _gx[(ij+stride_j)*nsp_per_block] = s1x - xjxi * s0x;
+                                            s1x = s0x;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        __syncthreads();
+                        if (pair_ij < shl_pair1) {
+#pragma unroll
+                            for (int n = 0; n < IJ_WIDTH; ++n) {
+                                int ij = gout_id + n * gout_stride;
+                                if (ij >= nfij) break;
+                                int i = ij % nfi;
+                                int j = ij / nfi;
+                                int addrx = idx_i[i*3+0] + idx_j[j*3+0];
+                                int addry = idx_i[i*3+1] + idx_j[j*3+1];
+                                int addrz = idx_i[i*3+2] + idx_j[j*3+2];
+                                for (int k = 0; k < nfk; ++k) {
+                                    double Ix = gx[addrx + idx_k[k*3+0]];
+                                    double Iy = gx[addry + idx_k[k*3+1]];
+                                    double Iz = gx[addrz + idx_k[k*3+2]];
+                                    gout[n] += Ix * Iy * Iz * vj_aux[k];
+                                }
+                            }
+                        }
+                    }
+                }
+                __syncthreads();
+            }
+        }
+
+        if (pair_ij < shl_pair1) {
+            int *ao_loc = envs.ao_loc;
+            int nao = ao_loc[nbas];
+            int i0 = ao_loc[ish];
+            int j0 = ao_loc[jsh];
+            double *vj = jk.vj + i0 * nao + j0;
+#pragma unroll
+            for (int n = 0; n < IJ_WIDTH; ++n) {
+                int ij = gout_id + n * gout_stride;
+                if (ij >= nfij) break;
+                int i = ij % nfi;
+                int j = ij / nfi;
+                atomicAdd(vj+i*nao+j, gout[n]);
+            }
+        }
+    }
+}
+
+extern "C" {
+// contract('ijP,P->ij', int3c2e, auxvec)
+int contract_int3c2e_auxvec(double *vj, double *auxvec, int n_dm, int naux,
+                            Int3c2eEnvVars *envs, int shm_size,
+                            int nbatches_shl_pair, int nbatches_ksh,
+                            int *shl_pair_offsets, int *ksh_offsets,
+                            int *bas_ij_idx, int *nsp_lookup,
+                            int *atm, int natm, int *bas, int nbas, double *env)
+{
+    BDiv3c2eBounds bounds = {naux, nbas, bas_ij_idx, shl_pair_offsets,
+        NULL, ksh_offsets, nsp_lookup};
+
+    double omega = env[PTR_RANGE_OMEGA];
+    JKMatrix jmat = {vj, NULL, auxvec, n_dm, 0, omega};
+    int threads = 256;
+    dim3 blocks(nbatches_shl_pair, nbatches_ksh);
+    contract_int3c2e_kernel<<<blocks, threads, shm_size>>>(*envs, jmat, bounds);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in contract_int3c2e_auxvec, error message = %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+int RYS_int3c2e_init(int shm_size)
+{
+    cudaFuncSetAttribute(contract_int3c2e_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+    return 0;
+}
+}

--- a/gpu4pyscf/lib/gvhf-rys/create_tasks.cu
+++ b/gpu4pyscf/lib/gvhf-rys/create_tasks.cu
@@ -197,6 +197,7 @@ void _fill_sr_vk_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
     float skl_cutoff = cutoff - s_ij;
     float omega = env[PTR_RANGE_OMEGA];
     float omega2 = omega * omega;
+    float theta_ij = omega2 * aij / (aij + omega2);
 
     for (int pair_kl = t_id; pair_kl < bounds.npairs_kl; pair_kl += threads) {
         int bas_kl = pair_kl_mapping[pair_kl];
@@ -237,7 +238,7 @@ void _fill_sr_vk_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
             float xkl = xk + xqc;
             float ykl = yk + yqc;
             float zkl = zk + zqc;
-            float theta = 1./(1./aij+1./akl+1./omega2);
+            float theta = theta_ij * akl / (theta_ij + akl);
             float xpq = xij - xkl;
             float ypq = yij - ykl;
             float zpq = zij - zkl;
@@ -312,6 +313,7 @@ void _fill_sr_vjk_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
     float skl_cutoff = cutoff - s_ij;
     float omega = env[PTR_RANGE_OMEGA];
     float omega2 = omega * omega;
+    float theta_ij = omega2 * aij / (aij + omega2);
 
     for (int pair_kl = t_id; pair_kl < bounds.npairs_kl; pair_kl += threads) {
         int bas_kl = pair_kl_mapping[pair_kl];
@@ -354,7 +356,7 @@ void _fill_sr_vjk_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
             float xkl = xk + xqc;
             float ykl = yk + yqc;
             float zkl = zk + zqc;
-            float theta = 1./(1./aij+1./akl+1./omega2);
+            float theta = theta_ij * akl / (theta_ij + akl);
             float xpq = xij - xkl;
             float ypq = yij - ykl;
             float zpq = zij - zkl;
@@ -431,6 +433,7 @@ void _fill_sr_vj_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
     float skl_cutoff = cutoff - s_ij;
     float omega = env[PTR_RANGE_OMEGA];
     float omega2 = omega * omega;
+    float theta_ij = omega2 * aij / (aij + omega2);
 
     for (int pair_kl = t_id; pair_kl < bounds.npairs_kl; pair_kl += threads) {
         int bas_kl = pair_kl_mapping[pair_kl];
@@ -469,7 +472,7 @@ void _fill_sr_vj_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
             float xkl = xk + xqc;
             float ykl = yk + yqc;
             float zkl = zk + zqc;
-            float theta = 1./(1./aij+1./akl+1./omega2);
+            float theta = theta_ij * akl / (theta_ij + akl);
             float xpq = xij - xkl;
             float ypq = yij - ykl;
             float zpq = zij - zkl;
@@ -585,6 +588,7 @@ void _fill_sr_vjk_tasks_nosym(int *ntasks, int *bas_kl_idx, int bas_ij,
     float skl_cutoff = cutoff - s_ij;
     float omega = env[PTR_RANGE_OMEGA];
     float omega2 = omega * omega;
+    float theta_ij = omega2 * aij / (aij + omega2);
 
     for (int pair_kl = t_id; pair_kl < bounds.npairs_kl; pair_kl += threads) {
         int bas_kl = pair_kl_mapping[pair_kl];
@@ -624,7 +628,7 @@ void _fill_sr_vjk_tasks_nosym(int *ntasks, int *bas_kl_idx, int bas_ij,
             float xkl = xk + xqc;
             float ykl = yk + yqc;
             float zkl = zk + zqc;
-            float theta = 1./(1./aij+1./akl+1./omega2);
+            float theta = theta_ij * akl / (theta_ij + akl);
             float xpq = xij - xkl;
             float ypq = yij - ykl;
             float zpq = zij - zkl;
@@ -746,6 +750,7 @@ static void _fill_sr_ejk_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
     float skl_cutoff = cutoff - s_ij;
     float omega = env[PTR_RANGE_OMEGA];
     float omega2 = omega * omega;
+    float theta_ij = omega2 * aij / (aij + omega2);
     int do_j = jk.j_factor != 0;
     int do_k = jk.k_factor != 0;
 
@@ -787,7 +792,7 @@ static void _fill_sr_ejk_tasks(int *ntasks, int *bas_kl_idx, int bas_ij,
             float xkl = xk + xqc;
             float ykl = yk + yqc;
             float zkl = zk + zqc;
-            float theta = 1./(1./aij+1./akl+1./omega2);
+            float theta = theta_ij * akl / (theta_ij + akl);
             float xpq = xij - xkl;
             float ypq = yij - ykl;
             float zpq = zij - zkl;

--- a/gpu4pyscf/lib/gvhf-rys/rys_constant.cu
+++ b/gpu4pyscf/lib/gvhf-rys/rys_constant.cu
@@ -16,7 +16,7 @@
 
 #include <cuda.h>
 #include <cuda_runtime.h>
-#include <vhf.cuh>
+#include <gvhf-rys/vhf.cuh>
 
 __constant__ int _c_cartesian_lexical_xyz[] = {
     // s, offset = 0

--- a/gpu4pyscf/lib/gvhf-rys/vhf.cuh
+++ b/gpu4pyscf/lib/gvhf-rys/vhf.cuh
@@ -47,8 +47,8 @@
 
 #pragma once
 typedef struct {
-    uint16_t natm;
-    uint16_t nbas;
+    int natm;
+    int nbas;
     int *atm;
     int *bas;
     double *env;

--- a/gpu4pyscf/lib/pbc/fill_int2c2e.cu
+++ b/gpu4pyscf/lib/pbc/fill_int2c2e.cu
@@ -23,7 +23,7 @@
 #include "pbc.cuh"
 #include "int3c2e.cuh"
 
-#define GOUT_WIDTH      43
+#define GOUT_WIDTH      50
 
 __global__
 void pbc_int2c2e_kernel(double *out, PBCIntEnvVars envs, PBCInt2c2eBounds bounds)

--- a/gpu4pyscf/lib/tests/test_cupy_helper.py
+++ b/gpu4pyscf/lib/tests/test_cupy_helper.py
@@ -261,6 +261,14 @@ class KnownValues(unittest.TestCase):
         dat = cupy_helper.block_diag(arrs)
         assert cupy.array_equal(ref, dat)
 
+    def test_condense(self):
+        a = cupy.random.rand(120*6, 80*5)
+        loc_x = numpy.append(numpy.arange(0, a.shape[0], 6), a.shape[0])
+        loc_y = numpy.append(numpy.arange(0, a.shape[1], 5), a.shape[1])
+        dat = cupy_helper.condense('sum', a, loc_x, loc_y)
+        ref = a.reshape(120,6,80,5).transpose(0,2,1,3).sum(axis=(2,3))
+        assert abs(dat - ref).max() < 1e-12
+
 if __name__ == "__main__":
     print("Full tests for cupy helper module")
     unittest.main()

--- a/gpu4pyscf/pbc/gto/tests/test_pbc_int1e.py
+++ b/gpu4pyscf/pbc/gto/tests/test_pbc_int1e.py
@@ -62,6 +62,11 @@ def test_int1e_kin():
     dat = int1e.int1e_kin(cell, kpts=kpts).get()
     assert abs(dat - ref).max() < 1e-10
 
+    mol = cell.to_mol()
+    dat = int1e.int1e_kin(mol).get()
+    ref = mol.intor('int1e_kin', hermi=1)
+    assert abs(dat - ref).max() < 1e-12
+
 def test_int1e_ipovlp():
     cell = pyscf.M(
         atom='''C1  1.3    .2       .3
@@ -84,6 +89,11 @@ def test_int1e_ipovlp():
 
     dat = int1e.int1e_ipovlp(cell, kpts=kpts).get()
     assert abs(dat - ref).max() < 1e-10
+
+    mol = cell.to_mol()
+    dat = int1e.int1e_ipovlp(mol).get()
+    ref = mol.intor('int1e_ipovlp')
+    assert abs(dat - ref).max() < 1e-12
 
 def test_int1e_ipkin():
     cell = pyscf.M(

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -122,9 +122,10 @@ def get_hcore(mol):
         h = asarray(h)
     else:
         assert not mol.nucmod
-        from gpu4pyscf.gto.int3c1e import int1e_grids
+        from gpu4pyscf.df.int3c2e_bdiv import contract_int3c2e_auxvec
+        nucmol = gto.mole.fakemol_for_charges(mol.atom_coords())
         #:h = mol.intor_symmetric('int1e_nuc')
-        h = int1e_grids(mol, mol.atom_coords(), charges=-mol.atom_charges())
+        h = contract_int3c2e_auxvec(mol, nucmol, -mol.atom_charges())
         h += asarray(mol.intor_symmetric('int1e_kin'))
     if len(mol._ecpbas) > 0:
         h += get_ecp(mol)

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -113,20 +113,19 @@ def level_shift(s, d, f, factor):
     return f + dm_vir * factor
 
 def get_hcore(mol):
+    from gpu4pyscf.pbc.gto.int1e import int1e_kin
     if mol._pseudo:
         # Although mol._pseudo for GTH PP is only available in Cell, GTH PP
         # may exist if mol is converted from cell object.
         from pyscf.gto import pp_int
-        h = mol.intor_symmetric('int1e_kin')
-        h += pp_int.get_gth_pp(mol)
-        h = asarray(h)
+        h = asarray(pp_int.get_gth_pp(mol))
     else:
         assert not mol.nucmod
         from gpu4pyscf.df.int3c2e_bdiv import contract_int3c2e_auxvec
         nucmol = gto.mole.fakemol_for_charges(mol.atom_coords())
         #:h = mol.intor_symmetric('int1e_nuc')
         h = contract_int3c2e_auxvec(mol, nucmol, -mol.atom_charges())
-        h += asarray(mol.intor_symmetric('int1e_kin'))
+    h += int1e_kin(mol)
     if len(mol._ecpbas) > 0:
         h += get_ecp(mol)
     return h
@@ -623,7 +622,6 @@ class SCF(pyscf_lib.StreamObject):
     build                    = hf_cpu.SCF.build
     opt                      = NotImplemented
     dump_flags               = hf_cpu.SCF.dump_flags
-    get_ovlp                 = return_cupy_array(hf_cpu.SCF.get_ovlp)
     get_fock                 = get_fock
     get_occ                  = get_occ
     get_grad                 = staticmethod(get_grad)
@@ -677,6 +675,11 @@ class SCF(pyscf_lib.StreamObject):
     def get_hcore(self, mol=None):
         if mol is None: mol = self.mol
         return get_hcore(mol)
+
+    def get_ovlp(self, mol=None):
+        if mol is None: mol = self.mol
+        from gpu4pyscf.pbc.gto.int1e import int1e_ovlp
+        return int1e_ovlp(mol)
 
     def make_rdm1(self, mo_coeff=None, mo_occ=None, **kwargs):
         if mo_occ is None: mo_occ = self.mo_occ

--- a/gpu4pyscf/scf/hf_lowmem.py
+++ b/gpu4pyscf/scf/hf_lowmem.py
@@ -232,6 +232,8 @@ class RHF(hf.RHF):
 
     def get_hcore(self, mol=None):
         '''The lower triangular part of Hcore'''
+        if mol is None:
+            mol = self.mol
         hcore = hf.get_hcore(mol)
         return pack_tril(hcore).get()
 

--- a/gpu4pyscf/scf/j_engine.py
+++ b/gpu4pyscf/scf/j_engine.py
@@ -164,10 +164,6 @@ class _VHFOpt(jk._VHFOpt):
         log = logger.new_logger(self.mol, verbose)
         sorted_mol = self.sorted_mol
         prim_mol = self.prim_mol
-        # Small arrays pair_mappings, pair_loc etc may the occupy freed memory
-        # created in dms(). Preallocate workspace for these arrays
-        workspace = cp.empty(prim_mol.nbas**2*2)
-        workspace = None # noqa: F841
         if callable(dms):
             dms = dms()
         p2c_mapping = cp.asarray(self.prim_to_ctr_mapping)

--- a/gpu4pyscf/scf/jk.py
+++ b/gpu4pyscf/scf/jk.py
@@ -152,6 +152,97 @@ def get_j(mol, dm, hermi=0, vhfopt=None, verbose=None):
     log.timer('vj', *cput0)
     return vj
 
+def apply_coeff_C_mat_CT(spherical_matrix, mol, sorted_mol, uniq_l_ctr,
+                         l_ctr_offsets, ao_idx, l_ctr_paddings=None):
+    '''
+    Unsort AO and perform sph2cart transformation (if needed) for the last 2 axes
+    Fused kernel to perform 'ip,npq,qj->nij'
+    '''
+    spherical_matrix = cp.asarray(spherical_matrix)
+    spherical_matrix_ndim = spherical_matrix.ndim
+    if spherical_matrix_ndim == 2:
+        spherical_matrix = spherical_matrix[None]
+    counts = spherical_matrix.shape[0]
+    n_spherical = mol.nao
+    assert spherical_matrix.shape[1] == n_spherical
+    assert spherical_matrix.shape[2] == n_spherical
+    n_cartesian = sorted_mol.nao
+
+    l_ctr_count = np.asarray(l_ctr_offsets[1:] - l_ctr_offsets[:-1], dtype = np.int32)
+    l_ctr_l = np.asarray(uniq_l_ctr[:,0], dtype=np.int32, order='C')
+    if l_ctr_paddings is None:
+        l_ctr_pad_counts = np.zeros_like(l_ctr_count)
+    else:
+        l_ctr_pad_counts = np.asarray(l_ctr_paddings, dtype=np.int32)
+    ao_idx = cp.asarray(ao_idx, dtype=np.int32)
+    stream = cp.cuda.get_current_stream()
+
+    out = cp.zeros((counts, n_cartesian, n_cartesian), order = "C")
+    for i_dm in range(counts):
+        libgint.cart2sph_C_mat_CT_with_padding(
+            ctypes.cast(stream.ptr, ctypes.c_void_p),
+            ctypes.cast(out[i_dm].data.ptr, ctypes.c_void_p),
+            ctypes.cast(spherical_matrix[i_dm].data.ptr, ctypes.c_void_p),
+            ctypes.c_int(n_cartesian),
+            ctypes.c_int(n_spherical),
+            ctypes.c_int(l_ctr_l.shape[0]),
+            l_ctr_l.ctypes.data_as(ctypes.c_void_p),
+            l_ctr_count.ctypes.data_as(ctypes.c_void_p),
+            l_ctr_pad_counts.ctypes.data_as(ctypes.c_void_p),
+            ctypes.cast(ao_idx.data.ptr, ctypes.c_void_p),
+            ctypes.c_bool(mol.cart),
+        )
+
+    if spherical_matrix_ndim == 2:
+        out = out[0]
+    return out
+
+def apply_coeff_CT_mat_C(cartesian_matrix, mol, sorted_mol, uniq_l_ctr,
+                         l_ctr_offsets, ao_idx, l_ctr_paddings=None):
+    '''
+    Sort AO and perform cart2sph transformation (if needed) for the last 2 axes
+    Fused kernel to perform 'ip,npq,qj->nij'
+    '''
+    cartesian_matrix = cp.asarray(cartesian_matrix)
+    cartesian_matrix_ndim = cartesian_matrix.ndim
+    if cartesian_matrix_ndim == 2:
+        cartesian_matrix = cartesian_matrix[None]
+    counts = cartesian_matrix.shape[0]
+    n_cartesian = sorted_mol.nao
+    assert cartesian_matrix.shape[1] == n_cartesian
+    assert cartesian_matrix.shape[2] == n_cartesian
+    n_spherical = mol.nao
+
+    l_ctr_count = np.asarray(l_ctr_offsets[1:] - l_ctr_offsets[:-1], dtype = np.int32)
+    l_ctr_l = np.asarray(uniq_l_ctr[:,0], dtype=np.int32, order='C')
+    if l_ctr_paddings is None:
+        l_ctr_pad_counts = np.zeros_like(l_ctr_count)
+    else:
+        l_ctr_pad_counts = np.asarray(l_ctr_paddings, dtype=np.int32)
+    ao_idx = cp.asarray(ao_idx, dtype=np.int32)
+    stream = cp.cuda.get_current_stream()
+
+    out = cp.empty((counts, n_spherical, n_spherical), order = "C")
+    for i_dm in range(counts):
+        libgint.cart2sph_CT_mat_C_with_padding(
+            ctypes.cast(stream.ptr, ctypes.c_void_p),
+            ctypes.cast(cartesian_matrix[i_dm].data.ptr, ctypes.c_void_p),
+            ctypes.cast(out[i_dm].data.ptr, ctypes.c_void_p),
+            ctypes.c_int(n_cartesian),
+            ctypes.c_int(n_spherical),
+            ctypes.c_int(l_ctr_l.shape[0]),
+            l_ctr_l.ctypes.data_as(ctypes.c_void_p),
+            l_ctr_count.ctypes.data_as(ctypes.c_void_p),
+            l_ctr_pad_counts.ctypes.data_as(ctypes.c_void_p),
+            ctypes.cast(ao_idx.data.ptr, ctypes.c_void_p),
+            ctypes.c_bool(mol.cart),
+        )
+
+    if cartesian_matrix_ndim == 2:
+        out = out[0]
+    return out
+
+
 class _VHFOpt:
     def __init__(self, mol, cutoff=1e-13, tile=TILE):
         self.mol = mol
@@ -175,7 +266,7 @@ class _VHFOpt:
         mol, ao_idx, l_ctr_pad_counts, uniq_l_ctr, l_ctr_counts = group_basis(mol, self.tile, group_size, sparse_coeff = True)
         self.sorted_mol = mol
         self.ao_idx = ao_idx
-        self.l_ctr_pad_counts = l_ctr_pad_counts
+        self.l_ctr_pad_counts = np.asarray(l_ctr_pad_counts, dtype=np.int32)
         self.uniq_l_ctr = uniq_l_ctr
         self.l_ctr_offsets = np.append(0, np.cumsum(l_ctr_counts))
 
@@ -220,8 +311,8 @@ class _VHFOpt:
         return self
 
     def sort_orbitals(self, mat, axis=[]):
-        ''' 
-        Transform given axis of a matrix into sorted AO 
+        '''
+        Transform given axis of a matrix into sorted AO
         '''
         idx = self.ao_idx
         shape_ones = (1,) * mat.ndim
@@ -237,8 +328,8 @@ class _VHFOpt:
         return mat[tuple(fancy_index)]
 
     def unsort_orbitals(self, sorted_mat, axis=[]):
-        ''' 
-        Transform given axis of a matrix into sorted AO 
+        '''
+        Transform given axis of a matrix into sorted AO
         '''
         idx = self.ao_idx
         shape_ones = (1,) * sorted_mat.ndim
@@ -258,93 +349,25 @@ class _VHFOpt:
     def apply_coeff_C_mat_CT(self, spherical_matrix):
         '''
         Unsort AO and perform sph2cart transformation (if needed) for the last 2 axes
-        Fused kernel to perform 'ip,npq,qj->nij' 
+        Fused kernel to perform 'ip,npq,qj->nij'
         '''
-        spherical_matrix = cp.asarray(spherical_matrix)
-        spherical_matrix_ndim = spherical_matrix.ndim
-        if spherical_matrix_ndim == 2:
-            spherical_matrix = spherical_matrix[None]
-        counts = spherical_matrix.shape[0]
-        n_spherical = self.mol.nao
-        assert spherical_matrix.shape[1] == n_spherical
-        assert spherical_matrix.shape[2] == n_spherical
-        n_cartesian = self.sorted_mol.nao
-
-        l_ctr_count = np.asarray(self.l_ctr_offsets[1:] - self.l_ctr_offsets[:-1], dtype = np.int32)
-        l_ctr_l = np.asarray(self.uniq_l_ctr[:,0].copy(), dtype = np.int32)
-        self.l_ctr_pad_counts = np.asarray(self.l_ctr_pad_counts, dtype = np.int32)
-        cupy_ao_idx = self.cupy_ao_idx
-        stream = cp.cuda.get_current_stream()
-
-        # ref = cp.einsum("ij,qjk,kl->qil", self.coeff, spherical_matrix, self.coeff.T)
-
-        out = cp.zeros((counts, n_cartesian, n_cartesian), order = "C")
-        for i_dm in range(counts):
-            libgint.cart2sph_C_mat_CT_with_padding(
-                ctypes.cast(stream.ptr, ctypes.c_void_p),
-                ctypes.cast(out[i_dm].data.ptr, ctypes.c_void_p),
-                ctypes.cast(spherical_matrix[i_dm].data.ptr, ctypes.c_void_p),
-                ctypes.c_int(n_cartesian),
-                ctypes.c_int(n_spherical),
-                ctypes.c_int(l_ctr_l.shape[0]),
-                l_ctr_l.ctypes.data_as(ctypes.c_void_p),
-                l_ctr_count.ctypes.data_as(ctypes.c_void_p),
-                self.l_ctr_pad_counts.ctypes.data_as(ctypes.c_void_p),
-                ctypes.cast(cupy_ao_idx.data.ptr, ctypes.c_void_p),
-                ctypes.c_bool(self.mol.cart),
-            )
-
-        if spherical_matrix_ndim == 2:
-            out = out[0]
-        return out
+        return apply_coeff_C_mat_CT(
+            spherical_matrix, self.mol, self.sorted_mol, self.uniq_l_ctr,
+            self.l_ctr_offsets, self.cupy_ao_idx, self.l_ctr_pad_counts)
 
     def apply_coeff_CT_mat_C(self, cartesian_matrix):
         '''
         Sort AO and perform cart2sph transformation (if needed) for the last 2 axes
-        Fused kernel to perform 'ip,npq,qj->nij' 
+        Fused kernel to perform 'ip,npq,qj->nij'
         '''
-        cartesian_matrix = cp.asarray(cartesian_matrix)
-        cartesian_matrix_ndim = cartesian_matrix.ndim
-        if cartesian_matrix_ndim == 2:
-            cartesian_matrix = cartesian_matrix[None]
-        counts = cartesian_matrix.shape[0]
-        n_cartesian = self.sorted_mol.nao
-        assert cartesian_matrix.shape[1] == n_cartesian
-        assert cartesian_matrix.shape[2] == n_cartesian
-        n_spherical = self.mol.nao
-
-        l_ctr_count = np.asarray(self.l_ctr_offsets[1:] - self.l_ctr_offsets[:-1], dtype = np.int32)
-        l_ctr_l = np.asarray(self.uniq_l_ctr[:,0].copy(), dtype = np.int32)
-        self.l_ctr_pad_counts = np.asarray(self.l_ctr_pad_counts, dtype = np.int32)
-        cupy_ao_idx = self.cupy_ao_idx
-        stream = cp.cuda.get_current_stream()
-
-        # ref = cp.einsum("ij,qjk,kl->qil", self.coeff.T, cartesian_matrix, self.coeff)
-
-        out = cp.empty((counts, n_spherical, n_spherical), order = "C")
-        for i_dm in range(counts):
-            libgint.cart2sph_CT_mat_C_with_padding(
-                ctypes.cast(stream.ptr, ctypes.c_void_p),
-                ctypes.cast(cartesian_matrix[i_dm].data.ptr, ctypes.c_void_p),
-                ctypes.cast(out[i_dm].data.ptr, ctypes.c_void_p),
-                ctypes.c_int(n_cartesian),
-                ctypes.c_int(n_spherical),
-                ctypes.c_int(l_ctr_l.shape[0]),
-                l_ctr_l.ctypes.data_as(ctypes.c_void_p),
-                l_ctr_count.ctypes.data_as(ctypes.c_void_p),
-                self.l_ctr_pad_counts.ctypes.data_as(ctypes.c_void_p),
-                ctypes.cast(cupy_ao_idx.data.ptr, ctypes.c_void_p),
-                ctypes.c_bool(self.mol.cart),
-            )
-
-        if cartesian_matrix_ndim == 2:
-            out = out[0]
-        return out
+        return apply_coeff_CT_mat_C(
+            cartesian_matrix, self.mol, self.sorted_mol, self.uniq_l_ctr,
+            self.l_ctr_offsets, self.cupy_ao_idx, self.l_ctr_pad_counts)
 
     def apply_coeff_C_mat(self, right_matrix):
         '''
         Sort AO and perform cart2sph transformation (if needed) for the second last axis
-        Fused kernel to perform 'ip,npq->niq' 
+        Fused kernel to perform 'ip,npq->niq'
         '''
         right_matrix = cp.asarray(right_matrix)
         assert right_matrix.ndim == 2
@@ -512,7 +535,7 @@ class _VHFOpt:
 
             t1 = log.timer_debug1(f'q_cond and dm_cond on Device {device_id}', *t0)
             workers = gpu_specs['multiProcessorCount']
-            # An additional integer to count for the proccessed pair_ijs 
+            # An additional integer to count for the proccessed pair_ijs
             pool = cp.empty(workers*QUEUE_DEPTH+1, dtype=np.int32)
 
             timing_counter = Counter()
@@ -914,13 +937,30 @@ class _VHFOpt:
 
 class RysIntEnvVars(ctypes.Structure):
     _fields_ = [
-        ('natm', ctypes.c_uint16),
-        ('nbas', ctypes.c_uint16),
+        ('natm', ctypes.c_int),
+        ('nbas', ctypes.c_int),
         ('atm', ctypes.c_void_p),
         ('bas', ctypes.c_void_p),
         ('env', ctypes.c_void_p),
         ('ao_loc', ctypes.c_void_p),
     ]
+
+    @classmethod
+    def new(cls, natm, nbas, atm, bas, env, ao_loc):
+        obj = RysIntEnvVars(natm, nbas, atm.data.ptr, bas.data.ptr,
+                            env.data.ptr, ao_loc.data.ptr)
+        # Keep a reference to these arrays, prevent releasing them upon returning
+        obj._env_ref_holder = (atm, bas, env, ao_loc)
+        obj._device = cp.cuda.device.get_device_id()
+        return obj
+
+    def copy(self):
+        atm, bas, env, ao_loc = self._env_ref_holder
+        atm = cp.asarray(atm)
+        bas = cp.asarray(bas)
+        env = cp.asarray(env)
+        ao_loc = cp.asarray(ao_loc)
+        return RysIntEnvVars.new(self.natm, self.nbas, atm, bas, env, ao_loc)
 
 def _scale_sp_ctr_coeff(mol):
     # Match normalization factors of s, p functions in libcint

--- a/gpu4pyscf/scf/tests/test_scf_j_engine.py
+++ b/gpu4pyscf/scf/tests/test_scf_j_engine.py
@@ -210,3 +210,23 @@ H  -5.8042 -1.0067 12.1503
     vj = j_engine.get_j(mol, dm)
     vj1 = vj.get()
     assert abs(vj1 - ref).max() < 1e-9
+
+def test_general_contraction():
+    mol = pyscf.M(
+        atom = '''
+        O   0.000   -0.    0.1174
+        H  -0.757    4.   -0.4696
+        H   0.757    4.   -0.4696
+        C   1.      1.    0.
+        ''',
+        basis=('ccpvdz', [[3, [2., 1., .5], [1., .5, 1.]]]),
+        unit='B',)
+
+    np.random.seed(9)
+    nao = mol.nao
+    dm = np.random.rand(nao, nao)
+    dm = dm.dot(dm.T)
+
+    vj = j_engine.get_j(mol, dm)
+    ref = jk.get_jk(mol, dm)[0]
+    assert abs(vj - ref).max() < 1e-9

--- a/gpu4pyscf/scf/tests/test_scf_jk.py
+++ b/gpu4pyscf/scf/tests/test_scf_jk.py
@@ -235,3 +235,24 @@ def test_k_hermi1():
     vk = jk.get_k(mol, dm, hermi=1).get()
     assert abs(vk - ref).max() < 1e-9
     assert abs(lib.fp(vk) - 327.9485135045478) < 1e-9
+
+def test_general_contraction():
+    mol = pyscf.M(
+        atom = '''
+        O   0.000   -0.    0.1174
+        C   1.      1.    0.
+        ''',
+        basis=('ccpvdz', [[3, [2., 1., .5], [1., .5, 1.]]]),
+        unit='B',)
+
+    np.random.seed(9)
+    nao = mol.nao
+    dm = np.random.rand(nao, nao)
+    dm = dm.dot(dm.T)
+
+    vj, vk = jk.get_jk(mol, dm, hermi=1)
+    vj1 = vj.get()
+    vk1 = vk.get()
+    ref = get_jk(mol, dm, hermi=1)
+    assert abs(vj1 - ref[0]).max() < 1e-9
+    assert abs(vk1 - ref[1]).max() < 1e-9

--- a/gpu4pyscf/scf/tests/test_scf_jk.py
+++ b/gpu4pyscf/scf/tests/test_scf_jk.py
@@ -256,3 +256,16 @@ def test_general_contraction():
     ref = get_jk(mol, dm, hermi=1)
     assert abs(vj1 - ref[0]).max() < 1e-9
     assert abs(vk1 - ref[1]).max() < 1e-9
+
+def test_vhfopt_coeff():
+    from gpu4pyscf.gto.mole import group_basis
+    mol = pyscf.M(
+        atom = '''
+        O   0.000   -0.    0.1174
+        C   1.      1.    0.
+        ''',
+        basis='ccpvtz',
+        unit='B',)
+    vhfopt = jk._VHFOpt(mol).build()
+    ref = group_basis(mol, tile=vhfopt.tile)[1]
+    assert abs(vhfopt.coeff - ref).max() < 1e-12


### PR DESCRIPTION
* Allow for skipping the generation of three-center integrals when computing Coulomb matrix in TDDFT-ris