### PR TITLE
Support overlap matrix with large condition number

### DIFF
--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -1149,3 +1149,15 @@ def set_conditional_mempool_malloc(n_bytes_threshold=100000000):
             return cuda_malloc(size)
         return default_mempool_malloc(size)
     cupy.cuda.set_allocator(malloc)
+
+# def safe_eigh(h, s, lindep=1e-6):
+#     e, v = cupy.linalg.eigh(s)
+#     x = v[:,e>lindep] / cupy.sqrt(e[e>lindep])
+#     xhx = x.T @ h @ x
+#     e, c = cupy.linalg.eigh(xhx)
+#     c = cupy.dot(x, c)
+
+#     nao, nmo = x.shape
+#     c = cupy.concatenate([c, cupy.zeros([nao, nao-nmo])], axis = 1)
+#     e = cupy.concatenate([e, cupy.zeros(nao-nmo) + 1000000])
+#     return e, c

--- a/gpu4pyscf/scf/hf.py
+++ b/gpu4pyscf/scf/hf.py
@@ -29,6 +29,7 @@ from gpu4pyscf.lib.cupy_helper import (
     block_diag, sandwich_dot)
 from gpu4pyscf.scf import diis, jk, j_engine
 from gpu4pyscf.lib import logger
+from gpu4pyscf import __config__
 
 __all__ = [
     'get_jk', 'get_occ', 'get_grad', 'damping', 'level_shift', 'get_fock',
@@ -144,6 +145,9 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
     if dm is None: dm = mf.make_rdm1()
     s1e = cupy.asarray(s1e)
     dm = cupy.asarray(dm)
+    overlap_x = None
+    if hasattr(mf, 'overlap_canonical_decomposed_x') and mf.overlap_canonical_decomposed_x is not None:
+        overlap_x = cupy.asarray(mf.overlap_canonical_decomposed_x)
     if diis_start_cycle is None:
         diis_start_cycle = mf.diis_start_cycle
     if level_shift_factor is None:
@@ -154,7 +158,7 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
     if 0 <= cycle < diis_start_cycle-1 and abs(damp_factor) > 1e-4:
         f = damping(s1e, dm*.5, f, damp_factor)
     if diis is not None and cycle >= diis_start_cycle:
-        f = diis.update(s1e, dm, f, mf, h1e, vhf)
+        f = diis.update(s1e, dm, f, overlap_x)
 
     if abs(level_shift_factor) > 1e-4:
         f = level_shift(s1e, dm*.5, f, level_shift_factor)
@@ -578,6 +582,7 @@ class SCF(pyscf_lib.StreamObject):
     conv_check          = hf_cpu.SCF.conv_check
     callback            = hf_cpu.SCF.callback
     _keys               = hf_cpu.SCF._keys
+    overlap_canonical_decomposed_x = None
 
     # methods
     def __init__(self, mol):
@@ -609,17 +614,51 @@ class SCF(pyscf_lib.StreamObject):
 
     def check_sanity(self):
         s1e = self.get_ovlp()
-        if isinstance(s1e, cupy.ndarray) and s1e.ndim == 2:
+        assert isinstance(s1e, cupy.ndarray)
+        if s1e.ndim == 2:
             c = cond(s1e, sympos=True)
         else:
             c = cupy.asarray([cond(xi, sympos=True) for xi in s1e])
         logger.debug(self, 'cond(S) = %s', c)
-        if cupy.max(c)*1e-17 > self.conv_tol:
+        if cupy.max(c)*1e-17 > self.conv_tol or cupy.max(c) > 1e10:
             logger.warn(self, 'Singularity detected in overlap matrix (condition number = %4.3g). '
                         'SCF may be inaccurate and hard to converge.', cupy.max(c))
+
+            remove_overlap_zero_eigenvalue = getattr(__config__, 'scf_hf_remove_overlap_zero_eigenvalue', False)
+            overlap_zero_eigenvalue_threshold = getattr(__config__, 'scf_hf_overlap_zero_eigenvalue_threshold', 1e-8)
+
+            if remove_overlap_zero_eigenvalue:
+                e, v = cupy.linalg.eigh(s1e)
+                mask = e > overlap_zero_eigenvalue_threshold
+                x = v[:,mask] / cupy.sqrt(e[mask])
+
+                nao, nmo = x.shape
+                if nmo < nao:
+                    self.overlap_canonical_decomposed_x = x
+                    logger.warn(self, f"{nao - nmo} small eigenvector of overlap matrix removed "
+                                       "because of linear dependency between AOs.\n"
+                                       "The support for low-rank overlap matrix is not fully tested. "
+                                       "Please report any bug you encountered to the developers.")
+
         return super().check_sanity()
 
-    build                    = hf_cpu.SCF.build
+    def build(self, mol=None):
+        if mol is None: mol = self.mol
+        self.check_sanity()
+        return self
+
+    def eig(self, fock, s):
+        x = None
+        if hasattr(self, 'overlap_canonical_decomposed_x') and self.overlap_canonical_decomposed_x is not None:
+            x = cupy.asarray(self.overlap_canonical_decomposed_x)
+        if x is None:
+            mo_energy, mo_coeff = eigh(fock, s)
+            return mo_energy, mo_coeff
+        else:
+            mo_energy, C = cupy.linalg.eigh(x.T @ fock @ x)
+            mo_coeff = x @ C
+            return mo_energy, mo_coeff
+
     opt                      = NotImplemented
     dump_flags               = hf_cpu.SCF.dump_flags
     get_ovlp                 = return_cupy_array(hf_cpu.SCF.get_ovlp)
@@ -639,7 +678,6 @@ class SCF(pyscf_lib.StreamObject):
     energy_nuc               = hf_cpu.SCF.energy_nuc
     check_convergence        = None
     _eigh                    = staticmethod(eigh)
-    eig                      = hf_cpu.SCF.eig
     do_disp                  = hf_cpu.SCF.do_disp
     get_dispersion           = hf_cpu.SCF.get_dispersion
     kernel = scf             = scf
@@ -707,6 +745,7 @@ class SCF(pyscf_lib.StreamObject):
         self._opt_gpu = {None: None}
         self._opt_jengine = {None: None}
         self.scf_summary = {}
+        self.overlap_canonical_decomposed_x = None
         return self
 
     def dump_chk(self, envs):

--- a/gpu4pyscf/scf/hf_lowmem.py
+++ b/gpu4pyscf/scf/hf_lowmem.py
@@ -78,6 +78,7 @@ def kernel(mf, dm0=None, conv_tol=1e-10, conv_tol_grad=None,
             s1e = mf.get_ovlp(mol)
             fock = mf.get_fock(h1e, s1e, vhf, dm)  # = h1e + vhf, no DIIS
             mf.mo_energy, mf.mo_coeff = mf.eig(fock, s1e)
+            fock = s1e = None
             mf.mo_occ = mf.get_occ(mf.mo_energy, mf.mo_coeff)
             mf.converged = scf_conv
         return e_tot
@@ -92,7 +93,7 @@ def kernel(mf, dm0=None, conv_tol=1e-10, conv_tol_grad=None,
         # the input matrices. The input can be overwritten so as to reduce GPU
         # memory footprint.
         s1e = asarray(mf.get_ovlp(mol))
-        c = eigh(unpack_tril(asarray(h1e)), s1e, overwrite=True)[1]
+        c = mf.eig(unpack_tril(asarray(h1e)), s1e)[1]
         mf_diis.Corth = c.get()
         s1e = c = None
     else:
@@ -201,8 +202,8 @@ class RHFWfn(WaveFunction):
         return dm
 
 class CDIIS(diis.CDIIS):
-    def update(self, s, d, f, *args, **kwargs):
-        out = super().update(s, d, f, *args, **kwargs)
+    def update(self, s, d, f, x, *args, **kwargs):
+        out = super().update(s, d, f, x, *args, **kwargs)
         if isinstance(self.Corth, cp.ndarray):
             # Store Corth on host to reduce GPU memory pressure
             self.Corth = self.Corth.get()
@@ -228,7 +229,10 @@ class RHF(hf.RHF):
         if mol.spin != 0:
             raise RuntimeError(
                 f'Invalid number of electrons {mol.nelectron} for RHF method.')
-        return self
+        return_value = super(type(self), self).check_sanity()
+        if hasattr(self, 'overlap_canonical_decomposed_x') and self.overlap_canonical_decomposed_x is not None:
+            self.overlap_canonical_decomposed_x = self.overlap_canonical_decomposed_x.get()
+        return return_value
 
     def get_hcore(self, mol=None):
         '''The lower triangular part of Hcore'''
@@ -327,6 +331,10 @@ class RHF(hf.RHF):
         if s1e.shape[-1] != f.shape[-1]:
             s1e = unpack_tril(s1e)
 
+        overlap_x = None
+        if hasattr(self, 'overlap_canonical_decomposed_x') and self.overlap_canonical_decomposed_x is not None:
+            overlap_x = asarray(self.overlap_canonical_decomposed_x)
+
         if diis_start_cycle is None:
             diis_start_cycle = self.diis_start_cycle
         if level_shift_factor is None:
@@ -337,7 +345,7 @@ class RHF(hf.RHF):
         if 0 <= cycle < diis_start_cycle-1 and abs(damp_factor) > 1e-4:
             f = hf.damping(s1e, dm*.5, f, damp_factor)
         if diis is not None and cycle >= diis_start_cycle:
-            f = diis.update(s1e, dm, f)
+            f = diis.update(s1e, dm, f, overlap_x)
             cp.get_default_memory_pool().free_all_blocks()
 
         if abs(level_shift_factor) > 1e-4:
@@ -378,14 +386,26 @@ class RHF(hf.RHF):
         return e_tot, e_coul
 
     def _eigh(self, h, s):
-        # In DIIS, fock and overlap matrices are temporarily constructed and
-        # discarded, they can be overwritten in the eigh solver.
-        e, c = eigh(h, s, overwrite=True)
-        # eigh allocates a large memory buffer "work". Immediately free the cupy
-        # memory after the eigh function to avoid this buffer being trapped by
-        # small-sized arrays.
+        x = None
+        if hasattr(self, 'overlap_canonical_decomposed_x') and self.overlap_canonical_decomposed_x is not None:
+            x = asarray(self.overlap_canonical_decomposed_x)
+        if x is None:
+            # In DIIS, fock and overlap matrices are temporarily constructed and
+            # discarded, they can be overwritten in the eigh solver.
+            e, c = eigh(h, s, overwrite=True)
+            # eigh allocates a large memory buffer "work". Immediately free the cupy
+            # memory after the eigh function to avoid this buffer being trapped by
+            # small-sized arrays.
+        else:
+            h_no_lindep = x.T @ h @ x
+            e, c = cp.linalg.eigh(h_no_lindep)
+            h_no_lindep = None
+            c = x @ c
+            x = None
         cp.get_default_memory_pool().free_all_blocks()
         return e, c
+
+    eig = _eigh
 
     def to_cpu(self):
         raise NotImplementedError

--- a/gpu4pyscf/scf/tests/test_diffuse_orbital.py
+++ b/gpu4pyscf/scf/tests/test_diffuse_orbital.py
@@ -1,0 +1,222 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import pyscf
+import gpu4pyscf
+from gpu4pyscf import scf, dft
+
+def setUpModule():
+    global mol #, ref_mol
+    mol = pyscf.M(
+        atom = """
+            H 0 0 0
+            Li 1.0 0.1 0
+        """,
+        basis = """
+            X    S
+                0.3425250914E+01       0.1543289673E+00
+                0.6239137298E+00       0.5353281423E+00
+                0.1688554040E+00       0.4446345422E+00
+            X    S
+                0.1611957475E+02       0.1543289673E+00
+                0.2936200663E+01       0.5353281423E+00
+                0.7946504870E+00       0.4446345422E+00
+            X    P
+                0.010000 1.0
+            X    P
+                0.010001 1.0
+        """,
+        verbose = 5,
+        output = '/dev/null',
+    )
+
+    # ref_mol = pyscf.M(
+    #     atom = """
+    #         H 0 0 0
+    #         Li 1.0 0.1 0
+    #     """,
+    #     basis = """
+    #         X    S
+    #             0.3425250914E+01       0.1543289673E+00
+    #             0.6239137298E+00       0.5353281423E+00
+    #             0.1688554040E+00       0.4446345422E+00
+    #         X    S
+    #             0.1611957475E+02       0.1543289673E+00
+    #             0.2936200663E+01       0.5353281423E+00
+    #             0.7946504870E+00       0.4446345422E+00
+    #         X    P
+    #             0.010000 1.0
+    #         # X    P
+    #         #     0.010001 1.0
+    #     """,
+    #     verbose = 5,
+    # )
+
+def tearDownModule():
+    global mol #, ref_mol
+    mol.stdout.close()
+    del mol
+
+class KnownValues(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        gpu4pyscf.__config__.scf_hf_remove_overlap_zero_eigenvalue = True
+
+    @classmethod
+    def tearDownClass(cls):
+        del gpu4pyscf.__config__.scf_hf_remove_overlap_zero_eigenvalue
+
+    def test_rhf(self):
+        mf = scf.RHF(mol)
+        mf.conv_tol = 1e-10
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.670162135801041) < 1e-5
+
+        gobj = mf.Gradients()
+        gradient = gobj.kernel()
+        assert np.max(np.abs(gradient - np.array([
+            [ 2.53027311e-01,  2.53027311e-02,  1.78111017e-19],
+            [-2.53027311e-01, -2.53027311e-02, -1.78111017e-19],
+        ]))) < 1e-5
+
+        dipole = mf.dip_moment()
+        assert np.max(np.abs(dipole - np.array([4.26375987e+00, 4.26375987e-01, 1.86659164e-16]))) < 1e-4
+
+    def test_rhf_soscf(self):
+        mf = dft.RKS(mol, xc = "wB97M-d3bj")
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-10
+        mf = mf.newton()
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.773544875779531) < 1e-5
+
+        gobj = mf.Gradients()
+        gradient = gobj.kernel()
+        assert np.max(np.abs(gradient - np.array([
+            [ 2.44614610e-01,  2.44653881e-02, -3.14001231e-18],
+            [-2.44641034e-01, -2.44569088e-02, -6.41480825e-18],
+        ]))) < 1e-5
+
+    def test_uhf(self):
+        mf = dft.RKS(mol, xc = "PBE")
+        mf.grids.atom_grid = (50,194)
+        mf = mf.density_fit(auxbasis = "def2-universal-jkfit")
+        mf.conv_tol = 1e-10
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.748763949503415) < 1e-5
+
+        gobj = mf.Gradients()
+        gobj.grid_response = True
+        gradient = gobj.kernel()
+        assert np.max(np.abs(gradient - np.array([
+            [ 2.44275992e-01,  2.44757818e-02,  3.22713915e-19],
+            [-2.44275992e-01, -2.44757818e-02, -3.17524970e-19],
+        ]))) < 1e-5
+
+    def test_rohf(self):
+        mf = dft.ROKS(mol, xc = "PBE0")
+        mf.grids.level = 3
+        mf.conv_tol = 1e-10
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.749335934429277) < 1e-5
+
+        # TODO: There seems to be some problem with ROHF gradient, there's no class grad.rohf.Gradients,
+        # and the gradient class falls back onto grad.rhf.Gradients
+
+    def test_rhf_hessian(self):
+        mf = dft.RKS(mol, xc = "PBE0")
+        mf.grids.atom_grid = (99,590)
+        mf.conv_tol = 1e-10
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.749450458759258) < 1e-5
+
+        hobj = mf.Hessian()
+        hessian = hobj.kernel()
+        assert np.max(np.abs(hessian - np.array(
+       [[[[ 5.47269479e-01,  6.77947776e-02,  1.36415823e-17],
+         [ 6.77947776e-02, -1.23184348e-01, -2.77752324e-17],
+         [ 1.36415823e-17, -2.77752324e-17, -1.29751072e-01]],
+
+        [[-5.47077502e-01, -6.76941081e-02, -3.30772790e-18],
+         [-6.76918425e-02,  1.23166473e-01,  1.95849919e-17],
+         [-6.41033433e-18,  1.90019347e-17,  1.29935820e-01]]],
+
+
+       [[[-5.47077502e-01, -6.76918425e-02, -6.41033433e-18],
+         [-6.76941081e-02,  1.23166473e-01,  1.90019347e-17],
+         [-3.30772790e-18,  1.95849919e-17,  1.29935820e-01]],
+
+        [[ 5.47043561e-01,  6.77385721e-02,  1.73115648e-16],
+         [ 6.77385721e-02, -1.23177949e-01,  7.29238276e-17],
+         [ 1.73115648e-16,  7.29238276e-17, -1.29908851e-01]]]]
+        ))) < 1e-5
+
+    def test_uhf_solvent(self):
+        mf = dft.UKS(mol, xc = "PBE0")
+        mf.grids.atom_grid = (50,194)
+        mf.conv_tol = 1e-10
+        mf = mf.PCM()
+        mf.with_solvent.method = "IEF-PCM"
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.770917908597051) < 1e-5
+
+        gobj = mf.Gradients()
+        gobj.grid_response = True
+        gradient = gobj.kernel()
+        assert np.max(np.abs(gradient - np.array([
+            [ 2.52149477e-01,  2.52230067e-02,  5.40896707e-18],
+            [-2.52149477e-01, -2.52230067e-02, -5.44037802e-18],
+        ]))) < 1e-5
+
+    def test_rhf_lowmem(self):
+        mf = scf.hf_lowmem.RHF(mol)
+        mf.conv_tol = 1e-10
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.670162135801045) < 1e-5
+
+        gobj = mf.Gradients()
+        gradient = gobj.kernel()
+        assert np.max(np.abs(gradient - np.array([
+            [ 2.53027311e-01,  2.53027311e-02, -6.39723698e-19],
+            [-2.53027311e-01, -2.53027311e-02,  6.39723698e-19],
+        ]))) < 1e-5
+
+    def test_rks_lowmem(self):
+        mf = dft.rks_lowmem.RKS(mol, xc = "wB97M-V")
+        mf.grids.atom_grid = (99,590)
+        mf.nlcgrids.atom_grid = (50,194)
+        mf.conv_tol = 1e-10
+        energy = mf.kernel()
+        assert mf.converged
+        assert np.abs(energy - -7.755312446937159) < 1e-5
+
+        gobj = mf.Gradients()
+        gradient = gobj.kernel()
+        assert np.max(np.abs(gradient - np.array([
+            [ 2.44591704e-01,  2.44630215e-02,  1.52039894e-19],
+            [-2.44604955e-01, -2.44532125e-02,  3.37936483e-17],
+        ]))) < 1e-5
+
+if __name__ == "__main__":
+    print("Tests for System with Diffuse Orbitals (Ill-conditioned Overlap Matrices)")
+    unittest.main()


### PR DESCRIPTION
Not turned on by default, set `gpu4pyscf.__config__.scf_hf_remove_overlap_zero_eigenvalue = True` if needed.