### PR TITLE
twine version issue

### DIFF
--- a/.github/workflows/pypi_wheel.yml
+++ b/.github/workflows/pypi_wheel.yml
@@ -28,7 +28,7 @@ jobs:
         ls ${{ github.workspace }}/wheelhouse
     - name: Publish to PyPI
       run: |
-          pip install twine
+          pip install twine==6.0.1
           export TWINE_USERNAME=__token__
           export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
           twine upload --verbose "${{ github.workspace }}/wheelhouse/*"
@@ -51,7 +51,7 @@ jobs:
         ls ${{ github.workspace }}/wheelhouse
     - name: Publish to PyPI
       run: |
-          pip install twine
+          pip install twine==6.0.1
           export TWINE_USERNAME=__token__
           export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
           twine upload --verbose "${{ github.workspace }}/wheelhouse/*"
@@ -74,7 +74,7 @@ jobs:
         ls ${{ github.workspace }}/wheelhouse
     - name: Publish to PyPI
       run: |
-          pip install twine
+          pip install twine==6.0.1
           export TWINE_USERNAME=__token__
           export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
           twine upload --verbose "${{ github.workspace }}/wheelhouse/*"

--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ setup(
     version=VERSION,
     description=DESCRIPTION,
     license=LICENSE,
+    license_files=('LICENSE',),
     author=AUTHOR,
     author_email=AUTHOR_EMAIL,
     package_dir={'gpu4pyscf': 'gpu4pyscf'},  # packages are under directory pyscf


### PR DESCRIPTION
twine must be 6.0.1 for uploading pip wheels