### PR TITLE
Implement RIS-approximated Z-vector solver for TD-RKS gradients and NACs

### DIFF
--- a/examples/37-tddft_ris_gradient.py
+++ b/examples/37-tddft_ris_gradient.py
@@ -84,3 +84,11 @@ print(np.linalg.norm(g.de - g_ris.de))
 """
 0.007065933384199997
 """
+
+"""
+Using the ris-approximated Z-vector solver rather than the standard Z-vector solver.
+"""
+g_ris = td_ris.nuc_grad_method()
+g_ris.ris_zvector_solver = True # Use ris-approximated Z-vector solver
+g_ris.state=1
+g_ris.kernel()

--- a/examples/38-tddft_ris_nacv.py
+++ b/examples/38-tddft_ris_nacv.py
@@ -128,3 +128,11 @@ print()
 0.10849919731015174
 """
 
+"""
+Using the ris-approximated Z-vector solver rather than the standard Z-vector solver.
+"""
+nac_ris = td_ris.nac_method()
+nac_ris.ris_zvector_solver = True # Use ris-approximated Z-vector solver
+nac_ris.states=(1,2)
+nac_ris.kernel()
+

--- a/gpu4pyscf/grad/tdrhf.py
+++ b/gpu4pyscf/grad/tdrhf.py
@@ -323,7 +323,6 @@ class Gradients(rhf_grad.GradientsBase):
         )
         log.info("cphf_conv_tol = %g", self.cphf_conv_tol)
         log.info("cphf_max_cycle = %d", self.cphf_max_cycle)
-        log.info("chkfile = %s", self.chkfile)
         log.info("State ID = %d", self.state)
         log.info("\n")
         return self

--- a/gpu4pyscf/grad/tdrks_ris.py
+++ b/gpu4pyscf/grad/tdrks_ris.py
@@ -48,12 +48,8 @@ def gen_response_ris(mf, mf_J, mf_K, mo_coeff=None, mo_occ=None,
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
     hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-    if singlet is None:
-        spin = 0
-    else:
+    if singlet is not None:
         raise ValueError('TDDFT ris solver only supports singlet state')
-
-    dm0 = None
 
     if singlet is None:
         # Without specify singlet, used in ground state orbital hessian

--- a/gpu4pyscf/grad/tdrks_ris.py
+++ b/gpu4pyscf/grad/tdrks_ris.py
@@ -207,8 +207,10 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO):
     # set singlet=None, generate function for CPHF type response kernel
     # TODO: LR-PCM TDDFT
     if td_grad.ris_zvector_solver:
+        log.note('Use ris-approximated Z-vector solver')
         vresp = gen_response_ris(mf, mf_J, mf_K, singlet=None, hermi=1)
     else:
+        log.note('Use standard Z-vector solver')
         vresp = td_grad.base._scf.gen_response(singlet=None, hermi=1)
 
     def fvind(x):
@@ -365,6 +367,33 @@ def get_veff_ris(mf_J, mf_K, mol=None, dm=None, j_factor=1.0, k_factor=1.0, omeg
 
 
 class Gradients(tdrhf.Gradients):
+    """
+    Analytical gradients for TDRKS using the RIS approximation.
+
+    This class implements the analytical gradient calculation between TDRKS excited states
+    (or between excited state and ground state) utilizing the Resolution of Identity (RI)
+    approximation for both Coulomb and Exchange integrals.
+
+    Attributes:
+        ris_zvector_solver: Solves the Z-vector equation (Lagrangian multipliers) 
+        specific to the RIS approximation.
+
+    Notes:
+        The TDDFT or TDA is computed ** using the RIS approximation **.
+        The Z-vector solver implementation here has two versions:
+        1. Standard Z-vector solver: Solves the Z-vector equation using the standard method.
+        2. RIS approximation Z-vector solver: Solves the Z-vector equation using the RIS approximation, 
+            when ris_zvector_solver is True.
+
+    References:
+        For the detailed derivation of the RIS gradient and Z-vector equation, 
+        please refer to the following paper:
+        
+        [1] "Analytical Excited-State Gradients and Derivative
+            Couplings in TDDFT with Minimal Auxiliary Basis Set
+            Approximation and GPU Acceleration", 
+            ArXiv:2511.18233
+    """
 
     _keys = {'ris_zvector_solver'}
 

--- a/gpu4pyscf/grad/tdrks_ris.py
+++ b/gpu4pyscf/grad/tdrks_ris.py
@@ -28,6 +28,55 @@ from gpu4pyscf.grad import tdrhf
 from gpu4pyscf.grad import tdrks
 from gpu4pyscf import tdscf
 from gpu4pyscf.tdscf.ris import get_auxmol
+from gpu4pyscf.hessian.rks import nr_rks_fnlc_mo
+
+
+def gen_response_ris(mf, mf_J, mf_K, mo_coeff=None, mo_occ=None,
+                      singlet=None, hermi=0):
+    '''Generate a function to compute the product of RHF response function and
+    RHF density matrices.
+
+    Kwargs:
+        singlet (None or boolean) : If singlet is None, response function for
+            orbital hessian or CPHF will be generated. If singlet is boolean,
+            it is used in TDDFT response kernel.
+    '''
+    if mo_coeff is None: mo_coeff = mf.mo_coeff
+    if mo_occ is None: mo_occ = mf.mo_occ
+    mol = mf.mol
+    ni = mf._numint
+    omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+
+    if singlet is None:
+        spin = 0
+    else:
+        raise ValueError('TDDFT ris solver only supports singlet state')
+
+    dm0 = None
+
+    if singlet is None:
+        # Without specify singlet, used in ground state orbital hessian
+        def vind(dm1):
+            # The singlet hessian
+            v1 = cp.zeros_like(dm1)
+            if hybrid:
+                if hermi != 2:
+                    vj = mf_J.get_j(mol, dm1, hermi=hermi)
+                    vk = mf_K.get_k(mol, dm1, hermi=hermi)
+                    vk *= hyb
+                    if omega > 1e-10:  # For range separated Coulomb
+                        vk += mf_K.get_k(mol, dm1, hermi, omega) * (alpha-hyb)
+                    v1 += vj - .5 * vk
+                else:
+                    vk = mf_K.get_k(mol, dm1, hermi=hermi)
+                    v1 -= .5 * hyb * vk
+            elif hermi != 2:
+                vj = mf_J.get_j(mol, dm1, hermi=hermi)
+                v1 += vj
+            return v1
+
+    return vind
 
 def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO):
     """
@@ -161,7 +210,10 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO):
 
     # set singlet=None, generate function for CPHF type response kernel
     # TODO: LR-PCM TDDFT
-    vresp = td_grad.base._scf.gen_response(singlet=None, hermi=1)
+    if td_grad.ris_zvector_solver:
+        vresp = gen_response_ris(mf, mf_J, mf_K, singlet=None, hermi=1)
+    else:
+        vresp = td_grad.base._scf.gen_response(singlet=None, hermi=1)
 
     def fvind(x):
         dm = reduce(cp.dot, (orbv, x.reshape(nvir, nocc) * 2, orbo.T))
@@ -317,6 +369,13 @@ def get_veff_ris(mf_J, mf_K, mol=None, dm=None, j_factor=1.0, k_factor=1.0, omeg
 
 
 class Gradients(tdrhf.Gradients):
+
+    _keys = {'ris_zvector_solver'}
+
+    def __init__(self, td):
+        super().__init__(td)
+        self.ris_zvector_solver = False
+
     def kernel(self, xy=None, state=None, singlet=None, atmlst=None):
         """
         Args:
@@ -356,12 +415,16 @@ class Gradients(tdrhf.Gradients):
             self.check_sanity()
         if self.verbose >= logger.INFO:
             self.dump_flags()
+        if self.verbose >= logger.DEBUG and self.ris_zvector_solver:
+            log.debug('Using ris-approximated zvector solver')
+        
         de = self.grad_elec(xy, singlet, atmlst, verbose=self.verbose)
         self.de = de = de + self.grad_nuc(atmlst=atmlst)
         if self.mol.symmetry:
             self.de = self.symmetrize(self.de, atmlst)
         self._finalize()
         return self.de
+
     @lib.with_doc(grad_elec.__doc__)
     def grad_elec(self, xy, singlet, atmlst=None, verbose=logger.info):
         return grad_elec(self, xy, singlet=singlet, atmlst=atmlst, verbose=self.verbose)

--- a/gpu4pyscf/nac/tdrhf.py
+++ b/gpu4pyscf/nac/tdrhf.py
@@ -740,10 +740,10 @@ class NAC_Scanner(lib.GradScanner):
                 else:
                     xi0 = self.base.xy[0][states[0]-1]*np.sqrt(0.5)
                     yi0 = self.base.xy[0][states[0]-1]*0.0
+                xi0 = xi0.reshape(nocc, nvir)
+                yi0 = yi0.reshape(nocc, nvir)
             else:
                 xi0, yi0 = self.base.xy[states[0]-1]
-            xi0 = xi0.reshape(nocc, nvir)
-            yi0 = yi0.reshape(nocc, nvir)
         if isinstance(self.base, tdscf.ris.TDDFT) or isinstance(self.base, tdscf.ris.TDA):
             if self.base.xy[1] is not None:
                 xj0 = self.base.xy[0][states[1]-1]*np.sqrt(0.5)
@@ -751,10 +751,10 @@ class NAC_Scanner(lib.GradScanner):
             else:
                 xj0 = self.base.xy[0][states[1]-1]*np.sqrt(0.5)
                 yj0 = self.base.xy[0][states[1]-1]*0.0
+            xj0 = xj0.reshape(nocc, nvir)
+            yj0 = yj0.reshape(nocc, nvir)
         else:
             xj0, yj0 = self.base.xy[states[1]-1]
-        xj0 = xj0.reshape(nocc, nvir)
-        yj0 = yj0.reshape(nocc, nvir)
 
         td_scanner = self.base
 
@@ -774,10 +774,10 @@ class NAC_Scanner(lib.GradScanner):
                 else:
                     xi1 = self.base.xy[0][states[0]-1]*np.sqrt(0.5)
                     yi1 = self.base.xy[0][states[0]-1]*0.0
+                xi1 = xi1.reshape(nocc, nvir)
+                yi1 = yi1.reshape(nocc, nvir)
             else:
                 xi1, yi1 = self.base.xy[states[0]-1]
-            xi1 = xi1.reshape(nocc, nvir)
-            yi1 = yi1.reshape(nocc, nvir)
         if isinstance(self.base, tdscf.ris.TDDFT) or isinstance(self.base, tdscf.ris.TDA):
             if self.base.xy[1] is not None:
                 xj1 = self.base.xy[0][states[1]-1]*np.sqrt(0.5)
@@ -785,10 +785,10 @@ class NAC_Scanner(lib.GradScanner):
             else:
                 xj1 = self.base.xy[0][states[1]-1]*np.sqrt(0.5)
                 yj1 = self.base.xy[0][states[1]-1]*0.0
+            xj1 = xj1.reshape(nocc, nvir)
+            yj1 = yj1.reshape(nocc, nvir)
         else:
             xj1, yj1 = self.base.xy[states[1]-1]
-        xj1 = xj1.reshape(nocc, nvir)
-        yj1 = yj1.reshape(nocc, nvir)
         
         mo2_reordered = cp.asarray(mo2_reordered)
         mo_coeff0 = cp.asarray(mo_coeff0)

--- a/gpu4pyscf/nac/tdrks.py
+++ b/gpu4pyscf/nac/tdrks.py
@@ -108,7 +108,7 @@ def get_nacv_ge(td_nac, x_yI, EI, singlet=True, atmlst=None, verbose=logger.INFO
             log.note('Use standard Z-vector solver')
             vresp = td_nac.base._scf.gen_response(singlet=None, hermi=1)
     else:
-        if td_nac.ris_zvector_solver:
+        if getattr(td_nac, 'ris_zvector_solver', None) is not None:
             raise NotImplementedError('Ris-approximated Z-vector solver is not supported for standard TDDFT or TDA')
         vresp = td_nac.base.gen_response(singlet=None, hermi=1)
 

--- a/gpu4pyscf/nac/tdrks_ris.py
+++ b/gpu4pyscf/nac/tdrks_ris.py
@@ -227,8 +227,10 @@ def get_nacv_ee(td_nac, x_yI, x_yJ, EI, EJ, singlet=True, atmlst=None, verbose=l
         veff0momJ = cp.zeros((nmo, nmo))
 
     if td_nac.ris_zvector_solver:
+        log.note('Use ris-approximated Z-vector solver')
         vresp = tdrks_ris.gen_response_ris(mf, mf_J, mf_K, singlet=None, hermi=1)
     else:
+        log.note('Use standard Z-vector solver')
         vresp = mf.gen_response(singlet=None, hermi=1)
     # vresp = mf.gen_response(singlet=None, hermi=1)
 
@@ -445,6 +447,33 @@ def get_nacv_ee(td_nac, x_yI, x_yJ, EI, EJ, singlet=True, atmlst=None, verbose=l
 
 
 class NAC(tdrks_nac.NAC):
+    """
+    Non-Adiabatic Couplings (NAC) for TDRKS using the RIS approximation.
+
+    This class implements the analytical NAC calculation between TDRKS excited states
+    (or between excited state and ground state) utilizing the Resolution of Identity (RI)
+    approximation for both Coulomb and Exchange integrals.
+
+    Attributes:
+        ris_zvector_solver: Solves the Z-vector equation (Lagrangian multipliers) 
+        specific to the RIS approximation.
+
+    Notes:
+        The TDDFT or TDA is computed ** using the RIS approximation **.
+        The Z-vector solver implementation here has two versions:
+        1. Standard Z-vector solver: Solves the Z-vector equation using the standard method.
+        2. RIS approximation Z-vector solver: Solves the Z-vector equation using the RIS approximation, 
+            when ris_zvector_solver is True.
+
+    References:
+        For the detailed derivation of the RIS gradient and Z-vector equation, 
+        please refer to the following paper:
+        
+        [1] "Analytical Excited-State Gradients and Derivative
+            Couplings in TDDFT with Minimal Auxiliary Basis Set
+            Approximation and GPU Acceleration", 
+            ArXiv:2511.18233
+    """
 
     _keys = {'ris_zvector_solver'}
 

--- a/gpu4pyscf/nac/tdrks_ris.py
+++ b/gpu4pyscf/nac/tdrks_ris.py
@@ -226,7 +226,11 @@ def get_nacv_ee(td_nac, x_yI, x_yJ, EI, EJ, singlet=True, atmlst=None, verbose=l
         veff0momI = cp.zeros((nmo, nmo))
         veff0momJ = cp.zeros((nmo, nmo))
 
-    vresp = mf.gen_response(singlet=None, hermi=1)
+    if td_nac.ris_zvector_solver:
+        vresp = tdrks_ris.gen_response_ris(mf, mf_J, mf_K, singlet=None, hermi=1)
+    else:
+        vresp = mf.gen_response(singlet=None, hermi=1)
+    # vresp = mf.gen_response(singlet=None, hermi=1)
 
     def fvind(x):
         dm = reduce(cp.dot, (orbv, x.reshape(nvir, nocc) * 2, orbo.T)) # double occupency
@@ -441,6 +445,12 @@ def get_nacv_ee(td_nac, x_yI, x_yJ, EI, EJ, singlet=True, atmlst=None, verbose=l
 
 
 class NAC(tdrks_nac.NAC):
+
+    _keys = {'ris_zvector_solver'}
+
+    def __init__(self, td):
+        super().__init__(td)
+        self.ris_zvector_solver = False
 
     @lib.with_doc(get_nacv_ee.__doc__)
     def get_nacv_ee(self, x_yI, x_yJ, EI, EJ, singlet, atmlst=None, verbose=logger.INFO):

--- a/gpu4pyscf/nac/tdrks_ris.py
+++ b/gpu4pyscf/nac/tdrks_ris.py
@@ -485,8 +485,6 @@ class NAC(tdrks_nac.NAC):
     def get_nacv_ee(self, x_yI, x_yJ, EI, EJ, singlet, atmlst=None, verbose=logger.INFO):
         return get_nacv_ee(self, x_yI, x_yJ, EI, EJ, singlet, atmlst, verbose)
 
-    as_scanner = NotImplemented
-
     def kernel(self, xy_I=None, xy_J=None, E_I=None, E_J=None, singlet=None, atmlst=None):
 
         logger.warn(self, "This module is under development!!")

--- a/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ee.py
+++ b/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ee.py
@@ -63,8 +63,6 @@ class KnownValues(unittest.TestCase):
         mf = dft.rks.RKS(mol, xc="pbe").to_gpu()
         mf.grids.atom_grid = (99,590)
         mf.kernel()
-        td = mf.TDA().set(nstates=5)
-        td.kernel()
 
         td_ris = tdscf.ris.TDA(mf=mf, nstates=5, spectra=False, single=False, gram_schmidt=True)
         td_ris.conv_tol = 1.0E-4
@@ -197,6 +195,87 @@ class KnownValues(unittest.TestCase):
             [[ 5.48922915e-16, -9.00876449e-02, -2.47854031e-09],
              [-1.15755555e-15,  4.50438148e-02, -3.53895964e-02],
              [ 4.84556048e-16,  4.50438185e-02,  3.53895989e-02],])
+
+        # compare with previous calculation resusts
+        assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5
+        assert np.linalg.norm(np.abs(nac_ris.de_etf) - np.abs(ref_de_etf)) < 1.0E-5
+
+    def test_nac_pbe_tda_singlet_vs_ref_ris_zvector_solver(self):
+        mf = dft.rks.RKS(mol, xc="pbe").to_gpu()
+        mf.grids.atom_grid = (99,590)
+        mf.kernel()
+
+        td_ris = tdscf.ris.TDA(mf=mf, nstates=5, spectra=False, single=False, gram_schmidt=True)
+        td_ris.conv_tol = 1.0E-4
+        td_ris.Ktrunc = 0.0
+        td_ris.kernel()
+        nac_ris = td_ris.nac_method()
+        nac_ris.states=(1,2)
+        nac_ris.ris_zvector_solver = True
+        nac_ris.kernel()
+
+        ref_de = np.array(
+            [[ 0.0000000000, -0.0941080765, -0.0000000000],
+             [-0.0000000000,  0.0540026157, -0.0355220643],
+             [ 0.0000000000,  0.0540026157,  0.0355220643],])
+        ref_de_etf = np.array(
+            [[ 0.0000000000, -0.0931219594, -0.0000000000],
+             [-0.0000000000,  0.0465609593, -0.0370296058],
+             [ 0.0000000000,  0.0465609593,  0.0370296058],])
+
+        # compare with previous calculation resusts
+        assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5
+        assert np.linalg.norm(np.abs(nac_ris.de_etf) - np.abs(ref_de_etf)) < 1.0E-5
+
+    def test_nac_pbe0_tda_singlet_vs_ref_ris_zvector_solver(self):
+        mf = dft.rks.RKS(mol, xc="pbe0").to_gpu()
+        mf.grids.atom_grid = (99,590)
+        mf.kernel()
+
+        td_ris = tdscf.ris.TDA(mf=mf, nstates=5, spectra=False, single=False, gram_schmidt=True)
+        td_ris.conv_tol = 1.0E-4
+        td_ris.Ktrunc = 0.0
+        td_ris.kernel()
+        nac_ris = td_ris.nac_method()
+        nac_ris.states=(1,2)
+        nac_ris.ris_zvector_solver = True
+        nac_ris.kernel()
+
+        ref_de = np.array(
+            [[-0.0000000000, -0.1017318256, -0.0000000014],
+             [ 0.0000000000,  0.0579454885, -0.0387517422],
+             [ 0.0000000000,  0.0579454908,  0.0387517436],])
+        ref_de_etf = np.array(
+            [[-0.0000000000, -0.1013903631, -0.0000000015],
+             [ 0.0000000000,  0.0506951632, -0.0401688078],
+             [-0.0000000000,  0.0506951657,  0.0401688093],])
+
+        # compare with previous calculation resusts
+        assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5
+        assert np.linalg.norm(np.abs(nac_ris.de_etf) - np.abs(ref_de_etf)) < 1.0E-5
+
+    def test_nac_camb3lyp_tda_singlet_vs_ref_ris_zvector_solver(self):
+        mf = dft.rks.RKS(mol, xc="camb3lyp").to_gpu()
+        mf.grids.atom_grid = (99,590)
+        mf.kernel()
+
+        td_ris = tdscf.ris.TDA(mf=mf, nstates=5, spectra=False, single=False, gram_schmidt=True)
+        td_ris.conv_tol = 1.0E-4
+        td_ris.Ktrunc = 0.0
+        td_ris.kernel()
+        nac_ris = td_ris.nac_method()
+        nac_ris.states=(1,2)
+        nac_ris.ris_zvector_solver = True
+        nac_ris.kernel()
+
+        ref_de = np.array(
+            [[ 0.0000000000, -0.0909942185, -0.0000000010],
+             [-0.0000000000,  0.0528867701, -0.0344111229],
+             [ 0.0000000000,  0.0528867724,  0.0344111239],])
+        ref_de_etf = np.array(
+            [[ 0.0000000000, -0.0906362599, -0.0000000011],
+             [-0.0000000000,  0.0453181227, -0.0359291095],
+             [ 0.0000000000,  0.0453181251,  0.0359291106],])
 
         # compare with previous calculation resusts
         assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5

--- a/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ge.py
+++ b/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ge.py
@@ -187,6 +187,87 @@ class KnownValues(unittest.TestCase):
         assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5
         assert np.linalg.norm(np.abs(nac_ris.de_etf) - np.abs(ref_de_etf)) < 1.0E-5
 
+    def test_nac_pbe_tdaris_singlet_vs_ref_ris_zvector_solver(self):
+        mf = dft.rks.RKS(mol, xc="pbe").to_gpu()
+        mf.grids.atom_grid = (99,590)
+        mf.kernel()
+
+        td_ris = tdscf.ris.TDA(mf=mf, nstates=5, spectra=False, single=False, gram_schmidt=True)
+        td_ris.conv_tol = 1.0E-4
+        td_ris.Ktrunc = 0.0
+        td_ris.kernel()
+        nac_ris = td_ris.nac_method()
+        nac_ris.ris_zvector_solver = True
+        nac_ris.states=(1,0)
+        nac_ris.kernel()
+
+        ref_de = np.array(
+            [[-0.0150780367, -0.0000000000, 0.0000000000],
+             [ 0.0241640836,  0.0000000000, 0.0000000000],
+             [ 0.0241640836, -0.0000000000, 0.0000000000],])
+        ref_de_etf = np.array(
+            [[-0.1096218702,  0.0000000000, 0.0000000000],
+             [ 0.0548109333,  0.0000000000, 0.0000000000],
+             [ 0.0548109333, -0.0000000000, 0.0000000000],])
+
+        # compare with previous calculation resusts
+        assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5
+        assert np.linalg.norm(np.abs(nac_ris.de_etf) - np.abs(ref_de_etf)) < 1.0E-5
+
+    def test_nac_pbe0_tdaris_singlet_vs_ref_ris_zvector_solver(self):
+        mf = dft.rks.RKS(mol, xc="pbe0").to_gpu()
+        mf.grids.atom_grid = (99,590)
+        mf.kernel()
+
+        td_ris = tdscf.ris.TDA(mf=mf, nstates=5, spectra=False, single=False, gram_schmidt=True)
+        td_ris.conv_tol = 1.0E-4
+        td_ris.Ktrunc = 0.0
+        td_ris.kernel()
+        nac_ris = td_ris.nac_method()
+        nac_ris.ris_zvector_solver = True
+        nac_ris.states=(1,0)
+        nac_ris.kernel()
+
+        ref_de = np.array(
+            [[ 0.0127227850, -0.0000000000, 0.0000000000],
+             [-0.0251899178,  0.0000000000, 0.0000000000],
+             [-0.0251899197, -0.0000000000, 0.0000000000],])
+        ref_de_etf = np.array(
+            [[ 0.1169076233,  0.0000000000, 0.0000000000],
+             [-0.0584538196,  0.0000000000, 0.0000000000],
+             [-0.0584538263, -0.0000000000, 0.0000000000],])
+
+        # compare with previous calculation resusts
+        assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5
+        assert np.linalg.norm(np.abs(nac_ris.de_etf) - np.abs(ref_de_etf)) < 1.0E-5
+
+    def test_nac_camb3lyp_tdaris_singlet_vs_ref_ris_zvector_solver(self):
+        mf = dft.rks.RKS(mol, xc="camb3lyp").to_gpu()
+        mf.grids.atom_grid = (99,590)
+        mf.kernel()
+
+        td_ris = tdscf.ris.TDA(mf=mf, nstates=5, spectra=False, single=False, gram_schmidt=True)
+        td_ris.conv_tol = 1.0E-4
+        td_ris.Ktrunc = 0.0
+        td_ris.kernel()
+        nac_ris = td_ris.nac_method()
+        nac_ris.ris_zvector_solver = True
+        nac_ris.states=(1,0)
+        nac_ris.kernel()
+
+        ref_de = np.array(
+            [[-0.0105566781, -0.0000000000, 0.0000000000],
+             [ 0.0241046858,  0.0000000000, 0.0000000000],
+             [ 0.0241046879, -0.0000000000, 0.0000000000],])
+        ref_de_etf = np.array(
+            [[-0.1117981850,  0.0000000000, 0.0000000000],
+             [ 0.0558990554,  0.0000000000, 0.0000000000],
+             [ 0.0558990627, -0.0000000000, 0.0000000000],])
+
+        # compare with previous calculation resusts
+        assert np.linalg.norm(np.abs(nac_ris.de) - np.abs(ref_de)) < 1.0E-5
+        assert np.linalg.norm(np.abs(nac_ris.de_etf) - np.abs(ref_de_etf)) < 1.0E-5
+
 if __name__ == "__main__":
     print("Full Tests for TD-RKS-ris nonadiabatic coupling vectors between ground and excited state.")
     unittest.main()

--- a/gpu4pyscf/nac/tests/test_tdrks_ris_nac_scanner.py
+++ b/gpu4pyscf/nac/tests/test_tdrks_ris_nac_scanner.py
@@ -1,0 +1,93 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import cupy as cp
+import pyscf
+from pyscf import lib, gto, scf, dft
+from gpu4pyscf import tdscf, nac
+import gpu4pyscf
+from gpu4pyscf.lib.multi_gpu import num_devices
+
+atom = """
+O       0.0000000000     0.0000000000     0.0000000000
+H       0.0000000000    -0.7570000000     0.5870000000
+H       0.0000000000     0.7570000000     0.5870000000
+"""
+atom1 = """
+O       0.0000000000     0.0000000000     0.0000000000
+H       0.0000000000    -0.7570000000     0.5870000000
+H       0.0000000000     0.7570000000     0.5870000000
+"""
+
+bas0 = "cc-pvdz"
+
+def setUpModule():
+    global mol, mol1
+    mol = pyscf.M(
+        atom=atom, basis=bas0, max_memory=32000, output="/dev/null", verbose=1)
+    mol1 = pyscf.M(
+        atom=atom1, basis=bas0, max_memory=32000, output="/dev/null", verbose=1)
+
+
+def tearDownModule():
+    global mol, mol1
+    mol.stdout.close()
+    mol1.stdout.close()
+    del mol, mol1
+
+
+class KnownValues(unittest.TestCase):
+    def test_nac_scanner_ge(self):
+        mf = dft.RKS(mol, xc="b3lyp").to_gpu().density_fit()
+        mf.kernel()
+        td = tdscf.ris.TDA(mf=mf, nstates=5, Ktrunc = 0.0, spectra=False, single=False, gram_schmidt=True)
+        td.kernel()
+        nac1 = td.nac_method()
+        nac1.states=(0,1)
+        nac_benchmark = nac1.kernel()
+        nac_benchmark_de = nac_benchmark[0]
+
+        nac_scanner = nac1.as_scanner()
+        new_nac = nac_scanner(mol1)
+        assert (new_nac[1]*nac_benchmark_de).sum()/np.linalg.norm(new_nac[1])/np.linalg.norm(nac_benchmark_de) > 0.99
+        new_nac = nac_scanner(mol)
+        assert (new_nac[1]*nac_benchmark_de).sum()/np.linalg.norm(new_nac[1])/np.linalg.norm(nac_benchmark_de) > 0.99
+        new_nac = nac_scanner(mol1)
+        assert (new_nac[1]*nac_benchmark_de).sum()/np.linalg.norm(new_nac[1])/np.linalg.norm(nac_benchmark_de) > 0.99
+
+    @unittest.skipIf(num_devices > 1, '')
+    def test_nac_scanner_ee(self):
+        mf = dft.RKS(mol, xc="b3lyp").to_gpu().density_fit()
+        mf.kernel()
+        td = tdscf.ris.TDA(mf=mf, nstates=5, Ktrunc = 0.0, spectra=False, single=False, gram_schmidt=True)
+        td.kernel()
+        nac1 = td.nac_method()
+        nac1.states=(1,2)
+        nac_benchmark = nac1.kernel()
+        nac_benchmark_de = nac_benchmark[0]
+
+        nac_scanner = nac1.as_scanner()
+        new_nac = nac_scanner(mol1)
+        assert (new_nac[1]*nac_benchmark_de).sum()/np.linalg.norm(new_nac[1])/np.linalg.norm(nac_benchmark_de) > 0.99
+        new_nac = nac_scanner(mol)
+        assert (new_nac[1]*nac_benchmark_de).sum()/np.linalg.norm(new_nac[1])/np.linalg.norm(nac_benchmark_de) > 0.99
+        new_nac = nac_scanner(mol1)
+        assert (new_nac[1]*nac_benchmark_de).sum()/np.linalg.norm(new_nac[1])/np.linalg.norm(nac_benchmark_de) > 0.99
+
+
+if __name__ == "__main__":
+    print("Full Tests for TD-RKS-ris nonadiabatic coupling vectors scanner.")
+    unittest.main()


### PR DESCRIPTION
Added support for an RIS-approximated Z-vector solver. This allows the use of auxiliary basis sets (via `mf_J` and `mf_K`) when solving the Z-vector equation for TDDFT analytic gradients and Non-Adiabatic Couplings (NACs).

Changes:
1. Added `gen_response_ris` in `grad/tdrks_ris.py`.
2. Integrated the solver into Gradient and NAC modules (`grad_elec`, `get_nacv_ge`, `get_nacv_ee`).
3. Added tests for gradients and NACs (GE/EE) covering pure, hybrid, and range-separated functionals.