### PR TITLE
PCM lowmem mode, without ngrids^2 storage

### DIFF
--- a/gpu4pyscf/lib/solvent/pcm.cu
+++ b/gpu4pyscf/lib/solvent/pcm.cu
@@ -37,7 +37,7 @@ static void _pcm_d_s(double* __restrict__ matrix_d, double* __restrict__ matrix_
     // calculate xi
     double ei = charge_exp[i];
     double ej = charge_exp[j];
-    double xi_ij = ei * ej / sqrt(ei*ei + ej*ej);
+    double xi_ij = ei * ej * rsqrt(ei*ei + ej*ej);
 
     // calculate r
     double xi = coords[3*i];
@@ -96,7 +96,7 @@ static void _pcm_left_multiply_S_offdiagonal(double* __restrict__ output, const 
     for (int j = threadIdx.x; j < n; j += blockDim.x) {
         // calculate xi
         const double ej = charge_exp[j];
-        const double xi_ij = ei * ej / sqrt(ei*ei + ej*ej);
+        const double xi_ij = ei * ej * rsqrt(ei*ei + ej*ej);
 
         // calculate r
         const double xj = coords[j    ];
@@ -161,7 +161,7 @@ static void _pcm_left_multiply_D(double* __restrict__ output, const double* __re
     for (int j = threadIdx.y; j < n; j += blockDim.y) {
         // calculate xi
         const double ej = charge_exp[j];
-        const double xi_ij = ei * ej / sqrt(ei*ei + ej*ej);
+        const double xi_ij = ei * ej * rsqrt(ei*ei + ej*ej);
 
         // calculate r
         const double xj = coords[3*j  ];
@@ -221,7 +221,7 @@ static void _pcm_dD_dS(double* __restrict__ matrix_dd, double* __restrict__ matr
     // calculate xi
     double ei = charge_exp[i];
     double ej = charge_exp[j];
-    double xi_ij = ei * ej / sqrt(ei*ei + ej*ej);
+    double xi_ij = ei * ej * rsqrt(ei*ei + ej*ej);
 
     // calculate r
     double dx = coords[3*i]   - coords[3*j];
@@ -281,7 +281,7 @@ static void _pcm_left_multiply_dS(double* __restrict__ output, const double* __r
     for (int j = threadIdx.y; j < n; j += blockDim.y) {
         // calculate xi
         const double ej = charge_exp[j];
-        const double xi_ij = ei * ej / sqrt(ei*ei + ej*ej);
+        const double xi_ij = ei * ej * rsqrt(ei*ei + ej*ej);
 
         // calculate r
         const double xj = coords[3*j  ];
@@ -378,7 +378,7 @@ static void _pcm_left_multiply_dD(double* __restrict__ output, const double* __r
     for (int j = threadIdx.y; j < n; j += blockDim.y) {
         // calculate xi
         const double ej = charge_exp[j];
-        const double xi_ij = ei * ej / sqrt(ei*ei + ej*ej);
+        const double xi_ij = ei * ej * rsqrt(ei*ei + ej*ej);
 
         // calculate r
         const double xj = coords[3*j  ];
@@ -472,7 +472,7 @@ static void _pcm_d2D_d2S(double* __restrict__ matrix_d2D, double* __restrict__ m
     // calculate xi
     const double ei = charge_exp[i];
     const double ej = charge_exp[j];
-    const double eij = ei * ej / sqrt(ei*ei + ej*ej);
+    const double eij = ei * ej * rsqrt(ei*ei + ej*ej);
 
     // calculate r
     const double dx = coords[3*i]   - coords[3*j];

--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -241,7 +241,6 @@ def contract_dSii(surface, contract_vector):
     R_in_J      = surface['R_in_J']
     R_sw_J      = surface['R_sw_J']
 
-    ngrids = grid_coords.shape[0]
     natom = atom_coords.shape[0]
     de_dSii_term = cupy.zeros([natom, 3])
 
@@ -282,7 +281,6 @@ def contract_dA(surface, contract_vector):
         If not in short of memory, it is preferable to compute dA together with dF (part of dSii) using get_dF_dA().
     '''
     charge_exp  = surface['charge_exp']
-    switch_fun  = surface['switch_fun']
     n = charge_exp.shape[0]
     assert contract_vector.shape == (n,)
 
@@ -292,7 +290,6 @@ def contract_dA(surface, contract_vector):
     R_sw_J      = surface['R_sw_J']
     area        = surface['area']
 
-    ngrids = grid_coords.shape[0]
     natom = atom_coords.shape[0]
     de_dA_term = cupy.zeros([natom, 3])
 

--- a/gpu4pyscf/solvent/grad/pcm.py
+++ b/gpu4pyscf/solvent/grad/pcm.py
@@ -25,7 +25,7 @@ from pyscf import lib
 from pyscf import gto
 from pyscf.grad import rhf as rhf_grad
 from gpu4pyscf.gto import int3c1e
-from gpu4pyscf.solvent.pcm import PI, switch_h, libsolvent
+from gpu4pyscf.solvent.pcm import PI, switch_h, libsolvent, left_multiply_S, left_multiply_D
 from gpu4pyscf.gto.int3c1e_ip import int1e_grids_ip1, int1e_grids_ip2
 from gpu4pyscf.lib.cupy_helper import contract
 from gpu4pyscf.lib import logger
@@ -166,10 +166,11 @@ def get_dD_dS(surface, with_S=True, with_D=False, stream=None):
         raise RuntimeError('Failed in generating PCM dD and dS matrices.')
     return dD, dS
 
-def left_multiply_dS(surface, right_vector, transpose = False, stream = None):
+def left_multiply_dS_offdiagonal(surface, right_vector, transpose = False, stream = None):
     charge_exp  = surface['charge_exp']
     grid_coords = surface['grid_coords']
     n = charge_exp.shape[0]
+    assert right_vector.size == n
     output = cupy.empty([3,n], order = "C")
     if stream is None:
         stream = cupy.cuda.get_current_stream()
@@ -182,10 +183,34 @@ def left_multiply_dS(surface, right_vector, transpose = False, stream = None):
         ctypes.c_int(n)
     )
     if err != 0:
-        raise RuntimeError('Failed in left_multiply_dS')
+        raise RuntimeError('Failed in left_multiply_dS_offdiagonal')
     if transpose:
         # S is symmetric and Sij depends only on ri and rj
         output *= -1
+    return output.T
+
+def left_multiply_dD(surface, right_vector, transpose = False, stream = None):
+    grid_coords = surface['grid_coords']
+    charge_exp  = surface['charge_exp']
+    norm_vec    = surface['norm_vec']
+    n = charge_exp.shape[0]
+    assert right_vector.size == n
+    assert type(transpose) is bool
+    output = cupy.empty([3,n], order = "C")
+    if stream is None:
+        stream = cupy.cuda.get_current_stream()
+    err = libsolvent.pcm_left_multiply_dd(
+        ctypes.cast(stream.ptr, ctypes.c_void_p),
+        ctypes.cast(output.data.ptr, ctypes.c_void_p),
+        ctypes.cast(right_vector.data.ptr, ctypes.c_void_p),
+        ctypes.cast(grid_coords.data.ptr, ctypes.c_void_p),
+        ctypes.cast(charge_exp.data.ptr, ctypes.c_void_p),
+        ctypes.cast(norm_vec.data.ptr, ctypes.c_void_p),
+        ctypes.c_int(n),
+        ctypes.c_bool(transpose),
+    )
+    if err != 0:
+        raise RuntimeError('Failed in left_multiply_dD')
     return output.T
 
 def get_dSii(surface, dF):
@@ -196,6 +221,110 @@ def get_dSii(surface, dF):
     dSii_dF = -charge_exp * (2.0/PI)**0.5 / switch_fun**2
     dSii = dSii_dF[:,None] * dF
     return dSii
+
+def contract_dSii(surface, contract_vector):
+    '''
+        Returns contract('g,dgA->Ad', contract_vector, dSii)
+        The main purpose of this function is to save memory, as dSii requires 3*natm*ngrids storage.
+    '''
+    charge_exp  = surface['charge_exp']
+    switch_fun  = surface['switch_fun']
+    n = charge_exp.shape[0]
+    assert contract_vector.shape == (n,)
+
+    dSii_dF = -numpy.sqrt(2.0/PI) * charge_exp / switch_fun**2
+    contract_vector *= dSii_dF
+    dSii_dF = None
+
+    atom_coords = surface['atom_coords']
+    grid_coords = surface['grid_coords']
+    R_in_J      = surface['R_in_J']
+    R_sw_J      = surface['R_sw_J']
+
+    ngrids = grid_coords.shape[0]
+    natom = atom_coords.shape[0]
+    de_dSii_term = cupy.zeros([natom, 3])
+
+    for ia in range(natom):
+        p0,p1 = surface['gslice_by_atom'][ia]
+        coords = grid_coords[p0:p1]
+        ri_rJ = cupy.expand_dims(coords, axis=1) - atom_coords
+        riJ = cupy.linalg.norm(ri_rJ, axis=-1)
+        diJ = (riJ - R_in_J) / R_sw_J
+        diJ[:,ia] = 1.0
+        diJ[diJ < 1e-8] = 0.0
+        ri_rJ[:,ia,:] = 0.0
+        ri_rJ[diJ < 1e-8] = 0.0
+
+        fiJ = switch_h(diJ)
+        dfiJ = grad_switch_h(diJ) / (fiJ * riJ * R_sw_J)
+        dfiJ = cupy.expand_dims(dfiJ, axis=-1) * ri_rJ
+
+        Fi = switch_fun[p0:p1]
+
+        # grids response
+        Fi = cupy.expand_dims(Fi, axis=-1)
+        dFi_grid = cupy.sum(dfiJ, axis=1)
+        # dF[p0:p1,ia,:] += Fi * dFi_grid
+        de_dSii_term[ia,:] += contract("gd,g->d", Fi * dFi_grid, contract_vector[p0:p1])
+
+        # atom response
+        Fi = cupy.expand_dims(Fi, axis=-2)
+        # dF[p0:p1,:,:] -= Fi * dfiJ
+        de_dSii_term -= contract("gAd,g->Ad", Fi * dfiJ, contract_vector[p0:p1])
+
+    return de_dSii_term
+
+def contract_dA(surface, contract_vector):
+    '''
+        Returns contract('g,dgA->Ad', contract_vector, dA)
+        The main purpose of this function is to save memory, as dA requires 3*natm*ngrids storage.
+        If not in short of memory, it is preferable to compute dA together with dF (part of dSii) using get_dF_dA().
+    '''
+    charge_exp  = surface['charge_exp']
+    switch_fun  = surface['switch_fun']
+    n = charge_exp.shape[0]
+    assert contract_vector.shape == (n,)
+
+    atom_coords = surface['atom_coords']
+    grid_coords = surface['grid_coords']
+    R_in_J      = surface['R_in_J']
+    R_sw_J      = surface['R_sw_J']
+    area        = surface['area']
+
+    ngrids = grid_coords.shape[0]
+    natom = atom_coords.shape[0]
+    de_dA_term = cupy.zeros([natom, 3])
+
+    for ia in range(natom):
+        p0,p1 = surface['gslice_by_atom'][ia]
+        coords = grid_coords[p0:p1]
+        ri_rJ = cupy.expand_dims(coords, axis=1) - atom_coords
+        riJ = cupy.linalg.norm(ri_rJ, axis=-1)
+        diJ = (riJ - R_in_J) / R_sw_J
+        diJ[:,ia] = 1.0
+        diJ[diJ < 1e-8] = 0.0
+        ri_rJ[:,ia,:] = 0.0
+        ri_rJ[diJ < 1e-8] = 0.0
+
+        fiJ = switch_h(diJ)
+        dfiJ = grad_switch_h(diJ) / (fiJ * riJ * R_sw_J)
+        dfiJ = cupy.expand_dims(dfiJ, axis=-1) * ri_rJ
+
+        Ai = area[p0:p1]
+
+        # grids response
+        Ai = cupy.expand_dims(Ai, axis=-1)
+        dFi_grid = cupy.sum(dfiJ, axis=1)
+        # dA[p0:p1,ia,:] += Ai * dFi_grid
+        de_dA_term[ia,:] += contract("gd,g->d", Ai * dFi_grid, contract_vector[p0:p1])
+
+        # atom response
+        Ai = cupy.expand_dims(Ai, axis=-2)
+        # dA[p0:p1,:,:] -= Ai * dfiJ
+        de_dA_term -= contract("gAd,g->Ad", Ai * dfiJ, contract_vector[p0:p1])
+
+    return de_dA_term
 
 def grad_nuc(pcmobj, dm, q_sym = None):
     mol = pcmobj.mol
@@ -313,8 +442,9 @@ def grad_solver(pcmobj, dm, v_grids = None, v_grids_l = None, q = None):
         v_grids_l = pcmobj._intermediates['v_grids']
     if q is None:
         q = pcmobj._intermediates['q']
-    f_epsilon    = pcmobj._intermediates['f_epsilon']
-    if not pcmobj.if_method_in_CPCM_category:
+    f_epsilon = pcmobj._intermediates['f_epsilon']
+    lowmem_mode = getattr(pcmobj, "lowmem_intermediate_storage", False)
+    if (not pcmobj.if_method_in_CPCM_category) and (not lowmem_mode):
         A = pcmobj._intermediates['A']
         D = pcmobj._intermediates['D']
         S = pcmobj._intermediates['S']
@@ -348,70 +478,97 @@ def grad_solver(pcmobj, dm, v_grids = None, v_grids_l = None, q = None):
     de = cupy.zeros([pcmobj.mol.natm,3])
     if pcmobj.method.upper() in ['C-PCM', 'CPCM', 'COSMO']:
         # dR = 0, dK = dS
-        de_dS  = 0.5 * vK_1.reshape(-1, 1) * left_multiply_dS(pcmobj.surface, q, stream = None)
-        de_dS -= 0.5 * q.reshape(-1, 1) * left_multiply_dS(pcmobj.surface, vK_1, transpose = True, stream = None)
+        de_dS  = 0.5 * vK_1.reshape(-1, 1) * left_multiply_dS_offdiagonal(pcmobj.surface, q, stream = None)
+        de_dS -= 0.5 * q.reshape(-1, 1) * left_multiply_dS_offdiagonal(pcmobj.surface, vK_1, transpose = True, stream = None)
         de -= cupy.asarray([cupy.sum(de_dS[p0:p1], axis=0) for p0,p1 in gridslice])
 
-        dF, _ = get_dF_dA(pcmobj.surface, with_dA = False)
-        dSii = get_dSii(pcmobj.surface, dF)
-        de -= 0.5*contract('i,xij->jx', vK_1*q, dSii) # 0.5*cupy.einsum('i,xij,i->jx', vK_1, dSii, q)
+        de -= 0.5 * contract_dSii(pcmobj.surface, vK_1 * q)
 
     elif pcmobj.method.upper() in ['IEF-PCM', 'IEFPCM', 'SMD']:
-        dF, dA = get_dF_dA(pcmobj.surface)
-        dSii = get_dSii(pcmobj.surface, dF)
-        dF = None
-
-        dD, dS = get_dD_dS(pcmobj.surface, with_D=True, with_S=True)
-
         # dR = f_eps/(2*pi) * (dD*A + D*dA),
         # dK = dS - f_eps/(2*pi) * (dD*A*S + D*dA*S + D*A*dS)
         fac = f_epsilon/(2.0*PI)
 
-        Av = A*v_grids
-        de_dR  = 0.5*fac * contract_ket(vK_1, dD, Av)
-        de_dR -= 0.5*fac * contract_bra(vK_1, dD, Av)
-        de_dR  = cupy.asarray([cupy.sum(de_dR[p0:p1], axis=0) for p0,p1 in gridslice])
+        if not lowmem_mode:
+            dF, dA = get_dF_dA(pcmobj.surface)
+            dSii = get_dSii(pcmobj.surface, dF)
+            dF = None
 
-        vK_1_D = vK_1.dot(D)
-        vK_1_Dv = vK_1_D * v_grids
-        de_dR += 0.5*fac * contract('j,xjn->nx', vK_1_Dv, dA)
+            dD, dS = get_dD_dS(pcmobj.surface, with_D=True, with_S=True)
 
-        de_dS0  = 0.5*contract_ket(vK_1, dS, q)
-        de_dS0 -= 0.5*contract_bra(vK_1, dS, q)
-        de_dS0  = cupy.asarray([cupy.sum(de_dS0[p0:p1], axis=0) for p0,p1 in gridslice])
+            Av = A*v_grids
+            de_dR  = 0.5*fac * contract_ket(vK_1, dD, Av)
+            de_dR -= 0.5*fac * contract_bra(vK_1, dD, Av)
+            de_dR  = cupy.asarray([cupy.sum(de_dR[p0:p1], axis=0) for p0,p1 in gridslice])
 
-        vK_1_q = vK_1 * q
-        de_dS0 += 0.5*contract('i,xin->nx', vK_1_q, dSii)
+            vK_1_D = vK_1.dot(D)
+            vK_1_Dv = vK_1_D * v_grids
+            de_dR += 0.5*fac * contract('j,xjn->nx', vK_1_Dv, dA)
 
-        vK_1_DA = vK_1_D*A
-        de_dS1  = 0.5*contract_ket(vK_1_DA, dS, q)
-        de_dS1 -= 0.5*contract_bra(vK_1_DA, dS, q)
-        de_dS1  = cupy.asarray([cupy.sum(de_dS1[p0:p1], axis=0) for p0,p1 in gridslice])
+            de_dS0  = 0.5*contract_ket(vK_1, dS, q)
+            de_dS0 -= 0.5*contract_bra(vK_1, dS, q)
+            de_dS0  = cupy.asarray([cupy.sum(de_dS0[p0:p1], axis=0) for p0,p1 in gridslice])
 
-        vK_1_DAq = vK_1_DA*q
-        de_dS1 += 0.5*contract('j,xjn->nx', vK_1_DAq, dSii)
+            vK_1_q = vK_1 * q
+            de_dS0 += 0.5*contract('i,xin->nx', vK_1_q, dSii)
 
-        Sq = cupy.dot(S,q)
-        ASq = A*Sq
-        de_dD  = 0.5*contract_ket(vK_1, dD, ASq)
-        de_dD -= 0.5*contract_bra(vK_1, dD, ASq)
-        de_dD  = cupy.asarray([cupy.sum(de_dD[p0:p1], axis=0) for p0,p1 in gridslice])
+            vK_1_DA = vK_1_D*A
+            de_dS1  = 0.5*contract_ket(vK_1_DA, dS, q)
+            de_dS1 -= 0.5*contract_bra(vK_1_DA, dS, q)
+            de_dS1  = cupy.asarray([cupy.sum(de_dS1[p0:p1], axis=0) for p0,p1 in gridslice])
 
-        de_dA = 0.5*contract('j,xjn->nx', vK_1_D*Sq, dA)   # 0.5*cupy.einsum('j,xjn,j->nx', vK_1_D, dA, Sq)
+            vK_1_DAq = vK_1_DA*q
+            de_dS1 += 0.5*contract('j,xjn->nx', vK_1_DAq, dSii)
 
-        de_dK = de_dS0 - fac * (de_dD + de_dA + de_dS1)
-        de += de_dR - de_dK
+            Sq = cupy.dot(S,q)
+            ASq = A*Sq
+            de_dD  = 0.5*contract_ket(vK_1, dD, ASq)
+            de_dD -= 0.5*contract_bra(vK_1, dD, ASq)
+            de_dD  = cupy.asarray([cupy.sum(de_dD[p0:p1], axis=0) for p0,p1 in gridslice])
+
+            de_dA = 0.5*contract('j,xjn->nx', vK_1_D*Sq, dA)   # 0.5*cupy.einsum('j,xjn,j->nx', vK_1_D, dA, Sq)
+
+            de_dK = de_dS0 - fac * (de_dD + de_dA + de_dS1)
+            de += de_dR - de_dK
+        else:
+            A = pcmobj._intermediates['A']
+            Av = A*v_grids
+            de_dR  = 0.5*fac * vK_1.reshape(-1, 1) * left_multiply_dD(pcmobj.surface, Av, stream = None)
+            de_dR -= 0.5*fac * Av.reshape(-1, 1) * left_multiply_dD(pcmobj.surface, vK_1, transpose = True, stream = None)
+            de_dR  = cupy.asarray([cupy.sum(de_dR[p0:p1], axis=0) for p0,p1 in gridslice])
+
+            de_dS0  = 0.5 * vK_1.reshape(-1, 1) * left_multiply_dS_offdiagonal(pcmobj.surface, q, stream = None)
+            de_dS0 -= 0.5 * q.reshape(-1, 1) * left_multiply_dS_offdiagonal(pcmobj.surface, vK_1, transpose = True, stream = None)
+            de_dS0  = cupy.asarray([cupy.sum(de_dS0[p0:p1], axis=0) for p0,p1 in gridslice])
+
+            vK_1_D = left_multiply_D(pcmobj.surface, vK_1, transpose = True)
+            vK_1_DA = vK_1_D * A
+            de_dS1  = 0.5 * vK_1_DA.reshape(-1, 1) * left_multiply_dS_offdiagonal(pcmobj.surface, q, stream = None)
+            de_dS1 -= 0.5 * q.reshape(-1, 1) * left_multiply_dS_offdiagonal(pcmobj.surface, vK_1_DA, transpose = True, stream = None)
+            de_dS1  = cupy.asarray([cupy.sum(de_dS1[p0:p1], axis=0) for p0,p1 in gridslice])
+
+            Sq = left_multiply_S(pcmobj.surface, q)
+            ASq = A * Sq
+            de_dD  = 0.5 * vK_1.reshape(-1, 1) * left_multiply_dD(pcmobj.surface, ASq, stream = None)
+            de_dD -= 0.5 * ASq.reshape(-1, 1) * left_multiply_dD(pcmobj.surface, vK_1, transpose = True, stream = None)
+            de_dD  = cupy.asarray([cupy.sum(de_dD[p0:p1], axis=0) for p0,p1 in gridslice])
+
+            de_dK = de_dS0 - fac * (de_dD + de_dS1)
+            de_dK += 0.5 * contract_dSii(pcmobj.surface, vK_1 * q - fac * vK_1_DA * q)
+
+            de += de_dR - de_dK
+            de += 0.5*fac * contract_dA(pcmobj.surface, vK_1_D * v_grids + vK_1_D * Sq) # First term from de_dR, second from de_dK
 
     elif pcmobj.method.upper() in [ 'SS(V)PE' ]:
+        # dR = f_eps/(2*pi) * (dD*A + D*dA),
+        # dK = dS - f_eps/(2*pi) * (dD*A*S + D*dA*S + D*A*dS)
+        fac = f_epsilon/(2.0*PI)
+
         dF, dA = get_dF_dA(pcmobj.surface)
         dSii = get_dSii(pcmobj.surface, dF)
         dF = None
 
         dD, dS = get_dD_dS(pcmobj.surface, with_D=True, with_S=True)
-
-        # dR = f_eps/(2*pi) * (dD*A + D*dA),
-        # dK = dS - f_eps/(2*pi) * (dD*A*S + D*dA*S + D*A*dS)
-        fac = f_epsilon/(2.0*PI)
 
         Av = A*v_grids
         de_dR  = 0.5*fac * contract_ket(vK_1, dD, Av)

--- a/gpu4pyscf/solvent/pcm.py
+++ b/gpu4pyscf/solvent/pcm.py
@@ -404,7 +404,7 @@ class PCM(lib.StreamObject):
 
     _keys = {
         'method', 'vdw_scale', 'surface', 'r_probe', 'intopt',
-        'mol', 'radii_table', 'lebedev_order', 'lmax', 'eta',
+        'mol', 'radii_table', 'atom_radii', 'lebedev_order', 'lmax', 'eta',
         'eps', 'max_cycle', 'conv_tol', 'state_id', 'frozen',
         'frozen_dm0_for_finite_difference_without_response',
         'equilibrium_solvation', 'e', 'v', 'v_grids_n'
@@ -421,6 +421,7 @@ class PCM(lib.StreamObject):
         self.surface = {}
         self.r_probe = 0.0
         self.radii_table = None
+        self.atom_radii = None
         self.lebedev_order = 29
         self._intermediates = {}
         self.lowmem_intermediate_storage = False
@@ -446,6 +447,8 @@ class PCM(lib.StreamObject):
         logger.info(self, 'frozen = %s'       , self.frozen)
         logger.info(self, 'equilibrium_solvation = %s', self.equilibrium_solvation)
         logger.debug2(self, 'radii_table %s', self.radii_table)
+        if getattr(self, "atom_radii", None):
+            logger.info(self, 'User specified atomic radii %s', str(self.atom_radii))
         if getattr(self, "lowmem_intermediate_storage", False):
             logger.info(self, 'running in lowmem PCM mode, nothing with size O(ngrids**2) is stored')
             logger.info(self, 'GMRES convergence tolerance for K^-1 = %s', self.conv_tol)

--- a/gpu4pyscf/solvent/pcm.py
+++ b/gpu4pyscf/solvent/pcm.py
@@ -302,7 +302,7 @@ def left_solve_S(surface, right_vector, conv_tol = 1e-10, transpose = None, stre
                                       matvec = _S_preconditioner,
                                       dtype = right_vector.dtype)
     solution, info = minres(operator_S, right_vector.reshape(n), tol = conv_tol, M = preconditioner_S, maxiter = 100)
-    assert info == 0, f"CPCM S inversion with GMRES not converged in {info} iterations!"
+    assert info == 0, f"CPCM S inversion with MINRES not converged in {info} iterations!"
 
     solution = solution.reshape(right_vector.shape)
     return solution
@@ -404,7 +404,7 @@ def left_solve_K_SSVPE(surface, _intermediates, right_vector, conv_tol = 1e-10, 
                                       matvec = _K_preconditioner,
                                       dtype = right_vector.dtype)
     solution, info = minres(operator_K, right_vector.reshape(n), tol = conv_tol, M = preconditioner_K, maxiter = 100)
-    assert info == 0, f"SSVPE K inversion with GMRES not converged in {info} iterations!"
+    assert info == 0, f"SSVPE K inversion with MINRES not converged in {info} iterations!"
 
     solution = solution.reshape(right_vector.shape)
     return solution
@@ -461,7 +461,7 @@ class PCM(lib.StreamObject):
             logger.info(self, 'User specified atomic radii %s', str(self.atom_radii))
         if getattr(self, "lowmem_intermediate_storage", False):
             logger.info(self, 'running in lowmem PCM mode, nothing with size O(ngrids**2) is stored')
-            logger.info(self, 'GMRES convergence tolerance for K^-1 = %s', self.conv_tol)
+            logger.info(self, 'Iterative inversion convergence tolerance for K^-1 = %s', self.conv_tol)
         return self
 
     def build(self, ng=None):

--- a/gpu4pyscf/solvent/tests/test_pcm_lowmem.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_lowmem.py
@@ -49,6 +49,7 @@ def _energy_with_solvent(mf, method):
     cm.verbose = 0
     cm.lebedev_order = lebedev_order
     cm.method = method
+    cm.lowmem_intermediate_storage = True
     mf = mf.PCM(cm)
     e_tot = mf.kernel()
     return e_tot

--- a/gpu4pyscf/solvent/tests/test_pcm_lowmem_grad.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_lowmem_grad.py
@@ -49,6 +49,7 @@ def _gradient_with_solvent(mf, method):
     cm.verbose = 0
     cm.lebedev_order = lebedev_order
     cm.method = method
+    cm.lowmem_intermediate_storage = True
     mf = mf.PCM(cm)
     mf.conv_tol = 1e-10
     mf.kernel()

--- a/gpu4pyscf/solvent/tests/test_pcm_lowmem_grad.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_lowmem_grad.py
@@ -59,6 +59,7 @@ def _gradient_with_solvent(mf, method, lowmem_pcm = True):
 
 @unittest.skipIf(pcm.libsolvent is None, "solvent extension not compiled")
 class KnownValues(unittest.TestCase):
+    @pytest.mark.slow
     def test_lowmem_gradient_RHF_CPCM(self):
         # g_reference = _gradient_with_solvent(scf.RHF(mol), 'COSMO', False)
         g_reference = numpy.array([

--- a/gpu4pyscf/solvent/tests/test_pcm_lowmem_grad.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_lowmem_grad.py
@@ -43,15 +43,15 @@ def tearDownModule():
     mol.stdout.close()
     del mol
 
-def _gradient_with_solvent(mf, method):
+def _gradient_with_solvent(mf, method, lowmem_pcm = True):
     cm = pcm.PCM(mol)
     cm.eps = epsilon
     cm.verbose = 0
     cm.lebedev_order = lebedev_order
     cm.method = method
-    cm.lowmem_intermediate_storage = True
+    cm.lowmem_intermediate_storage = lowmem_pcm
     mf = mf.PCM(cm)
-    mf.conv_tol = 1e-10
+    mf.conv_tol = 1e-12
     mf.kernel()
 
     g_tot = mf.Gradients().kernel()
@@ -60,12 +60,12 @@ def _gradient_with_solvent(mf, method):
 @unittest.skipIf(pcm.libsolvent is None, "solvent extension not compiled")
 class KnownValues(unittest.TestCase):
     def test_lowmem_gradient_RHF_CPCM(self):
-        # g_reference = _gradient_with_solvent(scf.RHF(mol), 'COSMO')
+        # g_reference = _gradient_with_solvent(scf.RHF(mol), 'COSMO', False)
         g_reference = numpy.array([
-            [-0.0163174947894124,  0.0071813633451422,  0.0077272830289788],
-            [ 0.055901325985305 , -0.0113535254296157, -0.0294709948305932],
-            [-0.0071729768409255, -0.0177751943530026, -0.0040459320222851],
-            [-0.0324108543551454,  0.0219473564375562,  0.0257896438220912],
+            [-0.0163175067980038,  0.0071812687357845,  0.007727516476731 ],
+            [ 0.0559012485168635, -0.011353691832632 , -0.0294711367871   ],
+            [-0.0071729382647378, -0.0177750521871014, -0.0040458964935528],
+            [-0.0324108034542936,  0.0219474752840269,  0.025789516802629 ],
         ])
         g_test = _gradient_with_solvent(hf_lowmem.RHF(mol), 'COSMO')
 
@@ -74,12 +74,12 @@ class KnownValues(unittest.TestCase):
         assert diff < g_tolerance
 
     def test_lowmem_gradient_RHF_IEFPCM(self):
-        # g_reference = _gradient_with_solvent(scf.RHF(mol), 'IEF-PCM')
+        # g_reference = _gradient_with_solvent(scf.RHF(mol), 'IEF-PCM', False)
         g_reference = numpy.array([
-            [-0.0163091544133066,  0.0071854944214561,  0.0077255306119172],
-            [ 0.0558925557229586, -0.0113578352019582, -0.0294540386690879],
-            [-0.0071899040819504, -0.0177787858574423, -0.004052172393671 ],
-            [-0.0323934972278823,  0.0219511266380314,  0.0257806804490408],
+            [-0.0163091640644741,  0.0071854047204253,  0.0077257383274488],
+            [ 0.0558924741414254, -0.0113579898790315, -0.0294541518164558],
+            [-0.0071898644361561, -0.0177786593955563, -0.004052144958452 ],
+            [-0.0323934456409908,  0.0219512445542212,  0.0257805584461862],
         ])
         g_test = _gradient_with_solvent(hf_lowmem.RHF(mol), 'IEF-PCM')
 
@@ -88,12 +88,12 @@ class KnownValues(unittest.TestCase):
         assert diff < g_tolerance
 
     def test_lowmem_gradient_RHF_SSVPE(self):
-        # g_reference = _gradient_with_solvent(scf.RHF(mol), 'SS(V)PE')
+        # g_reference = _gradient_with_solvent(scf.RHF(mol), 'SS(V)PE', False)
         g_reference = numpy.array([
-            [-0.0162824724891702,  0.0071927956010561,  0.0078358202316499],
-            [ 0.0558764894925583, -0.0113434242569014, -0.0295305650377395],
-            [-0.0072341681793649, -0.0178095577692442, -0.0041154124459146],
-            [-0.0323598488242109,  0.0219601864251614,  0.0258101572502076],
+            [-0.0162824856323564,  0.0071927008916414,  0.0078360528313351],
+            [ 0.0558764125359919, -0.0113435908548165, -0.0295307062332608],
+            [-0.0072341291910355, -0.0178094153295815, -0.0041153768893911],
+            [-0.0323597977127988,  0.0219603052928713,  0.0258100302900295],
         ])
         g_test = _gradient_with_solvent(hf_lowmem.RHF(mol), 'SS(V)PE')
 
@@ -102,12 +102,12 @@ class KnownValues(unittest.TestCase):
         assert diff < g_tolerance
 
     def test_lowmem_gradient_RKS_CPCM(self):
-        # g_reference = _gradient_with_solvent(dft.RKS(mol, xc='b3lyp'), 'C-PCM')
+        # g_reference = _gradient_with_solvent(dft.RKS(mol, xc='b3lyp'), 'C-PCM', False)
         g_reference = numpy.array([
-            [ 0.0107094975860696, -0.0239253315377735,  0.0181754675482018],
-            [ 0.0304517629380441,  0.0203233534121517, -0.0119343709048924],
-            [-0.0295443405231933, -0.0159663759731676, -0.0169380599890039],
-            [-0.0116148291827615,  0.0195746794891644,  0.0107002955042028],
+            [ 0.0107095697534382, -0.0239253590983287,  0.0181754716966574],
+            [ 0.0304517151611092,  0.0203233799157037, -0.0119343636494438],
+            [-0.0295443021479662, -0.0159663515299563, -0.0169380713186013],
+            [-0.0116148919620014,  0.019574656096594 ,  0.0107002954608816],
         ])
         g_test = _gradient_with_solvent(rks_lowmem.RKS(mol, xc='b3lyp'), 'C-PCM')
 
@@ -116,12 +116,12 @@ class KnownValues(unittest.TestCase):
         assert diff < g_tolerance
 
     def test_lowmem_gradient_RKS_IEFPCM(self):
-        # g_reference = _gradient_with_solvent(dft.RKS(mol, xc='wb97m-v'), 'IEF-PCM')
+        # g_reference = _gradient_with_solvent(dft.RKS(mol, xc='wb97m-v'), 'IEF-PCM', False)
         g_reference = numpy.array([
-            [ 0.0092344065127647, -0.015735748870309 ,  0.0179434350777853],
-            [ 0.0319344700130117,  0.0122162799479534, -0.0133993962512032],
-            [-0.0281476667354037, -0.0159401990506446, -0.0161802722099711],
-            [-0.013016035388716 ,  0.019463124206746 ,  0.0116404233769247],
+            [ 0.0092344759118757, -0.0157357350651268,  0.0179434519747163],
+            [ 0.0319343630951492,  0.0122162239055141, -0.0133994229373763],
+            [-0.028147669061958 , -0.0159401762636575, -0.0161802707141887],
+            [-0.0130159955568279,  0.0194631436530942,  0.0116404316908084],
         ])
         g_test = _gradient_with_solvent(rks_lowmem.RKS(mol, xc='wb97m-v'), 'IEF-PCM')
 
@@ -130,12 +130,12 @@ class KnownValues(unittest.TestCase):
         assert diff < g_tolerance
 
     def test_lowmem_gradient_RKS_SSVPE(self):
-        # g_reference = _gradient_with_solvent(dft.RKS(mol, xc='pbe'), 'SS(V)PE')
+        # g_reference = _gradient_with_solvent(dft.RKS(mol, xc='pbe'), 'SS(V)PE', False)
         g_reference = numpy.array([
-            [ 0.0197558602164731, -0.0315200201481581,  0.0220234876552322],
-            [ 0.0221629676914258,  0.0281576145012744, -0.0063872949461893],
-            [-0.0371864324361556, -0.0155281188695062, -0.0213824833655754],
-            [-0.0047281688870682,  0.0188991381631425,  0.0057502521572663],
+            [ 0.0197558534156823, -0.031520015730371 ,  0.0220234927827623],
+            [ 0.0221629691155982,  0.0281576122655399, -0.0063872890269219],
+            [-0.0371864317077676, -0.015528121099998 , -0.0213824873378206],
+            [-0.0047281642564727,  0.0188991382028949,  0.0057502451040964],
         ])
         g_test = _gradient_with_solvent(rks_lowmem.RKS(mol, xc='pbe'), 'SS(V)PE')
 


### PR DESCRIPTION
This PR is unrelated to domain decomposition PCM available in pyscf. It is just reconstructing every S, D (thus R, K^-1) matrices on the fly, similar to the logic of direct SCF. K^-1 is obtained via GMRES in cupy.

- [x] CPCM energy
- [x] IEFPCM energy
- [x] CPCM gradient
- [x] IEFPCM gradient