### PR TITLE
Better PBC Becke weight support

### DIFF
--- a/gpu4pyscf/dft/gen_grid.py
+++ b/gpu4pyscf/dft/gen_grid.py
@@ -516,6 +516,8 @@ class Grids(lib.StreamObject):
             self.mol = mol
         self.coords = None
         self.weights = None
+        self.atm_idx = None
+        self.quadrature_weights = None
         self.non0tab = None
         self.screen_index = None
         self._non0ao_idx = None

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -2235,12 +2235,12 @@ def get_dweight_dA(mol, grids, grid_range = None):
     ngrids = grids.coords.shape[0]
     assert grids.atm_idx.shape[0] == ngrids
     assert grids.quadrature_weights.shape[0] == ngrids
-    atm_coords = cupy.asarray(mol.atom_coords(), order = "C")
+    atm_coords = cupy.asarray(mol.atom_coords(), order = "F")
 
     from gpu4pyscf.dft import radi
     a_factor = radi.get_treutler_fac(mol, grids.atomic_radii) # Please make sure this is antisymmetric
 
-    grids_coords = cupy.asarray(grids.coords)
+    grids_coords = cupy.asarray(grids.coords, order = "F")
     grids_quadrature_weights = cupy.asarray(grids.quadrature_weights)
     grids_atm_idx = cupy.asarray(grids.atm_idx)
     if grid_range is not None:
@@ -2290,12 +2290,12 @@ def get_d2weight_dAdB(mol, grids, grid_range = None):
     ngrids = grids.coords.shape[0]
     assert grids.atm_idx.shape[0] == ngrids
     assert grids.quadrature_weights.shape[0] == ngrids
-    atm_coords = cupy.asarray(mol.atom_coords(), order = "C")
+    atm_coords = cupy.asarray(mol.atom_coords(), order = "F")
 
     from gpu4pyscf.dft import radi
     a_factor = radi.get_treutler_fac(mol, grids.atomic_radii) # Please make sure this is antisymmetric
 
-    grids_coords = cupy.asarray(grids.coords)
+    grids_coords = cupy.asarray(grids.coords, order = "F")
     grids_quadrature_weights = cupy.asarray(grids.quadrature_weights)
     grids_atm_idx = cupy.asarray(grids.atm_idx)
     if grid_range is not None:

--- a/gpu4pyscf/lib/gdft/gen_grids.cu
+++ b/gpu4pyscf/lib/gdft/gen_grids.cu
@@ -212,6 +212,38 @@ __device__ double switch_function_dsdmu_over_s(const double mu, const double a_f
     return dsdmu * (*inv_s);
 }
 
+__device__ double switch_function_no_radii_adjust(const double mu)
+{
+    double s = mu;
+    s = (3.0 - s * s) * s * 0.5;
+    s = (3.0 - s * s) * s * 0.5;
+    s = (3.0 - s * s) * s * 0.5;
+    s = 0.5 * (1.0 - s);
+    return s;
+}
+
+__device__ double switch_function_no_radii_adjust_dsdmu_over_s(const double mu)
+{
+    const double f1 = (3.0 - mu * mu) * mu * 0.5;
+    const double f2 = (3.0 - f1 * f1) * f1 * 0.5;
+    const double f3 = (3.0 - f2 * f2) * f2 * 0.5;
+    const double s = 0.5 * (1.0 - f3);
+    const double dsdmu = -0.5 * 1.5 * (1 - f2 * f2) * 1.5 * (1 - f1 * f1) * 1.5 * (1 - mu * mu);
+    return dsdmu * inv(s);
+}
+
+__device__ double switch_function_no_radii_adjust_dsdmu_over_s(const double mu, double* inv_s)
+{
+    const double f1 = (3.0 - mu * mu) * mu * 0.5;
+    const double f2 = (3.0 - f1 * f1) * f1 * 0.5;
+    const double f3 = (3.0 - f2 * f2) * f2 * 0.5;
+    const double s = 0.5 * (1.0 - f3);
+    (*inv_s) = inv(s);
+    const double dsdmu = -0.5 * 1.5 * (1 - f2 * f2) * 1.5 * (1 - f1 * f1) * 1.5 * (1 - mu * mu);
+    return dsdmu * (*inv_s);
+}
+
+template <bool if_radii_adjust>
 __global__
 void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* __restrict__ grid_coords, const double* __restrict__ grid_quadrature_weights,
                                        const double* __restrict__ atm_coords, const double* __restrict__ a_factor, const int* __restrict__ atm_idx,
@@ -246,9 +278,14 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
         const double norm_BG_1 = inv(norm(BG));
         const double mu_BG = (norm_Br - norm_Gr) * norm_BG_1;
         const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + mu_BG * norm_BG_1 * BG);
-        const double a_factor_BG = a_factor[j_atom * natm + i_derivative_atom];
+        double dsBG_dmuBG_over_sBG = NAN;
         double inv_sBG = NAN;
-        const double dsBG_dmuBG_over_sBG = switch_function_dsdmu_over_s(mu_BG, a_factor_BG, &inv_sBG);
+        if constexpr (if_radii_adjust) {
+            const double a_factor_BG = a_factor[j_atom * natm + i_derivative_atom];
+            dsBG_dmuBG_over_sBG = switch_function_dsdmu_over_s(mu_BG, a_factor_BG, &inv_sBG);
+        } else {
+            dsBG_dmuBG_over_sBG = switch_function_no_radii_adjust_dsdmu_over_s(mu_BG, &inv_sBG);
+        }
         const double3 dsBG_dG = dsBG_dmuBG_over_sBG * dmuBG_dG;
         const double3 dPB_dG = P_B * dsBG_dG;
         sum_dPB_dG += dPB_dG;
@@ -274,8 +311,14 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
     const double norm_AG_1 = inv(norm(AG));
     const double mu_AG = (norm_Ar - norm_Gr) * norm_AG_1;
     const double3 dmuAG_dG = norm_AG_1 * (-norm_Gr_1 * Gr + mu_AG * norm_AG_1 * AG);
-    const double a_factor_AG = a_factor[i_associated_atom * natm + i_derivative_atom];
-    const double3 dPA_dG = switch_function_dsdmu_over_s(mu_AG, a_factor_AG) * P_A * dmuAG_dG;
+    double dsAG_dmuAG_over_sAG = NAN;
+    if constexpr (if_radii_adjust) {
+        const double a_factor_AG = a_factor[i_associated_atom * natm + i_derivative_atom];
+        dsAG_dmuAG_over_sAG = switch_function_dsdmu_over_s(mu_AG, a_factor_AG);
+    } else {
+        dsAG_dmuAG_over_sAG = switch_function_no_radii_adjust_dsdmu_over_s(mu_AG);
+    }
+    const double3 dPA_dG = dsAG_dmuAG_over_sAG * P_A * dmuAG_dG;
 
     const double sum_P_B_1 = invsumPB[i_grid];
     const double quadrature_weight = grid_quadrature_weights[i_grid];
@@ -615,6 +658,7 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
     d2w_dG1dG2[i_atom_G * natm * 9 * ngrids + i_atom_G * 9 * ngrids + 8 * ngrids + i_grid] = d2wi_dG2.z.z;
 }
 
+template <bool if_radii_adjust>
 __global__
 void GDFTgrid_becke_eval_PB_kernel(double* __restrict__ PB, const double* __restrict__ grid_coords,
                                    const double* __restrict__ atm_coords, const double* __restrict__ a_factor,
@@ -640,8 +684,13 @@ void GDFTgrid_becke_eval_PB_kernel(double* __restrict__ PB, const double* __rest
         const double norm_BC_1 = inv(norm(BC));
 
         const double mu_BC = (norm_Br - norm_Cr) * norm_BC_1;
-        const double a_factor_BC = a_factor[i_atom_B * natm + i_atom_C];
-        const double s_BC = switch_function(mu_BC, a_factor_BC);
+        double s_BC = NAN;
+        if constexpr (if_radii_adjust) {
+            const double a_factor_BC = a_factor[i_atom_B * natm + i_atom_C];
+            s_BC = switch_function(mu_BC, a_factor_BC);
+        } else {
+            s_BC = switch_function_no_radii_adjust(mu_BC);
+        }
 
         P_B *= s_BC;
     }
@@ -691,15 +740,15 @@ void GDFTgroup_grids_kernel(int* group_ids, const double* atom_coords, const dou
 extern "C"{
 __host__
 int GDFTbecke_partition_weights(double *weights, double *coords, double *atm_coords,
-                                double *a, int *atm_idx, int ngrids, int natm)
+                                double *a_factor, int *atm_idx, int ngrids, int natm)
 {
     dim3 threads(TILE, TILE);
     int blocks = (ngrids+TILE*TILE-1)/(TILE*TILE);
-    if (a != NULL) {
-        GDFTgrid_weight_kernel< true> <<<blocks, threads>>>(weights, coords, atm_coords, a,
+    if (a_factor != NULL) {
+        GDFTgrid_weight_kernel< true> <<<blocks, threads>>>(weights, coords, atm_coords, a_factor,
                                                             atm_idx, ngrids, natm);
     } else {
-        GDFTgrid_weight_kernel<false> <<<blocks, threads>>>(weights, coords, atm_coords, a,
+        GDFTgrid_weight_kernel<false> <<<blocks, threads>>>(weights, coords, atm_coords, a_factor,
                                                             atm_idx, ngrids, natm);
     }
     cudaError_t err = cudaGetLastError();
@@ -718,8 +767,14 @@ int GDFTbecke_partition_weight_derivative(double *dwdG, const double *grid_coord
     const dim3 threads(TILE, TILE);
     const dim3 blocks((ngrids + TILE - 1) / TILE,
                       (natm + TILE - 1) / TILE);
-    GDFTgrid_weight_derivative_kernel<<<blocks, threads>>>(dwdG, grid_coords, grid_quadrature_weights,
-                                                           atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm);
+    if (a_factor != NULL) {
+        GDFTgrid_weight_derivative_kernel< true> <<<blocks, threads>>>(dwdG, grid_coords, grid_quadrature_weights,
+                                                                       atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm);
+    } else {
+        GDFTgrid_weight_derivative_kernel<false> <<<blocks, threads>>>(dwdG, grid_coords, grid_quadrature_weights,
+                                                                       atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm);
+
+    }
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess){
         fprintf(stderr, "CUDA Error in GDFTgrid_weight_derivative: %s\n", cudaGetErrorString(err));
@@ -733,6 +788,12 @@ int GDFTbecke_partition_weight_second_derivative(double *d2w_dG1dG2, const doubl
                                                  const double *atm_coords, const double *a_factor, const int *atm_idx,
                                                  const double *PB, const double *invsumPB, const int ngrids, const int natm)
 {
+    if (a_factor == NULL) {
+        fprintf(stderr, "Becke weight second derivative kernel does not support a_factor == NULL yet");
+        cudaMemset(d2w_dG1dG2, 0xFF, natm * natm * 9 * ngrids * sizeof(double)); // Fill with NAN
+        return 1;
+    }
+
     {
         constexpr int n_grid_per_block = 16;
         constexpr int n_atom_per_block = 4;
@@ -765,13 +826,15 @@ int GDFTbecke_eval_PB(double *PB, const double *grid_coords,
                       const double *atm_coords, const double *a_factor,
                       const int ngrids, const int natm)
 {
-    {
-        constexpr int n_grid_per_block = 64;
-        constexpr int n_atom_per_block = 4;
-        const dim3 threads(n_grid_per_block, n_atom_per_block);
-        const dim3 blocks((ngrids + n_grid_per_block - 1) / n_grid_per_block,
-                          (natm   + n_atom_per_block - 1) / n_atom_per_block);
-        GDFTgrid_becke_eval_PB_kernel<<<blocks, threads>>>(PB, grid_coords, atm_coords, a_factor, ngrids, natm);
+    constexpr int n_grid_per_block = 64;
+    constexpr int n_atom_per_block = 4;
+    const dim3 threads(n_grid_per_block, n_atom_per_block);
+    const dim3 blocks((ngrids + n_grid_per_block - 1) / n_grid_per_block,
+                      (natm   + n_atom_per_block - 1) / n_atom_per_block);
+    if (a_factor != NULL) {
+        GDFTgrid_becke_eval_PB_kernel< true> <<<blocks, threads>>>(PB, grid_coords, atm_coords, a_factor, ngrids, natm);
+    } else {
+        GDFTgrid_becke_eval_PB_kernel<false> <<<blocks, threads>>>(PB, grid_coords, atm_coords, a_factor, ngrids, natm);
     }
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess){

--- a/gpu4pyscf/lib/gdft/gen_grids.cu
+++ b/gpu4pyscf/lib/gdft/gen_grids.cu
@@ -227,8 +227,8 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
     if (i_associated_atom == i_derivative_atom) // Dealt with later by translation invariance.
         return;
 
-    const double3 grid_r = { grid_coords[i_grid * 3 + 0], grid_coords[i_grid * 3 + 1], grid_coords[i_grid * 3 + 2] };
-    const double3 atom_G = { atm_coords[i_derivative_atom * 3 + 0], atm_coords[i_derivative_atom * 3 + 1], atm_coords[i_derivative_atom * 3 + 2] };
+    const double3 grid_r = { grid_coords[i_grid + 0 * ngrids], grid_coords[i_grid + 1 * ngrids], grid_coords[i_grid + 2 * ngrids] };
+    const double3 atom_G = { atm_coords[i_derivative_atom + 0 * natm], atm_coords[i_derivative_atom + 1 * natm], atm_coords[i_derivative_atom + 2 * natm] };
     const double3 Gr = atom_G - grid_r;
     const double norm_Gr = norm(Gr);
     const double norm_Gr_1 = inv(norm_Gr);
@@ -237,7 +237,7 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
     double3 dPG_dG = { 0.0, 0.0, 0.0 };
 
     for (int j_atom = 0; j_atom < natm; j_atom++) {
-        const double3 atom_B = { atm_coords[j_atom * 3 + 0], atm_coords[j_atom * 3 + 1], atm_coords[j_atom * 3 + 2] };
+        const double3 atom_B = { atm_coords[j_atom + 0 * natm], atm_coords[j_atom + 1 * natm], atm_coords[j_atom + 2 * natm] };
         const double3 Br = atom_B - grid_r;
         const double norm_Br = norm(Br);
         const double P_B = PB[j_atom * ngrids + i_grid];
@@ -265,7 +265,7 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
     const double P_G = PB[i_derivative_atom * ngrids + i_grid];
     sum_dPB_dG += P_G * dPG_dG;
 
-    const double3 atom_A = { atm_coords[i_associated_atom * 3 + 0], atm_coords[i_associated_atom * 3 + 1], atm_coords[i_associated_atom * 3 + 2] };
+    const double3 atom_A = { atm_coords[i_associated_atom + 0 * natm], atm_coords[i_associated_atom + 1 * natm], atm_coords[i_associated_atom + 2 * natm] };
     const double3 Ar = atom_A - grid_r;
     const double norm_Ar = norm(Ar);
     const double P_A = PB[i_associated_atom * ngrids + i_grid];
@@ -346,9 +346,9 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
     if (i_atom_G == i_atom_H) // Dealt with later in diagonal kernel.
         return;
 
-    const double3 grid_r = { grid_coords[i_grid * 3 + 0], grid_coords[i_grid * 3 + 1], grid_coords[i_grid * 3 + 2] };
+    const double3 grid_r = { grid_coords[i_grid + 0 * ngrids], grid_coords[i_grid + 1 * ngrids], grid_coords[i_grid + 2 * ngrids] };
 
-    const double3 atom_G = { atm_coords[i_atom_G * 3 + 0], atm_coords[i_atom_G * 3 + 1], atm_coords[i_atom_G * 3 + 2] };
+    const double3 atom_G = { atm_coords[i_atom_G + 0 * natm], atm_coords[i_atom_G + 1 * natm], atm_coords[i_atom_G + 2 * natm] };
     const double3 Gr = atom_G - grid_r;
     const double norm_Gr = norm(Gr);
     const double norm_Gr_1 = inv(norm_Gr);
@@ -356,7 +356,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
     const double P_G = PB[i_atom_G * ngrids + i_grid];
     double3 dPG_dG = { 0.0, 0.0, 0.0 };
 
-    const double3 atom_H = { atm_coords[i_atom_H * 3 + 0], atm_coords[i_atom_H * 3 + 1], atm_coords[i_atom_H * 3 + 2] };
+    const double3 atom_H = { atm_coords[i_atom_H + 0 * natm], atm_coords[i_atom_H + 1 * natm], atm_coords[i_atom_H + 2 * natm] };
     const double3 Hr = atom_H - grid_r;
     const double norm_Hr = norm(Hr);
     const double norm_Hr_1 = inv(norm_Hr);
@@ -367,7 +367,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
     double9 sum_d2PB_dGdH = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     for (int i_atom_B = 0; i_atom_B < natm; i_atom_B++) {
-        const double3 atom_B = { atm_coords[i_atom_B * 3 + 0], atm_coords[i_atom_B * 3 + 1], atm_coords[i_atom_B * 3 + 2] };
+        const double3 atom_B = { atm_coords[i_atom_B + 0 * natm], atm_coords[i_atom_B + 1 * natm], atm_coords[i_atom_B + 2 * natm] };
         const double3 Br = atom_B - grid_r;
         const double norm_Br = norm(Br);
         const double P_B = PB[i_atom_B * ngrids + i_grid];
@@ -453,7 +453,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
     const double9 d2PH_dGdH = P_H * (outer(dsHG_dG, dPH_dH - dsHG_dH) + d2sHG_dGdH);
     sum_d2PB_dGdH += d2PH_dGdH;
 
-    const double3 atom_A = { atm_coords[i_atom_A * 3 + 0], atm_coords[i_atom_A * 3 + 1], atm_coords[i_atom_A * 3 + 2] };
+    const double3 atom_A = { atm_coords[i_atom_A + 0 * natm], atm_coords[i_atom_A + 1 * natm], atm_coords[i_atom_A + 2 * natm] };
     const double3 Ar = atom_A - grid_r;
     const double norm_Ar = norm(Ar);
     const double P_A = PB[i_atom_A * ngrids + i_grid];
@@ -515,9 +515,9 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
     if (i_atom_A == i_atom_G) // Dealt with later by translation invariance.
         return;
 
-    const double3 grid_r = { grid_coords[i_grid * 3 + 0], grid_coords[i_grid * 3 + 1], grid_coords[i_grid * 3 + 2] };
+    const double3 grid_r = { grid_coords[i_grid + 0 * ngrids], grid_coords[i_grid + 1 * ngrids], grid_coords[i_grid + 2 * ngrids] };
 
-    const double3 atom_G = { atm_coords[i_atom_G * 3 + 0], atm_coords[i_atom_G * 3 + 1], atm_coords[i_atom_G * 3 + 2] };
+    const double3 atom_G = { atm_coords[i_atom_G + 0 * natm], atm_coords[i_atom_G + 1 * natm], atm_coords[i_atom_G + 2 * natm] };
     const double3 Gr = atom_G - grid_r;
     const double norm_Gr = norm(Gr);
     const double norm_Gr_1 = inv(norm_Gr);
@@ -529,7 +529,7 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
     double9 d2PG_dG2 = { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 };
 
     for (int i_atom_B = 0; i_atom_B < natm; i_atom_B++) {
-        const double3 atom_B = { atm_coords[i_atom_B * 3 + 0], atm_coords[i_atom_B * 3 + 1], atm_coords[i_atom_B * 3 + 2] };
+        const double3 atom_B = { atm_coords[i_atom_B + 0 * natm], atm_coords[i_atom_B + 1 * natm], atm_coords[i_atom_B + 2 * natm] };
         const double3 Br = atom_B - grid_r;
         const double norm_Br = norm(Br);
         const double P_B = PB[i_atom_B * ngrids + i_grid];
@@ -571,7 +571,7 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
     d2PG_dG2 += outer(dPG_dG, dPG_dG);
     sum_d2PB_dG2 += P_G * d2PG_dG2;
 
-    const double3 atom_A = { atm_coords[i_atom_A * 3 + 0], atm_coords[i_atom_A * 3 + 1], atm_coords[i_atom_A * 3 + 2] };
+    const double3 atom_A = { atm_coords[i_atom_A + 0 * natm], atm_coords[i_atom_A + 1 * natm], atm_coords[i_atom_A + 2 * natm] };
     const double3 Ar = atom_A - grid_r;
     const double norm_Ar = norm(Ar);
     const double P_A = PB[i_atom_A * ngrids + i_grid];
@@ -625,15 +625,15 @@ void GDFTgrid_becke_eval_PB_kernel(double* __restrict__ PB, const double* __rest
     if (i_grid >= ngrids || i_atom_B >= natm)
         return;
 
-    const double3 grid_r = { grid_coords[i_grid * 3 + 0], grid_coords[i_grid * 3 + 1], grid_coords[i_grid * 3 + 2] };
-    const double3 atom_B = { atm_coords[i_atom_B * 3 + 0], atm_coords[i_atom_B * 3 + 1], atm_coords[i_atom_B * 3 + 2] };
+    const double3 grid_r = { grid_coords[i_grid + 0 * ngrids], grid_coords[i_grid + 1 * ngrids], grid_coords[i_grid + 2 * ngrids] };
+    const double3 atom_B = { atm_coords[i_atom_B + 0 * natm], atm_coords[i_atom_B + 1 * natm], atm_coords[i_atom_B + 2 * natm] };
     const double3 Br = atom_B - grid_r;
     const double norm_Br = norm(Br);
 
     // P_B part
     double P_B = 1.0;
     for (int i_atom_C = 0; i_atom_C < natm; i_atom_C++) {
-        const double3 atom_C = { atm_coords[i_atom_C * 3 + 0], atm_coords[i_atom_C * 3 + 1], atm_coords[i_atom_C * 3 + 2] };
+        const double3 atom_C = { atm_coords[i_atom_C + 0 * natm], atm_coords[i_atom_C + 1 * natm], atm_coords[i_atom_C + 2 * natm] };
         const double3 Cr = atom_C - grid_r;
         const double3 BC = atom_B - atom_C;
         const double norm_Cr = norm(Cr);

--- a/gpu4pyscf/pbc/dft/gen_grid.py
+++ b/gpu4pyscf/pbc/dft/gen_grid.py
@@ -153,10 +153,10 @@ def get_becke_weight_derivative(grids, natm):
     a_factor = cp.zeros((sup_natm, sup_natm), dtype = cp.float64)
     # a_factor_ptr = lib.c_null_ptr()
 
-    grids_coords = cp.asarray(grids.coords, order = "C")
+    grids_coords = cp.asarray(grids.coords, order = "F")
     grids_quadrature_weights = cp.asarray(grids.quadrature_weights)
     grids_supatm_idx = cp.asarray(grids.supatm_idx)
-    grids_supatm_coords = cp.asarray(grids.supatm_coords, order = "C")
+    grids_supatm_coords = cp.asarray(grids.supatm_coords, order = "F")
     grids_supatm_to_atm_idx = cp.asarray(grids.supatm_to_atm_idx)
 
     P_B = cp.zeros([sup_natm, ngrids], order = "C")

--- a/gpu4pyscf/pbc/dft/gen_grid.py
+++ b/gpu4pyscf/pbc/dft/gen_grid.py
@@ -150,8 +150,8 @@ def get_becke_weight_derivative(grids, natm):
     sup_natm = grids.supatm_coords.shape[0]
     assert grids.supatm_to_atm_idx.shape[0] == sup_natm
 
-    a_factor = cp.zeros((sup_natm, sup_natm), dtype = cp.float64)
-    # a_factor_ptr = lib.c_null_ptr()
+    # a_factor = cp.zeros((sup_natm, sup_natm), dtype = cp.float64)
+    a_factor_ptr = lib.c_null_ptr()
 
     grids_coords = cp.asarray(grids.coords, order = "F")
     grids_quadrature_weights = cp.asarray(grids.quadrature_weights)
@@ -164,7 +164,7 @@ def get_becke_weight_derivative(grids, natm):
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_coords.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_supatm_coords.data.ptr, ctypes.c_void_p),
-        ctypes.cast(a_factor.data.ptr, ctypes.c_void_p),
+        a_factor_ptr,
         ctypes.c_int(ngrids),
         ctypes.c_int(sup_natm),
     )
@@ -181,7 +181,7 @@ def get_becke_weight_derivative(grids, natm):
         ctypes.cast(grids_coords.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_quadrature_weights.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_supatm_coords.data.ptr, ctypes.c_void_p),
-        ctypes.cast(a_factor.data.ptr, ctypes.c_void_p),
+        a_factor_ptr,
         ctypes.cast(grids_supatm_idx.data.ptr, ctypes.c_void_p),
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
         ctypes.cast(inv_sum_P_B.data.ptr, ctypes.c_void_p),

--- a/gpu4pyscf/pbc/dft/rks.py
+++ b/gpu4pyscf/pbc/dft/rks.py
@@ -186,7 +186,7 @@ def prune_small_rho_grids_(mf, cell, dm, grids, kpts):
         idx = abs(rho) > mf.small_rho_cutoff / size0
         grids.coords  = grids.coords [idx]
         grids.weights = grids.weights[idx]
-        grids.grids_quadrature_weights = grids.grids_quadrature_weights[idx]
+        grids.quadrature_weights = grids.quadrature_weights[idx]
         grids.supatm_idx = grids.supatm_idx[idx]
         logger.debug(mf, 'Drop grids %d', size0 - grids.weights.size)
     return grids

--- a/gpu4pyscf/pbc/dft/rks.py
+++ b/gpu4pyscf/pbc/dft/rks.py
@@ -186,6 +186,8 @@ def prune_small_rho_grids_(mf, cell, dm, grids, kpts):
         idx = abs(rho) > mf.small_rho_cutoff / size0
         grids.coords  = grids.coords [idx]
         grids.weights = grids.weights[idx]
+        grids.grids_quadrature_weights = grids.grids_quadrature_weights[idx]
+        grids.supatm_idx = grids.supatm_idx[idx]
         logger.debug(mf, 'Drop grids %d', size0 - grids.weights.size)
     return grids
 


### PR DESCRIPTION
- GPU-accelerate PBC Becke weight
- Fix reset() function for `pbc.dft.gen_grid.BeckeGrids` class
- Support PBC Becke weight first derivative (memory usage not optimized, full grid response not supported yet)
- Change coordinates inputs (grid and atom) for Becke weight derivative kernels from C order to Fortran order, so it is consistent with the Becke weight kernel.