### PR TITLE
Fix grid dimension overflow bug in ft_ao in fftdf pseudopotential evaluation

### DIFF
--- a/gpu4pyscf/lib/pbc/ft_ao_bdiv.cu
+++ b/gpu4pyscf/lib/pbc/ft_ao_bdiv.cu
@@ -33,8 +33,8 @@
 __global__ static
 void ft_ao_bdiv_kernel(double *out, PBCIntEnvVars envs, int nGv, double *grids)
 {
-    int sh_block_id = gridDim.x - blockIdx.x - 1;
-    int Gv_block_id = blockIdx.y;
+    int sh_block_id = gridDim.y - blockIdx.y - 1;
+    int Gv_block_id = blockIdx.x;
     int nsh_per_block = FT_AO_THREADS / NG_PER_BLOCK;
     int sh_id_in_block = threadIdx.y;
     int Gv_id_in_block = threadIdx.x;
@@ -195,11 +195,26 @@ int build_ft_ao(double *out, PBCIntEnvVars *envs, int ngrids, double *grids,
     dim3 threads(NG_PER_BLOCK, nsh_per_block);
     int nbatches_grids = (ngrids + NG_PER_BLOCK - 1) / NG_PER_BLOCK;
     int nbatches_shls = (nbas + nsh_per_block - 1) / nsh_per_block;
-    dim3 blocks(nbatches_shls, nbatches_grids);
+    dim3 blocks(nbatches_grids, nbatches_shls);
+    {
+        int device;
+        cudaGetDevice(&device);
+        cudaDeviceProp prop;
+        cudaGetDeviceProperties(&prop, device);
+        const int max_block_per_grid_x = prop.maxGridSize[0];
+        const int max_block_per_grid_y = prop.maxGridSize[1];
+        if (blocks.x > max_block_per_grid_x || blocks.y > max_block_per_grid_y) {
+            fprintf(stderr, "Grid dimension overflow in ft_ao_bdiv_kernel, expected grid dimension = (%d, %d), max allowed grid dimension = (%d, %d)\n"
+                            "If you see this message, please report to the developers to divide the inputs of build_ft_ao() function into small chunks.\n",
+                            blocks.x, blocks.y, max_block_per_grid_x, max_block_per_grid_y);
+            return 1;
+        }
+    }
+
     ft_ao_bdiv_kernel<<<blocks, threads>>>(out, *envs, ngrids, grids);
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
-        fprintf(stderr, "CUDA Error in ft_aopair_bdiv_kernel: %s\n", cudaGetErrorString(err));
+        fprintf(stderr, "CUDA Error in ft_ao_bdiv_kernel: %s\n", cudaGetErrorString(err));
         return 1;
     }
     return 0;

--- a/gpu4pyscf/pbc/df/ft_ao.py
+++ b/gpu4pyscf/pbc/df/ft_ao.py
@@ -96,6 +96,7 @@ def ft_ao(cell, Gv, shls_slice=None, b=None,
         _bas.data.ptr, _env.data.ptr, ao_loc_gpu.data.ptr, 1, 1, 0,
     )
     ngrids = len(Gv)
+    assert ngrids < np.iinfo(np.int32).max, "possible int32 overflow"
     GvT = (asarray(Gv).T + asarray(kpt[:,None])).ravel()
     GvT = cp.append(GvT, cp.zeros(THREADS))
     nao_cart = ao_loc_cpu[-1]

--- a/gpu4pyscf/pbc/df/ft_ao.py
+++ b/gpu4pyscf/pbc/df/ft_ao.py
@@ -75,7 +75,8 @@ def ft_ao(cell, Gv, shls_slice=None, b=None,
           sort_cell=True):
     '''Analytical Fourier transform basis functions on Gv grids.
 
-    If the sorted_cell in the input is specified, the transform
+    If the sort_cell in the input is specified, the ao is evaluated on a sorted Cartesian basis,
+    and then transformed back to original basis.
     '''
     assert shls_slice is None
     if sort_cell:
@@ -99,7 +100,7 @@ def ft_ao(cell, Gv, shls_slice=None, b=None,
     GvT = cp.append(GvT, cp.zeros(THREADS))
     nao_cart = ao_loc_cpu[-1]
     out = cp.empty((nao_cart, ngrids), dtype=np.complex128)
-    libpbc.build_ft_ao(
+    err = libpbc.build_ft_ao(
         ctypes.cast(out.data.ptr, ctypes.c_void_p),
         ctypes.byref(envs), ctypes.c_int(ngrids),
         ctypes.cast(GvT.data.ptr, ctypes.c_void_p),
@@ -107,6 +108,8 @@ def ft_ao(cell, Gv, shls_slice=None, b=None,
         sorted_cell._bas.ctypes, ctypes.c_int(sorted_cell.nbas),
         sorted_cell._env.ctypes
     )
+    if err != 0:
+        raise RuntimeError(f'build_ft_ao failed')
     if sort_cell:
         out = out.T.dot(asarray(coeff))
     else:

--- a/gpu4pyscf/pbc/df/ft_ao.py
+++ b/gpu4pyscf/pbc/df/ft_ao.py
@@ -109,7 +109,7 @@ def ft_ao(cell, Gv, shls_slice=None, b=None,
         sorted_cell._env.ctypes
     )
     if err != 0:
-        raise RuntimeError(f'build_ft_ao failed')
+        raise RuntimeError('build_ft_ao failed')
     if sort_cell:
         out = out.T.dot(asarray(coeff))
     else:

--- a/gpu4pyscf/pbc/df/tests/test_pbc_ft_ao.py
+++ b/gpu4pyscf/pbc/df/tests/test_pbc_ft_ao.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import unittest
 import ctypes
 import numpy as np

--- a/gpu4pyscf/pbc/df/tests/test_pbc_ft_ao.py
+++ b/gpu4pyscf/pbc/df/tests/test_pbc_ft_ao.py
@@ -110,6 +110,19 @@ class KnownValues(unittest.TestCase):
         ref = ft_ao_cpu.ft_ao(pcell, Gv)
         self.assertAlmostEqual(abs(ref-dat).max(), 0, 9)
 
+    @pytest.mark.slow
+    def test_ft_ao_large(self):
+        Gv = cell.get_Gv(mesh=[129,128,128])
+        dat = ft_ao_gpu.ft_ao(cell, Gv).get()
+        ref = ft_ao_cpu.ft_ao(cell, Gv)
+        self.assertAlmostEqual(abs(ref-dat).max(), 0, 9)
+
+        pcell = cell.copy()
+        pcell.cart = True
+        dat = ft_ao_gpu.ft_ao(pcell, Gv).get()
+        ref = ft_ao_cpu.ft_ao(pcell, Gv)
+        self.assertAlmostEqual(abs(ref-dat).max(), 0, 9)
+
     def test_ft_aopair_fill_triu(self):
         bvk_ncells, nao, nGv = 6, 13, 42
         out = cp.random.rand(bvk_ncells,nao,nao,nGv) + cp.random.rand(bvk_ncells,nao,nao,nGv) * 1j


### PR DESCRIPTION
This is a potentially lethal bug, that produces incorrect result silently.

It is encountered when all of the following conditions are met:
- A PBC FFTDF calculation is performed (FFTDF is the default)
- A uniform grid is introduced, and the number of grid points is larger than 128^3 (either from a big cell or from a dense grid)
- A GTH pseudopotential with a non-local contribution is involved

In this case, the AO evaluation kernel fails because the number of block per grid exceeds the maximum value set by CUDA. The following error message will appear: `CUDA Error in ft_aopair_bdiv_kernel: invalid configuration argument`. However this error is not caught on python side, and the calculation continues, with a wrong AO value. Upon a naive search, only FFTDF non-local pseudopotential and GDF (`gpu4pyscf.pbc.df.rsdf_builder`) has called the problematic function.

We encourage everyone using `gpu4pyscf.pbc` module to check if the error message above occurs in previous results.