### PR TITLE
Separate mol.has_ecp() into ecp and pseudo contribution; error out if pseudopotential gradient is not implemented / tested

### DIFF
--- a/gpu4pyscf/grad/tdrhf.py
+++ b/gpu4pyscf/grad/tdrhf.py
@@ -169,11 +169,14 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO,
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_ground = int3c2e.get_dh1e(mol, oo0)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_ground += rhf_grad.get_dh1e_ecp(mol, oo0)  # 1/r like terms
     dh1e_td = int3c2e.get_dh1e(mol, (dmz1doo + dmz1doo.T) * 0.5)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, (dmz1doo + dmz1doo.T) * 0.5)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     # this term contributes the ground state contribution.
     dvhf = td_grad.get_veff(mol, (dmz1doo + dmz1doo.T) * 0.5 + oo0, hermi=1)

--- a/gpu4pyscf/grad/tdrks.py
+++ b/gpu4pyscf/grad/tdrks.py
@@ -200,11 +200,14 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO,
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_ground = int3c2e.get_dh1e(mol, oo0)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_ground += rhf_grad.get_dh1e_ecp(mol, oo0)  # 1/r like terms
     dh1e_td = int3c2e.get_dh1e(mol, (dmz1doo + dmz1doo.T) * 0.5)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, (dmz1doo + dmz1doo.T) * 0.5)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     j_factor = 1.0
     k_factor = 0.0

--- a/gpu4pyscf/grad/tdrks_ris.py
+++ b/gpu4pyscf/grad/tdrks_ris.py
@@ -256,11 +256,14 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO):
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_ground = int3c2e.get_dh1e(mol, oo0)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_ground += rhf_grad.get_dh1e_ecp(mol, oo0)  # 1/r like terms
     dh1e_td = int3c2e.get_dh1e(mol, (dmz1doo + dmz1doo.T) * 0.5)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, (dmz1doo + dmz1doo.T) * 0.5)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     j_factor = 1.0
     k_factor = 0.0

--- a/gpu4pyscf/grad/tduhf.py
+++ b/gpu4pyscf/grad/tduhf.py
@@ -214,13 +214,16 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO,
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_ground = int3c2e.get_dh1e(mol, oo0a + oo0b)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_ground += rhf_grad.get_dh1e_ecp(mol, oo0a + oo0b)  # 1/r like terms
     dh1e_td = int3c2e.get_dh1e(mol, (dmz1dooa + dmz1doob) * 0.25 + (dmz1dooa + dmz1doob).T * 0.25)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(
             mol, (dmz1dooa + dmz1doob) * 0.25 + (dmz1dooa + dmz1doob).T * 0.25
         )  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     # this term contributes the ground state contribution.
     dvhf = td_grad.get_veff(

--- a/gpu4pyscf/grad/tduks.py
+++ b/gpu4pyscf/grad/tduks.py
@@ -260,12 +260,15 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None, verbose=logger.INFO,
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_ground = int3c2e.get_dh1e(mol, oo0a + oo0b)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_ground += rhf_grad.get_dh1e_ecp(mol, oo0a + oo0b)  # 1/r like terms
     dh1e_td = int3c2e.get_dh1e(mol, (dmz1dooa + dmz1doob) * 0.25 + (dmz1dooa + dmz1doob).T * 0.25)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(
             mol, (dmz1dooa + dmz1doob) * 0.25 + (dmz1dooa + dmz1doob).T * 0.25)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     j_factor = 1.0
     k_factor = 0.0

--- a/gpu4pyscf/grad/tduks_sf.py
+++ b/gpu4pyscf/grad/tduks_sf.py
@@ -280,12 +280,16 @@ def grad_elec(td_grad, x_y, atmlst=None, verbose=logger.INFO):
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_ground = int3c2e.get_dh1e(mol, oo0a + oo0b)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_ground += rhf_grad.get_dh1e_ecp(mol, oo0a + oo0b)  # 1/r like terms
     dh1e_td = int3c2e.get_dh1e(mol, (dmz1dooa + dmz1doob) * 0.25 + (dmz1dooa + dmz1doob).T * 0.25)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(
             mol, (dmz1dooa + dmz1doob) * 0.25 + (dmz1dooa + dmz1doob).T * 0.25)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
+
     j_factor = 1.0
     k_factor = 0.0
     with_k = ni.libxc.is_hybrid_xc(mf.xc)

--- a/gpu4pyscf/grad/uhf.py
+++ b/gpu4pyscf/grad/uhf.py
@@ -68,12 +68,16 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
 
     # Calculate ECP contributions in (i | \nabla hcore | j) and 
     # (\nabla i | hcore | j) simultaneously
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         ecp_atoms = sorted(set(mol._ecpbas[:,gto.ATOM_OF]))
         h1_ecp = get_ecp_ip(mol, ecp_atoms=ecp_atoms)
         h1 -= h1_ecp.sum(axis=0)
 
         dh1e[ecp_atoms] += 2.0 * contract('nxij,ij->nx', h1_ecp, dm0_sf)
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
+
     t1 = log.timer_debug1('gradients of h1e', *t1)
     log.debug('Computing Gradients of NR-HF Coulomb repulsion')
     dvhf = mf_grad.get_veff(mol, dm0)

--- a/gpu4pyscf/gto/ecp.py
+++ b/gpu4pyscf/gto/ecp.py
@@ -138,6 +138,8 @@ def get_ecp(mol):
         CuPy array: [nao, nao]
             sum of ECP integrals over all ecp atoms
     """
+    assert len(mol._ecpbas) > 0
+
     _sorted_mol, coeff, uniq_l_ctr, l_ctr_counts = group_basis(mol)
 
     _ecpbas = _sorted_mol._ecpbas
@@ -189,6 +191,8 @@ def get_ecp_ip(mol, ip_type='ip', ecp_atoms=None):
         CuPy array: [n_ecp_atoms, 3, nao, nao],
             reindex the first dimension acoording to ecp_atoms
     """
+    assert len(mol._ecpbas) > 0
+
     if ecp_atoms is None:
         ecp_atoms = sorted(set(mol._ecpbas[:,gto.ATOM_OF]))
 
@@ -257,6 +261,8 @@ def get_ecp_ipip(mol, ip_type='ipipv', ecp_atoms=None):
         CuPy array: [n_ecp_atoms, 9, nao, nao],
             reindex the first dimension acoording to ecp_atoms
     """
+    assert len(mol._ecpbas) > 0
+
     if ecp_atoms is None:
         ecp_atoms = set(mol._ecpbas[:,gto.ATOM_OF])
 

--- a/gpu4pyscf/hessian/rhf.py
+++ b/gpu4pyscf/hessian/rhf.py
@@ -588,7 +588,7 @@ def get_hcore(mol):
         h1ab+= mol.intor('int1e_ipnucip', comp=9)
     h1aa = cupy.asarray(h1aa)
     h1ab = cupy.asarray(h1ab)
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         #h1aa += mol.intor('ECPscalar_ipipnuc', comp=9)
         #h1ab += mol.intor('ECPscalar_ipnucip', comp=9)
         h1aa += get_ecp_ipip(mol, 'ipipv').sum(axis=0)
@@ -838,10 +838,13 @@ def _e_hcore_generator(hessobj, dm):
     de_nuc_elec = hess_nuc_elec(mol, dm)
     t1 = log.timer_debug1('hess_nuc_elec', *t1)
     dm = dm.get()
-    with_ecp = mol.has_ecp()
+    with_ecp = len(mol._ecpbas) > 0
     aoslices = mol.aoslice_by_atom()
     if with_ecp:
         de_ecp = hess_nuc_elec_ecp(mol, dm)
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential hessian not supported for molecular system yet")
 
     # Move data to GPU, get_hcore is slow on CPU
     h1aa, h1ab = hessobj.get_hcore(mol)

--- a/gpu4pyscf/hessian/uhf.py
+++ b/gpu4pyscf/hessian/uhf.py
@@ -221,7 +221,7 @@ def get_hcore(mol):
     else:
         h1aa+= mol.intor('int1e_ipipnuc', comp=9)
         h1ab+= mol.intor('int1e_ipnucip', comp=9)
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         h1aa += get_ecp_ip(mol, 'ipipv')
         h1ab += get_ecp_ip(mol, 'ipvip')
         #h1aa += mol.intor('ECPscalar_ipipnuc', comp=9)

--- a/gpu4pyscf/nac/tdrhf.py
+++ b/gpu4pyscf/nac/tdrhf.py
@@ -159,8 +159,11 @@ def get_nacv_ge(td_nac, x_yI, EI, singlet=True, atmlst=None, verbose=logger.INFO
     ds = rhf_grad.contract_h1e_dm(mol, s1, W, hermi=0)
 
     dh1e_td = int3c2e.get_dh1e(mol, dmz1doo)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, dmz1doo)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     dvhf  = td_nac.get_veff(mol, dmz1doo + oo0)
     dvhf -= td_nac.get_veff(mol, dmz1doo)
@@ -383,8 +386,11 @@ def get_nacv_ee(td_nac, x_yI, x_yJ, EI, EJ, singlet=True, atmlst=None, verbose=l
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_td = int3c2e.get_dh1e(mol, dmz1doo)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, dmz1doo)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     dvhf = td_nac.get_veff(mol, dmz1doo + oo0, hermi=1)
     # minus in the next TWO terms is due to only <g^{(\xi)};{D,P_{IJ}}> is needed,

--- a/gpu4pyscf/nac/tdrks.py
+++ b/gpu4pyscf/nac/tdrks.py
@@ -151,8 +151,11 @@ def get_nacv_ge(td_nac, x_yI, EI, singlet=True, atmlst=None, verbose=logger.INFO
     ds = rhf_grad.contract_h1e_dm(mol, s1, W, hermi=0)
 
     dh1e_td = int3c2e.get_dh1e(mol, dmz1doo)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, dmz1doo)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     j_factor = 1.0
     k_factor = 0.0
@@ -434,8 +437,11 @@ def get_nacv_ee(td_nac, x_yI, x_yJ, EI, EJ, singlet=True, atmlst=None, verbose=l
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_td = int3c2e.get_dh1e(mol, dmz1doo)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, dmz1doo)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     j_factor = 1.0
     k_factor = 0.0

--- a/gpu4pyscf/nac/tdrks_ris.py
+++ b/gpu4pyscf/nac/tdrks_ris.py
@@ -295,8 +295,11 @@ def get_nacv_ee(td_nac, x_yI, x_yJ, EI, EJ, singlet=True, atmlst=None, verbose=l
     ds = rhf_grad.contract_h1e_dm(mol, s1, im0, hermi=0)
 
     dh1e_td = int3c2e.get_dh1e(mol, dmz1doo)  # 1/r like terms
-    if mol.has_ecp():
+    if len(mol._ecpbas) > 0:
         dh1e_td += rhf_grad.get_dh1e_ecp(mol, dmz1doo)  # 1/r like terms
+
+    if mol._pseudo:
+        raise NotImplementedError("Pseudopotential gradient not supported for molecular system yet")
 
     j_factor = 1.0
     k_factor = 0.0


### PR DESCRIPTION
Maybe the behavior of `mol.has_ecp()` returning True when it has GTH pseudopotential is scientifically reasonable; however I think it's quite misleading for developers.