### PR TITLE
Change cupy.array(copy=False/None) to cupy.asarray()

### DIFF
--- a/gpu4pyscf/df/df.py
+++ b/gpu4pyscf/df/df.py
@@ -268,7 +268,7 @@ def cholesky_eri_gpu(intopt, mol, auxmol, cd_low,
     for device_id in range(num_devices):
         task_list_per_device.append(total_task_list[device_id::num_devices])
 
-    cd_low_f = cupy.array(cd_low, order='F', copy=False)
+    cd_low_f = cupy.asarray(cd_low, order='F')
     cd_low_f = tag_array(cd_low_f, tag=cd_low.tag)
 
     cupy.cuda.get_current_stream().synchronize()

--- a/gpu4pyscf/mp/dfmp2_old.py
+++ b/gpu4pyscf/mp/dfmp2_old.py
@@ -93,7 +93,7 @@ def kernel(mp, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2,
     emp2_ss = emp2_os = 0
     for i in range(nocc):
         buf = get_occ_blk(Lov_dist, i, nocc, nvir)
-        gi = cupy.array(buf, copy=False)
+        gi = cupy.asarray(buf)
         gi = gi.reshape(nvir,nocc,nvir).transpose(1,0,2)
         #lib.direct_sum('jb+a->jba', eia, eia[i])
         t2i = gi/(eia[:,:,None] + eia[i])


### PR DESCRIPTION
`cupy.array()` API has changed from cupy 13.6.0 (https://docs.cupy.dev/en/v13.6.0/reference/generated/cupy.array.html) to 14.0.1 (https://docs.cupy.dev/en/v14.0.1/reference/generated/cupy.array.html). Specifically, the `copy=False` behavior has changed: If copy is necessary, in 13.6.0 it silently returns a copied array, and in 14.0.1 it raises an error (and `copy=None` now silently returns a copied array). To avoid this confusion, we remove all `cupy.array(copy=False/None)` calls, and changed them to `cupy.asarray()`. `cupy.asarray()` is equivalent to `cupy.array(copy=False/None)`.