### PR TITLE
Refactor: standardize get_precond() inheritance in TDSCF/TDDFT

### DIFF
--- a/gpu4pyscf/tdscf/rhf.py
+++ b/gpu4pyscf/tdscf/rhf.py
@@ -409,17 +409,7 @@ class TDBase(lib.StreamObject):
         return get_ab(self, mf, singlet=self.singlet)
 
     def get_precond(self, hdiag):
-        threshold_t=1.0e-4
-        def precond(x, e, *args):
-            n_states = x.shape[0]
-            diagd = cp.repeat(hdiag.reshape(1,-1), n_states, axis=0)
-            e = e.reshape(-1,1)
-            diagd = hdiag - (e-self.level_shift)
-            diagd = cp.where(abs(diagd) < threshold_t, cp.sign(diagd)*threshold_t, diagd)
-            a_size = x.shape[1]//2
-            diagd[:,a_size:] = diagd[:,a_size:]*(-1)
-            return x/diagd
-        return precond
+        raise NotImplementedError
 
     def Gradients(self):
         raise NotImplementedError
@@ -729,6 +719,19 @@ def gen_tdhf_operation(td, mf, fock_ao=None, singlet=True, wfnsym=None):
 
 class TDHF(TDBase):
     __doc__ = tdhf_cpu.TDHF.__doc__
+
+    def get_precond(self, hdiag):
+        threshold_t=1.0e-4
+        def precond(x, e, *args):
+            n_states = x.shape[0]
+            diagd = cp.repeat(hdiag.reshape(1,-1), n_states, axis=0)
+            e = e.reshape(-1,1)
+            diagd = hdiag - (e-self.level_shift)
+            diagd = cp.where(abs(diagd) < threshold_t, cp.sign(diagd)*threshold_t, diagd)
+            a_size = x.shape[1]//2
+            diagd[:,a_size:] = diagd[:,a_size:]*(-1)
+            return x/diagd
+        return precond
 
     @lib.with_doc(gen_tdhf_operation.__doc__)
     def gen_vind(self, mf=None):

--- a/gpu4pyscf/tdscf/uhf.py
+++ b/gpu4pyscf/tdscf/uhf.py
@@ -728,6 +728,7 @@ class TDA(TDBase):
     __doc__ = tdhf_gpu.TDA.__doc__
 
     singlet = None
+    get_precond = tdhf_gpu.TDA.get_precond
 
     def gen_vind(self, mf=None):
         '''Generate function to compute Ax'''
@@ -858,6 +859,8 @@ class SpinFlipTDA(TDBase):
     collinear_samples = getattr(__config__, 'tdscf_uhf_SFTDA_collinear_samples', 200)
 
     _keys = {'extype', 'collinear', 'collinear_samples'}
+
+    get_precond = tdhf_gpu.TDA.get_precond
 
     def gen_vind(self):
         '''Generate function to compute A*x for spin-flip TDDFT case.


### PR DESCRIPTION
  This PR refactors the inheritance structure of get_precond() in TDSCF/TDDFT modules.

  - `TDBase.get_precond()` is changed to `NotImplementedError`.
  - The concrete implementation of get_precond() is moved/kept in the proper derived class (`TDHF/TDA` in `tdscf/rhf.py`).
  - Related classes are updated to explicitly inherit/reuse the corresponding get_precond() implementation.