### PR TITLE
fix: grid pruning by density for density-fitting UKS/ROKS

### DIFF
--- a/gpu4pyscf/df/df_jk.py
+++ b/gpu4pyscf/df/df_jk.py
@@ -213,9 +213,9 @@ class _DFHF:
         # for DFT
         if isinstance(self, rks.KohnShamDFT):
             t0 = logger.init_timer(self)
-            rks.initialize_grids(self, mol, dm)
             ni = self._numint
             if isinstance(self, (uhf.UHF, rohf.ROHF)): # UKS
+                rks.initialize_grids(self, mol, dm[0]+dm[1])
                 n, exc, vxc = ni.nr_uks(mol, self.grids, self.xc, dm)
                 logger.debug(self, 'nelec by numeric integration = %s', n)
                 if self.do_nlc():
@@ -248,6 +248,7 @@ class _DFHF:
                 ecoul = cupy.einsum('sij,ji->', dm, vj).real * .5
 
             elif isinstance(self, hf.RHF):
+                rks.initialize_grids(self, mol, dm)
                 n, exc, vxc = ni.nr_rks(mol, self.grids, self.xc, dm)
                 logger.debug(self, 'nelec by numeric integration = %s', n)
                 if self.do_nlc():


### PR DESCRIPTION
### Problem
In `dft.rks.initialize_grids`, the pruning logic `prune_small_rho_grids_` is only triggered if `dm.ndim == 2`, which is not triggered for DF-UKS/ROKS.

### Solution
Updated the DF initialization logic to pass the total density matrix `dm[0] + dm[1]` to `initialize_grids` for UKS/ROKS cases in `df/df_jk.py`. 
This ensures the grid is correctly pruned based on the total electron density, consistent with the behavior in `dft/uks.py`.

### Results (Example)
- **Before**: RKS (~515.8k) vs UKS (~630.8k) -> Pruning skipped for UKS.
- **After**: RKS (~515.8k) vs UKS (~516.1k) -> Pruning correctly triggered.