### PR TITLE
Fix int32 overflow in PBC  
  CUDA kernel pointer arithmetic

### DIFF
--- a/gpu4pyscf/lib/gvhf-rys/mole_helper.cu
+++ b/gpu4pyscf/lib/gvhf-rys/mole_helper.cu
@@ -67,13 +67,13 @@ void bra_sorted2cart_kernel(double *out, double *input, double *recontract_coef,
                     cval[n*THREADS+thread_id] = 0;
                 }
                 for (int ip = 0; ip < nprim; ++ip) {
-                    double s = pgto[(p_ao_offsets[ip]+i)*ncol+col_id];
+                    double s = pgto[(size_t)(p_ao_offsets[ip]+i)*ncol+col_id];
                     double *c = coef + ctr0*nprim + ip;
                     for (int n = 0; n < sub_nctr; ++n) {
                         cval[n*THREADS+thread_id] += s * c[n*nprim];
                     }
                 }
-                double *cgto = out + c_off + i * ncol + col_id;
+                double *cgto = out + c_off + (size_t)i * ncol + col_id;
                 for (int n = 0; n < sub_nctr; ++n) {
                     cgto[n*stride] = cval[n*THREADS+thread_id];
                 }
@@ -115,7 +115,7 @@ void bra_cart2sorted_kernel(double *out, double *input, double *recontract_coef,
         size_t c_off = (count * c_nao + c_ao_loc[c_bas_id] + ctr0*nfi) * ncol;
         for (int i = 0; i < nfi; ++i) {
             for (int col_id = col0+thread_id; col_id < col1; col_id += THREADS) {
-                double *cgto = input + c_off + i * ncol + col_id;
+                double *cgto = input + c_off + (size_t)i * ncol + col_id;
                 for (int n = 0; n < sub_nctr; ++n) {
                     cval[n*THREADS+thread_id] = cgto[n*stride];
                 }
@@ -125,7 +125,7 @@ void bra_cart2sorted_kernel(double *out, double *input, double *recontract_coef,
                     for (int n = 1; n < sub_nctr; ++n) {
                         s += cval[n*THREADS+thread_id] * c[n*nprim];
                     }
-                    pgto[(p_ao_offsets[ip]+i)*ncol+col_id] += s;
+                    pgto[(size_t)(p_ao_offsets[ip]+i)*ncol+col_id] += s;
                     //atomicAdd(pgto+(p_ao_offsets[ip]+i)*ncol+col_id,  s);
                 }
             }
@@ -171,14 +171,14 @@ void bra_sorted2sph_kernel(double *out, double *input, double *recontract_coef,
                     cval[n*THREADS+thread_id] = 0;
                 }
                 for (int ip = 0; ip < nprim; ++ip) {
-                    double s = pgto[(p_ao_offsets[ip]+i)*ncol+col_id];
+                    double s = pgto[(size_t)(p_ao_offsets[ip]+i)*ncol+col_id];
                     double *c = coef + ctr0*nprim + ip;
                     for (int n = 0; n < sub_nctr; ++n) {
                         cval[n*THREADS+thread_id] += s * c[n*nprim];
                     }
                 }
                 for (int n = 0; n < n_ctr; ++n) {
-                    double *cgto = out + c_off + n * di * ncol;
+                    double *cgto = out + c_off + (size_t)n * di * ncol;
                     switch (i+nfi*li/3) {
                     case 0: { // l=0, i=0
                         cgto[0*ncol] += 1 * cval[n*THREADS+thread_id];
@@ -560,7 +560,7 @@ void bra_sph2sorted_kernel(double *out, double *input, double *recontract_coef,
         size_t c_off = (count * c_nao + c_ao_loc[c_bas_id] + ctr0*di) * ncol;
         for (int i = 0; i < di; ++i) {
             for (int col_id = col0+thread_id; col_id < col1; col_id += THREADS) {
-                double *cgto = input + c_off + i * ncol + col_id;
+                double *cgto = input + c_off + (size_t)i * ncol + col_id;
                 for (int n = 0; n < sub_nctr; ++n) {
                     cval[n*THREADS+thread_id] = cgto[n*stride];
                 }
@@ -570,7 +570,7 @@ void bra_sph2sorted_kernel(double *out, double *input, double *recontract_coef,
                     for (int n = 1; n < sub_nctr; ++n) {
                         s += cval[n*THREADS+thread_id] * c[n*nprim];
                     }
-                    int p_off = p_ao_offsets[ip] * ncol + col_id;
+                    size_t p_off = (size_t)p_ao_offsets[ip] * ncol + col_id;
                     switch (li*li+i) {
                     case 0: { // l=0, m=0
                         pgto[0*ncol+p_off] += 1 * s;

--- a/gpu4pyscf/lib/pbc/ft_ao.cu
+++ b/gpu4pyscf/lib/pbc/ft_ao.cu
@@ -181,8 +181,8 @@ void ft_ao_bdiv_kernel(double *out, RysIntEnvVars envs, int nGv, double *Gv)
     }
 
     if (Gv_id < nGv) {
-        int stride = nGv * OF_COMPLEX;
-        double *aft_tensor = out + (envs.ao_loc[sh_id] * nGv + Gv_id) * OF_COMPLEX;
+        size_t stride = (size_t)nGv * OF_COMPLEX;
+        double *aft_tensor = out + ((size_t)envs.ao_loc[sh_id] * nGv + Gv_id) * OF_COMPLEX;
 #pragma unroll
         for (int n = 0; n < aux_nf; ++n) {
             if (n >= nfi) break;
@@ -468,7 +468,7 @@ void ft_aopair_kernel(double *out, PBCIntEnvVars envs, double *pool, int *shl_pa
                     out_local[addr+1] = goutI[n];
                 }
             } else {
-                double *aft_tensor = out + (pair_offset * nGv + Gv_id) * OF_COMPLEX;
+                double *aft_tensor = out + ((size_t)pair_offset * nGv + Gv_id) * OF_COMPLEX;
 #pragma unroll
                 for (int n = 0; n < GOUT_WIDTH; ++n) {
                     int ij = n*gout_stride + gout_id;
@@ -479,7 +479,7 @@ void ft_aopair_kernel(double *out, PBCIntEnvVars envs, double *pool, int *shl_pa
                         size_t i = ij - nfi * j;
                         addr = i * bvk_Nao + j;
                     }
-                    addr *= nGv * OF_COMPLEX;
+                    addr *= (size_t)nGv * OF_COMPLEX;
                     aft_tensor[addr  ] = goutR[n];
                     aft_tensor[addr+1] = goutI[n];
                 }
@@ -488,7 +488,7 @@ void ft_aopair_kernel(double *out, PBCIntEnvVars envs, double *pool, int *shl_pa
         __syncthreads();
         if (pair_idx < shl_pair1 && to_sph && (li > 1 || lj > 1)) {
             int di = li * 2 + 1;
-            int nGv_c = nGv * OF_COMPLEX;
+            size_t nGv_c = (size_t)nGv * OF_COMPLEX;
             int nGv_in_pool = nGv_per_block * OF_COMPLEX;
             size_t i_stride = nGv_c;
             size_t j_stride = nGv_c * di;
@@ -498,7 +498,7 @@ void ft_aopair_kernel(double *out, PBCIntEnvVars envs, double *pool, int *shl_pa
             }
             int Gv_start = Gv_block_id * nGv_per_block;
             double *inp_local = c2s_pool + sp_id * nfij * nGv_in_pool;
-            double *aft_tensor = out + (pair_offset * nGv + Gv_start) * OF_COMPLEX;
+            double *aft_tensor = out + ((size_t)pair_offset * nGv + Gv_start) * OF_COMPLEX;
             // Note each block within the compressed data in the input is transposed
             // for block with shape [nfi,nfj], i is accessed with smaller strides
             int comb_id = gout_id * nGv_per_block + Gv_id_in_block;

--- a/gpu4pyscf/lib/pbc/ft_ao_ip1.cu
+++ b/gpu4pyscf/lib/pbc/ft_ao_ip1.cu
@@ -144,7 +144,7 @@ void ft_aopair_ejk_ip1_kernel(double *out, double *dm, double *vG, double *Gv,
         // Note the density matrix is assumed to be real in get_ej_ip1 function
         double *dm_ij;
         if (vG == NULL) {
-            dm_ij = dm + (Gv_id + (j0*nao+i0) * nGv) * OF_COMPLEX;
+            dm_ij = dm + (Gv_id + (size_t)(j0*nao+i0) * nGv) * OF_COMPLEX;
         } else {
             dm_ij = dm + (j0*nao+i0);
         }
@@ -257,7 +257,7 @@ void ft_aopair_ejk_ip1_kernel(double *out, double *dm, double *vG, double *Gv,
                 uint32_t i = ij - nfi * j;
                 double dm_vR, dm_vI;
                 if (vG == NULL) {
-                    int addr = (j*nao+i)*nGv * OF_COMPLEX;
+                    size_t addr = (size_t)(j*nao+i)*nGv * OF_COMPLEX;
                     dm_vR = dm_ij[addr];
                     dm_vI = dm_ij[addr+1];
                 } else {
@@ -479,7 +479,7 @@ void ft_aopair_strain_deriv_kernel(double *out, double *sigma,
         // Note the density matrix is assumed to be real in get_ej_ip1 function
         double *dm_ij;
         if (vG == NULL) {
-            dm_ij = dm + (Gv_id + (j0*nao+i0) * nGv) * OF_COMPLEX;
+            dm_ij = dm + (Gv_id + (size_t)(j0*nao+i0) * nGv) * OF_COMPLEX;
         } else {
             dm_ij = dm + (j0*nao+i0);
         }
@@ -592,7 +592,7 @@ void ft_aopair_strain_deriv_kernel(double *out, double *sigma,
                 uint32_t i = ij - nfi * j;
                 double dm_vR, dm_vI;
                 if (vG == NULL) {
-                    int addr = (j*nao+i)*nGv * OF_COMPLEX;
+                    size_t addr = (size_t)(j*nao+i)*nGv * OF_COMPLEX;
                     dm_vR = dm_ij[addr];
                     dm_vI = dm_ij[addr+1];
                 } else {

--- a/gpu4pyscf/lib/pbc/nr_eval_gto.cu
+++ b/gpu4pyscf/lib/pbc/nr_eval_gto.cu
@@ -301,7 +301,7 @@ static void _cart_deriv0_kernel(double *out, PBCIntEnvVars envs, double *grids,
     }
     int *ao_loc = envs.ao_loc;
     int nf = (li + 1) * (li + 2) / 2;
-    out += ao_loc[bas_id] * ngrids;
+    out += (size_t)ao_loc[bas_id] * ngrids;
     for (int n = 0; n < n_cart_max; ++n) {
         if (n >= nf) break;
         out[n*ngrids+grid_id] = gto[n];
@@ -518,10 +518,10 @@ static void _cart_deriv1_kernel(double *out, PBCIntEnvVars envs, double *grids,
     }
     int *ao_loc = envs.ao_loc;
     int nf = (li + 1) * (li + 2) / 2;
-    out += ao_loc[bas_id] * ngrids + grid_id;
-    double *outx = out + 1 * nao * ngrids;
-    double *outy = out + 2 * nao * ngrids;
-    double *outz = out + 3 * nao * ngrids;
+    out += (size_t)ao_loc[bas_id] * ngrids + grid_id;
+    double *outx = out + 1 * (size_t)nao * ngrids;
+    double *outy = out + 2 * (size_t)nao * ngrids;
+    double *outz = out + 3 * (size_t)nao * ngrids;
     for (int n = 0; n < n_cart_max; ++n) {
         if (n >= nf) break;
         out [n*ngrids] = gto [n];
@@ -623,11 +623,11 @@ static void _cart_ip2_kernel(double *out, PBCIntEnvVars envs, double *grids,
 
     int *ao_loc = envs.ao_loc;
     int nf = (li + 1) * (li + 2) / 2;
-    double *out_x = out + ao_loc[bas_id] * ngrids + grid_id;
+    double *out_x = out + (size_t)ao_loc[bas_id] * ngrids + grid_id;
     for (int n = 0; n < n_cart_max; ++n) {
         if (n >= nf) break;
         for (int ix = 0; ix < 6; ++ix) {
-            out_x[(ix*nao+n)*ngrids] = gto[n*6+ix];
+            out_x[((size_t)ix*nao+n)*ngrids] = gto[n*6+ix];
         }
     }
 }
@@ -724,7 +724,7 @@ static void _sph_deriv0_kernel(double *out, PBCIntEnvVars envs, double *grids,
         }
     }
     int *ao_loc = envs.ao_loc;
-    out += ao_loc[bas_id] * ngrids;
+    out += (size_t)ao_loc[bas_id] * ngrids;
     switch (li) {
     case 0:
         out[grid_id] = gto[0];
@@ -967,11 +967,11 @@ static void _sph_deriv1_kernel(double *out, PBCIntEnvVars envs, double *grids,
         } }
     }
     int *ao_loc = envs.ao_loc;
-    out += ao_loc[bas_id] * ngrids + grid_id;
+    out += (size_t)ao_loc[bas_id] * ngrids + grid_id;
     switch (li) {
     case 0:
         for (int n = 0; n < 4; ++n) {
-            out[n * nao * ngrids] = gto[n];
+            out[n * (size_t)nao * ngrids] = gto[n];
         }
         break;
     case 1:
@@ -1108,11 +1108,11 @@ static void _sph_ip2_kernel(double *out, PBCIntEnvVars envs, double *grids,
     }
 
     int *ao_loc = envs.ao_loc;
-    out += ao_loc[bas_id] * ngrids + grid_id;
+    out += (size_t)ao_loc[bas_id] * ngrids + grid_id;
     switch (li) {
     case 0:
         for (int n = 0; n < 6; ++n) {
-            out[n * nao * ngrids] = gto[n];
+            out[n * (size_t)nao * ngrids] = gto[n];
         }
         break;
     case 1:
@@ -1378,7 +1378,7 @@ static void _cart_deriv0_strain_tensor_kernel(
     if (li < 4) {
         int *ao_loc = envs.ao_loc;
         int nf = (li + 1) * (li + 2) / 2;
-        out += ao_loc[bas_id] * ngrids + grid_id;
+        out += (size_t)ao_loc[bas_id] * ngrids + grid_id;
         size_t naog = nao * ngrids;
         for (int n = 0; n < 10; ++n) {
             if (n >= nf) break;
@@ -1389,7 +1389,7 @@ static void _cart_deriv0_strain_tensor_kernel(
     } else {
         int *ao_loc = envs.ao_loc;
         int nf = (li + 1) * (li + 2) / 2;
-        out += ao_loc[bas_id] * ngrids + grid_id;
+        out += (size_t)ao_loc[bas_id] * ngrids + grid_id;
         size_t naog = nao * ngrids;
         for (int n = 0; n < 15; ++n) {
             if (n >= nf) break;
@@ -1468,7 +1468,7 @@ static void _cart_deriv1_strain_tensor_kernel(
     double _rcut = rcut[bas_id % envs.cell0_nbas];
     double rrcutoff = _rcut * _rcut;
     int *ao_loc = envs.ao_loc;
-    out += ao_loc[bas_id] * ngrids + grid_id;
+    out += (size_t)ao_loc[bas_id] * ngrids + grid_id;
     int nimgs = envs.nimgs;
 
     switch (li) {


### PR DESCRIPTION
Fixes #726                                                        
   
  Cast int to size_t before multiplication in pointer offset calculations that can exceed INT32_MAX for     
  periodic cells with >~1000 basis functions.
                                                                                                            
  Files: ft_ao.cu, ft_ao_ip1.cu, nr_eval_gto.cu, mole_helper.cu                                             
   
  Verified with compute-sanitizer on 128-atom Fe (gth-dzvp-molopt-sr, ke_cutoff=75, A100 80GB). All 6974    
  memory errors eliminated.