### PR TITLE
Damping level shift CuPy bug workaround

### DIFF
--- a/gpu4pyscf/dft/ucdft.py
+++ b/gpu4pyscf/dft/ucdft.py
@@ -21,6 +21,7 @@ from pyscf import gto
 from gpu4pyscf.dft.rkspu import reference_mol, _make_minao_lo
 from gpu4pyscf import dft
 from gpu4pyscf.lib import logger
+from gpu4pyscf.lib.cupy_helper import asarray
 from gpu4pyscf.dft import radi
 from pyscf import __config__
 
@@ -474,8 +475,8 @@ class CDFT_UKS(CDFTBaseMixin, dft.UKS):
                 dampa, dampb = damp_factor
             else:
                 dampa = dampb = damp_factor
-            f = cp.asarray((damping(f[0], fock_last[0], dampa),
-                            damping(f[1], fock_last[1], dampb)))
+            f = cp.asarray((asarray(damping(f[0], fock_last[0], dampa)),
+                            asarray(damping(f[1], fock_last[1], dampb))))
         if diis and cycle >= diis_start_cycle:
             f = diis.update(s1e, dm, f)
 

--- a/gpu4pyscf/pbc/dft/kucdft.py
+++ b/gpu4pyscf/pbc/dft/kucdft.py
@@ -18,7 +18,7 @@ from gpu4pyscf.pbc import dft
 from gpu4pyscf.pbc.gto import int1e
 from gpu4pyscf.scf import hf as mol_hf
 from gpu4pyscf.lib import logger
-from gpu4pyscf.lib.cupy_helper import contract
+from gpu4pyscf.lib.cupy_helper import contract, asarray
 from gpu4pyscf.dft.rkspu import reference_mol
 from gpu4pyscf.dft.ucdft import _get_minao_basis_indices, CDFTBaseMixin
 from gpu4pyscf.pbc.dft.krkspu import _make_minao_lo
@@ -146,8 +146,8 @@ class CDFT_KUKS(CDFTBaseMixin, dft.KUKS):
             f_a = []
             f_b = []
             for k in range(len(s_kpts)):
-                f_a.append(mol_hf.damping(f_kpts[0][k], fock_last[0][k], dampa))
-                f_b.append(mol_hf.damping(f_kpts[1][k], fock_last[1][k], dampb))
+                f_a.append(asarray(mol_hf.damping(f_kpts[0][k], fock_last[0][k], dampa)))
+                f_b.append(asarray(mol_hf.damping(f_kpts[1][k], fock_last[1][k], dampb)))
             f_kpts = cp.asarray([f_a, f_b])
         if diis and cycle >= diis_start_cycle:
             f_kpts = diis.update(s_kpts, dm_kpts, f_kpts, self, h1e_kpts, vhf_kpts, f_prev=fock_last)

--- a/gpu4pyscf/pbc/dft/tests/test_pbc_dft_damp_levelshift.py
+++ b/gpu4pyscf/pbc/dft/tests/test_pbc_dft_damp_levelshift.py
@@ -1,0 +1,102 @@
+# Copyright 2021-2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from pyscf import lib
+from pyscf.pbc import gto as pgto
+from gpu4pyscf.pbc.dft.kucdft import CDFT_KUKS
+
+import pytest
+
+@pytest.fixture
+def cell():
+    L = 4.
+    cell = pgto.Cell()
+    cell.a = np.eye(3)*L
+    cell.atom =[['H' , ( L/2+0., L/2+0. ,   L/2+1.)],
+                ['H' , ( L/2+1., L/2+0. ,   L/2+1.)]]
+    cell.basis = [[0, (3.0, 1.0)], [0, (1.0, 1.0)]]
+    cell.verbose = 6
+    cell.output = '/dev/null'
+    cell.build()
+    return cell
+
+def test_rks_damp(cell):
+    mf = cell.RKS(xc='pbe').to_gpu()
+
+    mf.damp = 0.5
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_rks_levelshift(cell):
+    mf = cell.RKS(xc='pbe').to_gpu()
+
+    mf.level_shift = 0.2
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_uks_damp(cell):
+    mf = cell.UKS(xc='pbe').to_gpu()
+
+    mf.damp = 0.5
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_uks_levelshift(cell):
+    mf = cell.UKS(xc='pbe').to_gpu()
+
+    mf.level_shift = 0.2
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_krks_damp(cell):
+    kpts = cell.make_kpts([1,1,1])
+    mf = cell.KRKS(xc='pbe', kpts=kpts).to_gpu()
+
+    mf.damp = 0.5
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_krks_levelshift(cell):
+    kpts = cell.make_kpts([1,1,1])
+    mf = cell.KRKS(xc='pbe', kpts=kpts).to_gpu()
+
+    mf.level_shift = 0.2
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_kuks_damp(cell):
+    kpts = cell.make_kpts([1,1,1])
+    mf = cell.KUKS(xc='pbe', kpts=kpts).to_gpu()
+
+    mf.damp = 0.5
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_kuks_levelshift(cell):
+    kpts = cell.make_kpts([1,1,1])
+    mf = cell.KUKS(xc='pbe', kpts=kpts).to_gpu()
+
+    mf.level_shift = 0.2
+    mf.diis_start_cycle = 3
+    mf.run()
+
+def test_kucdft_damp(cell):
+    kpts = cell.make_kpts([1,1,1])
+    mf = CDFT_KUKS(cell, kpts).to_gpu()
+    mf.xc = 'pbe'
+
+    mf.damp = 0.5
+    mf.diis_start_cycle = 3
+    mf.kernel()

--- a/gpu4pyscf/pbc/scf/khf.py
+++ b/gpu4pyscf/pbc/scf/khf.py
@@ -27,7 +27,7 @@ from pyscf.pbc.scf import khf as khf_cpu
 from pyscf.pbc import tools
 from gpu4pyscf.lib import logger, utils
 from gpu4pyscf.lib.cupy_helper import (
-    return_cupy_array, contract, tag_array, sandwich_dot, eigh)
+    return_cupy_array, contract, tag_array, sandwich_dot, eigh, asarray)
 from gpu4pyscf.scf import hf as mol_hf
 from gpu4pyscf.pbc.scf import hf as pbchf
 from gpu4pyscf.pbc import df
@@ -52,15 +52,17 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
     if damp_factor is None:
         damp_factor = mf.damp
     if damp_factor is not None and 0 <= cycle < diis_start_cycle-1 and fock_last is not None:
-        f_kpts = cp.asarray([pbchf.damping(f, f_prev, damp_factor)
-                             for f,f_prev in zip(f_kpts,fock_last)])
+        # cp.asarray() can't handle lists of tagged arrays.
+        # need to convert CPArrayWithTag to cp.ndarray via cupy_helper.asarray().
+        f_kpts = cp.asarray([asarray(pbchf.damping(f, f_prev, damp_factor))
+                            for f,f_prev in zip(f_kpts,fock_last)])
     if diis and cycle >= diis_start_cycle:
         f_kpts = diis.update(s_kpts, dm_kpts, f_kpts, mf, h1e_kpts, vhf_kpts, f_prev=fock_last)
 
     if level_shift_factor is None:
         level_shift_factor = mf.level_shift
     if level_shift_factor is not None:
-        f_kpts = [pbchf.level_shift(s, dm_kpts[k], f_kpts[k], level_shift_factor)
+        f_kpts = [asarray(pbchf.level_shift(s, dm_kpts[k], f_kpts[k], level_shift_factor))
                   for k, s in enumerate(s_kpts)]
     return cp.asarray(f_kpts)
 

--- a/gpu4pyscf/pbc/scf/kuhf.py
+++ b/gpu4pyscf/pbc/scf/kuhf.py
@@ -29,7 +29,7 @@ from gpu4pyscf.pbc.scf import khf
 from gpu4pyscf.pbc.scf import uhf as pbcuhf
 from gpu4pyscf.lib import logger, utils
 from gpu4pyscf.lib.cupy_helper import (
-    return_cupy_array, contract, tag_array, sandwich_dot)
+    return_cupy_array, contract, tag_array, sandwich_dot, asarray)
 
 
 def make_rdm1(mo_coeff_kpts, mo_occ_kpts, **kwargs):
@@ -70,8 +70,8 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
         f_a = []
         f_b = []
         for k in range(len(s_kpts)):
-            f_a.append(mol_hf.damping(f_kpts[0][k], fock_last[0][k], dampa))
-            f_b.append(mol_hf.damping(f_kpts[1][k], fock_last[1][k], dampb))
+            f_a.append(asarray(mol_hf.damping(f_kpts[0][k], fock_last[0][k], dampa)))
+            f_b.append(asarray(mol_hf.damping(f_kpts[1][k], fock_last[1][k], dampb)))
         f_kpts = cp.asarray([f_a, f_b])
     if diis and cycle >= diis_start_cycle:
         f_kpts = diis.update(s_kpts, dm_kpts, f_kpts, mf, h1e_kpts, vhf_kpts, f_prev=fock_last)
@@ -83,9 +83,9 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
             shifta, shiftb = level_shift_factor
         else:
             shifta = shiftb = level_shift_factor
-        f_kpts =([mol_hf.level_shift(s, dm_kpts[0,k], f_kpts[0,k], shifta)
+        f_kpts =([asarray(mol_hf.level_shift(s, dm_kpts[0,k], f_kpts[0,k], shifta))
                   for k, s in enumerate(s_kpts)],
-                 [mol_hf.level_shift(s, dm_kpts[1,k], f_kpts[1,k], shiftb)
+                 [asarray(mol_hf.level_shift(s, dm_kpts[1,k], f_kpts[1,k], shiftb))
                   for k, s in enumerate(s_kpts)])
     return cp.asarray(f_kpts)
 

--- a/gpu4pyscf/scf/uhf.py
+++ b/gpu4pyscf/scf/uhf.py
@@ -85,8 +85,8 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
             dampa, dampb = damp_factor
         else:
             dampa = dampb = damp_factor
-        f = cupy.asarray((damping(f[0], fock_last[0], dampa),
-                          damping(f[1], fock_last[1], dampb)))
+        f = cupy.asarray((asarray(damping(f[0], fock_last[0], dampa)),
+                          asarray(damping(f[1], fock_last[1], dampb))))
     if diis and cycle >= diis_start_cycle:
         f = diis.update(s1e, dm, f)
 


### PR DESCRIPTION
CuPy crashes if you do
```python
cp.asarray([ list containing a CPArrayWithTag ])
```
I know this is true for 13.6.0, but I think it is still [true on the master branch](https://github.com/cupy/cupy/blob/9263620693c892864c52d2703b862dcf1c264c6a/cupy/_core/core.pyx#L2739-L2766).

This breaks damping and level shifting for many DFT subclasses. (Try any of the tests in [gpu4pyscf/pbc/dft/tests/test_pbc_dft_damp_levelshift.py](https://github.com/pyscf/gpu4pyscf/compare/master...chillenb:damping-level-shift?expand=1#diff-40166acdb04b9b209c954cdde2645da1985f4371c7e4f0b35eca59796e1ad01e))

I have tried to work around this bug using `lib.cupy_helper.asarray`.