### PR TITLE
GPU-accelerate vppnl_nuc_grad for GTH pseudopotentials

### DIFF
--- a/gpu4pyscf/lib/pbc/overlap.cu
+++ b/gpu4pyscf/lib/pbc/overlap.cu
@@ -400,6 +400,882 @@ void int1e_kin_kernel(double *out, PBCIntEnvVars envs, int *bas_ij_idx,
     }
 }
 
+// r^2 moment about origin: <i|r^2|j> with r measured from (0,0,0).
+//
+// Trick: x = (x - Bx) + Bx, so x^2 = (x-Bx)^2 + 2*Bx*(x-Bx) + Bx^2.  This
+// lets us reuse the existing OS recursion for S(ix, jx) = <xi|(x-Bx)^jx|xj>
+// and assemble the moment via three j-shifted samples.  The recursion is
+// extended by lj+2 in the j-axis (lij bumped by 2, HRR loop bumped by 2).
+// Final integrand for r^2 is x^2 + y^2 + z^2.
+__global__ static
+void int1e_r2_origi_kernel(double *out, PBCIntEnvVars envs, int *bas_ij_idx,
+                           int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    int sp_block_id = blockIdx.x;
+    int thread_id = threadIdx.x;
+    int nbas = envs.cell0_nbas * envs.bvk_ncells;
+    int *bas = envs.bas;
+    double *env = envs.env;
+    double *img_coords = envs.img_coords;
+    __shared__ int shl_pair0, shl_pair1;
+    __shared__ int li, lj, iprim, jprim;
+    __shared__ int gout_stride, nsp_per_block;
+    if (thread_id == 0) {
+        shl_pair0 = shl_pair_offsets[sp_block_id];
+        shl_pair1 = shl_pair_offsets[sp_block_id+1];
+        int bas_ij0 = bas_ij_idx[shl_pair0];
+        int ish0 = bas_ij0 / nbas;
+        int jsh0 = bas_ij0 % nbas;
+        li = bas[ish0*BAS_SLOTS+ANG_OF];
+        lj = bas[jsh0*BAS_SLOTS+ANG_OF];
+        iprim = bas[ish0*BAS_SLOTS+NPRIM_OF];
+        jprim = bas[jsh0*BAS_SLOTS+NPRIM_OF];
+        gout_stride = gout_stride_lookup[li*L_AUX1+lj];
+        nsp_per_block = THREADS / gout_stride;
+    }
+    __syncthreads();
+    int sp_id = thread_id % nsp_per_block;
+    int gout_id = thread_id / nsp_per_block;
+    int g_size = (li + 1) * (lj + 3);
+    int gx_len = g_size * nsp_per_block;
+    extern __shared__ double g[];
+    double *gx = g + sp_id;
+    double *gy = g + gx_len + sp_id;
+    double *gz = g + gx_len * 2 + sp_id;
+    double *rjri = g + gx_len * 3 + sp_id;
+    int idx_i = lex_xyz_offset(li);
+    int idx_j = lex_xyz_offset(lj);
+    if (gout_id == 0) {
+        gx[0] = PI_POW_1_5;
+        gy[0] = 1.;
+    }
+
+    for (int pair_ij = shl_pair0+sp_id; pair_ij < shl_pair1+sp_id; pair_ij += nsp_per_block) {
+        double gout[GOUT_WIDTH];
+#pragma unroll
+        for (int n = 0; n < GOUT_WIDTH; ++n) {
+            gout[n] = 0.;
+        }
+        int bas_ij;
+        if (pair_ij >= shl_pair1) {
+            bas_ij = bas_ij_idx[shl_pair0];
+        } else {
+            bas_ij = bas_ij_idx[pair_ij];
+        }
+        int ish = bas_ij / nbas;
+        int jsh = bas_ij % nbas;
+        int ri = bas[ish*BAS_SLOTS+PTR_BAS_COORD];
+        int rj = bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
+        int expi = bas[ish*BAS_SLOTS+PTR_EXP];
+        int expj = bas[jsh*BAS_SLOTS+PTR_EXP];
+        int ci = bas[ish*BAS_SLOTS+PTR_COEFF];
+        int cj = bas[jsh*BAS_SLOTS+PTR_COEFF];
+        for (int img = 0; img < envs.nimgs; img++) {
+            if (gout_id == 0) {
+                double xjL = img_coords[img*3+0];
+                double yjL = img_coords[img*3+1];
+                double zjL = img_coords[img*3+2];
+                double xjxi = env[rj+0] + xjL - env[ri+0];
+                double yjyi = env[rj+1] + yjL - env[ri+1];
+                double zjzi = env[rj+2] + zjL - env[ri+2];
+                double rr_ij = xjxi*xjxi + yjyi*yjyi + zjzi*zjzi;
+                rjri[0*nsp_per_block] = xjxi;
+                rjri[1*nsp_per_block] = yjyi;
+                rjri[2*nsp_per_block] = zjzi;
+                rjri[3*nsp_per_block] = rr_ij;
+            }
+            // Separation vector (ket - bra) for moment expansion about bra center.
+            // libcint's "origi" convention: r^2 measured from bra center.
+            double Bx = env[rj+0] + img_coords[img*3+0] - env[ri+0];
+            double By = env[rj+1] + img_coords[img*3+1] - env[ri+1];
+            double Bz = env[rj+2] + img_coords[img*3+2] - env[ri+2];
+            int ijprim = iprim * jprim;
+            for (int ijp = 0; ijp < ijprim; ++ijp) {
+                __syncthreads();
+                int ip = ijp % iprim;
+                int jp = ijp / iprim;
+                double ai = env[expi+ip];
+                double aj = env[expj+jp];
+                double aij = ai + aj;
+                double aj_aij = aj / aij;
+                if (gout_id == 0) {
+                    double theta = ai * aj_aij;
+                    double theta_rr = theta * rjri[3*nsp_per_block];
+                    double cicj = env[ci+ip] * env[cj+jp];
+                    gz[0] = cicj / (aij*sqrt(aij)) * exp(-theta_rr);
+                }
+                int lij = li + lj + 2;
+                int stride_j = li + 1;
+                int nsp = nsp_per_block;
+                __syncthreads();
+                double s0x, s1x, s2x;
+                double b = .5 / aij;
+                for (int n = gout_id; n < 3; n += gout_stride) {
+                    double *_gx = gx + n * gx_len;
+                    double xjxi = rjri[n*nsp];
+                    double xpa = xjxi * aj_aij;
+                    s0x = _gx[0];
+                    s1x = xpa * s0x;
+                    _gx[nsp] = s1x;
+                    for (int i = 1; i < lij; ++i) {
+                        s2x = xpa * s1x + i * b * s0x;
+                        _gx[(i+1)*nsp] = s2x;
+                        s0x = s1x;
+                        s1x = s2x;
+                    }
+                    // HRR extended by 2: produces gx[ix][jx] for jx = 0..lj+2
+                    for (int j = 0; j < lj+2; ++j) {
+                        int ij = (lij-j) + j*stride_j;
+                        s1x = _gx[ij*nsp];
+                        for (--ij; ij >= j*stride_j; --ij) {
+                            s0x = _gx[ij*nsp];
+                            _gx[(ij+stride_j)*nsp] = s1x - xjxi * s0x;
+                            s1x = s0x;
+                        }
+                    }
+                }
+                __syncthreads();
+                if (pair_ij >= shl_pair1) {
+                    continue;
+                }
+                int nfi = c_nf[li];
+                int nfj = c_nf[lj];
+                int nfij = nfi * nfj;
+                float div_nfi = c_div_nf[li];
+#pragma unroll
+                for (int n = 0; n < GOUT_WIDTH; ++n) {
+                    uint32_t ij = gout_id + n * gout_stride;
+                    if (ij >= nfij) break;
+                    uint32_t j = ij * div_nfi;
+                    uint32_t i = ij - j * nfi;
+                    int ix = _c_cartesian_lexical_xyz[idx_i + i*3+0];
+                    int iy = _c_cartesian_lexical_xyz[idx_i + i*3+1];
+                    int iz = _c_cartesian_lexical_xyz[idx_i + i*3+2];
+                    int jx = _c_cartesian_lexical_xyz[idx_j + j*3+0];
+                    int jy = _c_cartesian_lexical_xyz[idx_j + j*3+1];
+                    int jz = _c_cartesian_lexical_xyz[idx_j + j*3+2];
+                    int addrx0 = (ix + (jx+0)*stride_j) * nsp;
+                    int addrx1 = (ix + (jx+1)*stride_j) * nsp;
+                    int addrx2 = (ix + (jx+2)*stride_j) * nsp;
+                    int addry0 = (iy + (jy+0)*stride_j) * nsp;
+                    int addry1 = (iy + (jy+1)*stride_j) * nsp;
+                    int addry2 = (iy + (jy+2)*stride_j) * nsp;
+                    int addrz0 = (iz + (jz+0)*stride_j) * nsp;
+                    int addrz1 = (iz + (jz+1)*stride_j) * nsp;
+                    int addrz2 = (iz + (jz+2)*stride_j) * nsp;
+                    double sx = gx[addrx0];
+                    double sy = gy[addry0];
+                    double sz = gz[addrz0];
+                    {double mx = gx[addrx2] + 2.*Bx*gx[addrx1] + Bx*Bx*sx;
+                    double my = gy[addry2] + 2.*By*gy[addry1] + By*By*sy;
+                    double mz = gz[addrz2] + 2.*Bz*gz[addrz1] + Bz*Bz*sz;
+                    gout[n] += mx*sy*sz + sx*my*sz + sx*sy*mz;}
+                }
+            }
+        }
+
+        if (pair_ij < shl_pair1) {
+            int nfi = c_nf[li];
+            int nfj = c_nf[lj];
+            int nfij = nfi * nfj;
+            int *ao_loc = envs.ao_loc;
+            int nbas = envs.cell0_nbas;
+            size_t nao = ao_loc[nbas];
+            size_t nao2 = nao * nao;
+            int cell_id = jsh / nbas;
+            int jshp = jsh % nbas;
+            int i0 = ao_loc[ish];
+            int j0 = ao_loc[jshp];
+            double *out_subblock = out + cell_id*nao2 + i0 * nao + j0;
+#pragma unroll
+            for (int n = 0; n < GOUT_WIDTH; ++n) {
+                int ij = n*gout_stride+gout_id;
+                if (ij >= nfij) break;
+                int j = ij / nfi;
+                int i = ij % nfi;
+                out_subblock[i*nao+j] = gout[n];
+            }
+        }
+    }
+}
+
+// r^4 moment about origin: <i|r^4|j> with r measured from (0,0,0).
+//
+// r^4 = x^4+y^4+z^4 + 2(x^2*y^2 + y^2*z^2 + x^2*z^2).
+// Each 1D moment x^n uses binomial expansion x^n = sum_k C(n,k) Bx^(n-k) (x-Bx)^k.
+// Recursion extended by lj+4 in j-axis.
+__global__ static
+void int1e_r4_origi_kernel(double *out, PBCIntEnvVars envs, int *bas_ij_idx,
+                           int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    int sp_block_id = blockIdx.x;
+    int thread_id = threadIdx.x;
+    int nbas = envs.cell0_nbas * envs.bvk_ncells;
+    int *bas = envs.bas;
+    double *env = envs.env;
+    double *img_coords = envs.img_coords;
+    __shared__ int shl_pair0, shl_pair1;
+    __shared__ int li, lj, iprim, jprim;
+    __shared__ int gout_stride, nsp_per_block;
+    if (thread_id == 0) {
+        shl_pair0 = shl_pair_offsets[sp_block_id];
+        shl_pair1 = shl_pair_offsets[sp_block_id+1];
+        int bas_ij0 = bas_ij_idx[shl_pair0];
+        int ish0 = bas_ij0 / nbas;
+        int jsh0 = bas_ij0 % nbas;
+        li = bas[ish0*BAS_SLOTS+ANG_OF];
+        lj = bas[jsh0*BAS_SLOTS+ANG_OF];
+        iprim = bas[ish0*BAS_SLOTS+NPRIM_OF];
+        jprim = bas[jsh0*BAS_SLOTS+NPRIM_OF];
+        gout_stride = gout_stride_lookup[li*L_AUX1+lj];
+        nsp_per_block = THREADS / gout_stride;
+    }
+    __syncthreads();
+    int sp_id = thread_id % nsp_per_block;
+    int gout_id = thread_id / nsp_per_block;
+    int g_size = (li + 1) * (lj + 5);
+    int gx_len = g_size * nsp_per_block;
+    extern __shared__ double g[];
+    double *gx = g + sp_id;
+    double *gy = g + gx_len + sp_id;
+    double *gz = g + gx_len * 2 + sp_id;
+    double *rjri = g + gx_len * 3 + sp_id;
+    int idx_i = lex_xyz_offset(li);
+    int idx_j = lex_xyz_offset(lj);
+    if (gout_id == 0) {
+        gx[0] = PI_POW_1_5;
+        gy[0] = 1.;
+    }
+
+    for (int pair_ij = shl_pair0+sp_id; pair_ij < shl_pair1+sp_id; pair_ij += nsp_per_block) {
+        double gout[GOUT_WIDTH];
+#pragma unroll
+        for (int n = 0; n < GOUT_WIDTH; ++n) {
+            gout[n] = 0.;
+        }
+        int bas_ij;
+        if (pair_ij >= shl_pair1) {
+            bas_ij = bas_ij_idx[shl_pair0];
+        } else {
+            bas_ij = bas_ij_idx[pair_ij];
+        }
+        int ish = bas_ij / nbas;
+        int jsh = bas_ij % nbas;
+        int ri = bas[ish*BAS_SLOTS+PTR_BAS_COORD];
+        int rj = bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
+        int expi = bas[ish*BAS_SLOTS+PTR_EXP];
+        int expj = bas[jsh*BAS_SLOTS+PTR_EXP];
+        int ci = bas[ish*BAS_SLOTS+PTR_COEFF];
+        int cj = bas[jsh*BAS_SLOTS+PTR_COEFF];
+        for (int img = 0; img < envs.nimgs; img++) {
+            if (gout_id == 0) {
+                double xjL = img_coords[img*3+0];
+                double yjL = img_coords[img*3+1];
+                double zjL = img_coords[img*3+2];
+                double xjxi = env[rj+0] + xjL - env[ri+0];
+                double yjyi = env[rj+1] + yjL - env[ri+1];
+                double zjzi = env[rj+2] + zjL - env[ri+2];
+                double rr_ij = xjxi*xjxi + yjyi*yjyi + zjzi*zjzi;
+                rjri[0*nsp_per_block] = xjxi;
+                rjri[1*nsp_per_block] = yjyi;
+                rjri[2*nsp_per_block] = zjzi;
+                rjri[3*nsp_per_block] = rr_ij;
+            }
+            double Bx = env[rj+0] + img_coords[img*3+0] - env[ri+0];
+            double By = env[rj+1] + img_coords[img*3+1] - env[ri+1];
+            double Bz = env[rj+2] + img_coords[img*3+2] - env[ri+2];
+            int ijprim = iprim * jprim;
+            for (int ijp = 0; ijp < ijprim; ++ijp) {
+                __syncthreads();
+                int ip = ijp % iprim;
+                int jp = ijp / iprim;
+                double ai = env[expi+ip];
+                double aj = env[expj+jp];
+                double aij = ai + aj;
+                double aj_aij = aj / aij;
+                if (gout_id == 0) {
+                    double theta = ai * aj_aij;
+                    double theta_rr = theta * rjri[3*nsp_per_block];
+                    double cicj = env[ci+ip] * env[cj+jp];
+                    gz[0] = cicj / (aij*sqrt(aij)) * exp(-theta_rr);
+                }
+                int lij = li + lj + 4;
+                int stride_j = li + 1;
+                int nsp = nsp_per_block;
+                __syncthreads();
+                double s0x, s1x, s2x;
+                double b = .5 / aij;
+                for (int n = gout_id; n < 3; n += gout_stride) {
+                    double *_gx = gx + n * gx_len;
+                    double xjxi = rjri[n*nsp];
+                    double xpa = xjxi * aj_aij;
+                    s0x = _gx[0];
+                    s1x = xpa * s0x;
+                    _gx[nsp] = s1x;
+                    for (int i = 1; i < lij; ++i) {
+                        s2x = xpa * s1x + i * b * s0x;
+                        _gx[(i+1)*nsp] = s2x;
+                        s0x = s1x;
+                        s1x = s2x;
+                    }
+                    for (int j = 0; j < lj+4; ++j) {
+                        int ij = (lij-j) + j*stride_j;
+                        s1x = _gx[ij*nsp];
+                        for (--ij; ij >= j*stride_j; --ij) {
+                            s0x = _gx[ij*nsp];
+                            _gx[(ij+stride_j)*nsp] = s1x - xjxi * s0x;
+                            s1x = s0x;
+                        }
+                    }
+                }
+                __syncthreads();
+                if (pair_ij >= shl_pair1) {
+                    continue;
+                }
+                int nfi = c_nf[li];
+                int nfj = c_nf[lj];
+                int nfij = nfi * nfj;
+                float div_nfi = c_div_nf[li];
+                double Bx2 = Bx*Bx, By2 = By*By, Bz2 = Bz*Bz;
+#pragma unroll
+                for (int n = 0; n < GOUT_WIDTH; ++n) {
+                    uint32_t ij = gout_id + n * gout_stride;
+                    if (ij >= nfij) break;
+                    uint32_t j = ij * div_nfi;
+                    uint32_t i = ij - j * nfi;
+                    int ix = _c_cartesian_lexical_xyz[idx_i + i*3+0];
+                    int iy = _c_cartesian_lexical_xyz[idx_i + i*3+1];
+                    int iz = _c_cartesian_lexical_xyz[idx_i + i*3+2];
+                    int jx = _c_cartesian_lexical_xyz[idx_j + j*3+0];
+                    int jy = _c_cartesian_lexical_xyz[idx_j + j*3+1];
+                    int jz = _c_cartesian_lexical_xyz[idx_j + j*3+2];
+                    // Load S(ix, jx+k) for k=0..4  (and same for y, z)
+                    double Sx0 = gx[(ix + (jx+0)*stride_j) * nsp];
+                    double Sx1 = gx[(ix + (jx+1)*stride_j) * nsp];
+                    double Sx2 = gx[(ix + (jx+2)*stride_j) * nsp];
+                    double Sx3 = gx[(ix + (jx+3)*stride_j) * nsp];
+                    double Sx4 = gx[(ix + (jx+4)*stride_j) * nsp];
+                    double Sy0 = gy[(iy + (jy+0)*stride_j) * nsp];
+                    double Sy1 = gy[(iy + (jy+1)*stride_j) * nsp];
+                    double Sy2 = gy[(iy + (jy+2)*stride_j) * nsp];
+                    double Sy3 = gy[(iy + (jy+3)*stride_j) * nsp];
+                    double Sy4 = gy[(iy + (jy+4)*stride_j) * nsp];
+                    double Sz0 = gz[(iz + (jz+0)*stride_j) * nsp];
+                    double Sz1 = gz[(iz + (jz+1)*stride_j) * nsp];
+                    double Sz2 = gz[(iz + (jz+2)*stride_j) * nsp];
+                    double Sz3 = gz[(iz + (jz+3)*stride_j) * nsp];
+                    double Sz4 = gz[(iz + (jz+4)*stride_j) * nsp];
+                    // x^2 moment: S(ix,jx+2) + 2*Bx*S(ix,jx+1) + Bx^2*S(ix,jx)
+                    double mx2 = Sx2 + 2.*Bx*Sx1 + Bx2*Sx0;
+                    double my2 = Sy2 + 2.*By*Sy1 + By2*Sy0;
+                    double mz2 = Sz2 + 2.*Bz*Sz1 + Bz2*Sz0;
+                    // x^4 moment: S4 + 4*Bx*S3 + 6*Bx^2*S2 + 4*Bx^3*S1 + Bx^4*S0
+                    double mx4 = Sx4 + 4.*Bx*Sx3 + 6.*Bx2*Sx2 + 4.*Bx2*Bx*Sx1 + Bx2*Bx2*Sx0;
+                    double my4 = Sy4 + 4.*By*Sy3 + 6.*By2*Sy2 + 4.*By2*By*Sy1 + By2*By2*Sy0;
+                    double mz4 = Sz4 + 4.*Bz*Sz3 + 6.*Bz2*Sz2 + 4.*Bz2*Bz*Sz1 + Bz2*Bz2*Sz0;
+                    // r^4 = x^4+y^4+z^4 + 2(x^2*y^2 + y^2*z^2 + x^2*z^2)
+                    gout[n] += mx4*Sy0*Sz0 + Sx0*my4*Sz0 + Sx0*Sy0*mz4
+                            + 2.*(mx2*my2*Sz0 + Sx0*my2*mz2 + mx2*Sy0*mz2);
+                }
+            }
+        }
+
+        if (pair_ij < shl_pair1) {
+            int nfi = c_nf[li];
+            int nfj = c_nf[lj];
+            int nfij = nfi * nfj;
+            int *ao_loc = envs.ao_loc;
+            int nbas = envs.cell0_nbas;
+            size_t nao = ao_loc[nbas];
+            size_t nao2 = nao * nao;
+            int cell_id = jsh / nbas;
+            int jshp = jsh % nbas;
+            int i0 = ao_loc[ish];
+            int j0 = ao_loc[jshp];
+            double *out_subblock = out + cell_id*nao2 + i0 * nao + j0;
+#pragma unroll
+            for (int n = 0; n < GOUT_WIDTH; ++n) {
+                int ij = n*gout_stride+gout_id;
+                if (ij >= nfij) break;
+                int j = ij / nfi;
+                int i = ij % nfi;
+                out_subblock[i*nao+j] = gout[n];
+            }
+        }
+    }
+}
+
+// ip2 derivative of r^2 moment about origin: d/dB <i|r^2|j>.
+// d/dBx acts only on the j-basis (the weight r^2 is fixed at origin).
+// Uses j-side derivative: D_x[f(jx)] = -2*aj*f(jx+1) + jx*f(jx-1).
+// Needs S(ix, jx-1..jx+3) => lij = li+lj+3, g_size = (li+1)*(lj+4).
+// Output: 3 components (goutx, gouty, goutz) matching ip convention.
+__global__ static
+void int1e_r2_origi_ip2_kernel(double *out, PBCIntEnvVars envs, int *bas_ij_idx,
+                               int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    int sp_block_id = blockIdx.x;
+    int thread_id = threadIdx.x;
+    int nbas = envs.cell0_nbas * envs.bvk_ncells;
+    int *bas = envs.bas;
+    double *env = envs.env;
+    double *img_coords = envs.img_coords;
+    __shared__ int shl_pair0, shl_pair1;
+    __shared__ int li, lj, iprim, jprim;
+    __shared__ int gout_stride, nsp_per_block;
+    if (thread_id == 0) {
+        shl_pair0 = shl_pair_offsets[sp_block_id];
+        shl_pair1 = shl_pair_offsets[sp_block_id+1];
+        int bas_ij0 = bas_ij_idx[shl_pair0];
+        int ish0 = bas_ij0 / nbas;
+        int jsh0 = bas_ij0 % nbas;
+        li = bas[ish0*BAS_SLOTS+ANG_OF];
+        lj = bas[jsh0*BAS_SLOTS+ANG_OF];
+        iprim = bas[ish0*BAS_SLOTS+NPRIM_OF];
+        jprim = bas[jsh0*BAS_SLOTS+NPRIM_OF];
+        gout_stride = gout_stride_lookup[li*L_AUX1+lj];
+        nsp_per_block = THREADS / gout_stride;
+    }
+    __syncthreads();
+    int sp_id = thread_id % nsp_per_block;
+    int gout_id = thread_id / nsp_per_block;
+    int g_size = (li + 1) * (lj + 4);
+    int gx_len = g_size * nsp_per_block;
+    extern __shared__ double g[];
+    double *gx = g + sp_id;
+    double *gy = g + gx_len + sp_id;
+    double *gz = g + gx_len * 2 + sp_id;
+    double *rjri = g + gx_len * 3 + sp_id;
+    int idx_i = lex_xyz_offset(li);
+    int idx_j = lex_xyz_offset(lj);
+    if (gout_id == 0) {
+        gx[0] = PI_POW_1_5;
+        gy[0] = 1.;
+    }
+
+    for (int pair_ij = shl_pair0+sp_id; pair_ij < shl_pair1+sp_id; pair_ij += nsp_per_block) {
+        double goutx[GOUT_WIDTH_IP1];
+        double gouty[GOUT_WIDTH_IP1];
+        double goutz[GOUT_WIDTH_IP1];
+#pragma unroll
+        for (int n = 0; n < GOUT_WIDTH_IP1; ++n) {
+            goutx[n] = 0.;
+            gouty[n] = 0.;
+            goutz[n] = 0.;
+        }
+        int bas_ij;
+        if (pair_ij >= shl_pair1) {
+            bas_ij = bas_ij_idx[shl_pair0];
+        } else {
+            bas_ij = bas_ij_idx[pair_ij];
+        }
+        int ish = bas_ij / nbas;
+        int jsh = bas_ij % nbas;
+        int ri = bas[ish*BAS_SLOTS+PTR_BAS_COORD];
+        int rj = bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
+        int expi = bas[ish*BAS_SLOTS+PTR_EXP];
+        int expj = bas[jsh*BAS_SLOTS+PTR_EXP];
+        int ci = bas[ish*BAS_SLOTS+PTR_COEFF];
+        int cj = bas[jsh*BAS_SLOTS+PTR_COEFF];
+        for (int img = 0; img < envs.nimgs; img++) {
+            if (gout_id == 0) {
+                double xjL = img_coords[img*3+0];
+                double yjL = img_coords[img*3+1];
+                double zjL = img_coords[img*3+2];
+                double xjxi = env[rj+0] + xjL - env[ri+0];
+                double yjyi = env[rj+1] + yjL - env[ri+1];
+                double zjzi = env[rj+2] + zjL - env[ri+2];
+                double rr_ij = xjxi*xjxi + yjyi*yjyi + zjzi*zjzi;
+                rjri[0*nsp_per_block] = xjxi;
+                rjri[1*nsp_per_block] = yjyi;
+                rjri[2*nsp_per_block] = zjzi;
+                rjri[3*nsp_per_block] = rr_ij;
+            }
+            double Bx = env[rj+0] + img_coords[img*3+0] - env[ri+0];
+            double By = env[rj+1] + img_coords[img*3+1] - env[ri+1];
+            double Bz = env[rj+2] + img_coords[img*3+2] - env[ri+2];
+            double Bx2 = Bx*Bx, By2 = By*By, Bz2 = Bz*Bz;
+            int ijprim = iprim * jprim;
+            for (int ijp = 0; ijp < ijprim; ++ijp) {
+                __syncthreads();
+                int ip = ijp % iprim;
+                int jp = ijp / iprim;
+                double ai = env[expi+ip];
+                double aj = env[expj+jp];
+                double aj2 = aj * -2;
+                double aij = ai + aj;
+                double aj_aij = aj / aij;
+                if (gout_id == 0) {
+                    double theta = ai * aj_aij;
+                    double theta_rr = theta * rjri[3*nsp_per_block];
+                    double cicj = env[ci+ip] * env[cj+jp];
+                    gz[0] = cicj / (aij*sqrt(aij)) * exp(-theta_rr);
+                }
+                int lij = li + lj + 3;
+                int stride_j = li + 1;
+                int nsp = nsp_per_block;
+                __syncthreads();
+                double s0x, s1x, s2x;
+                double b = .5 / aij;
+                for (int n = gout_id; n < 3; n += gout_stride) {
+                    double *_gx = gx + n * gx_len;
+                    double xjxi = rjri[n*nsp];
+                    double xpa = xjxi * aj_aij;
+                    s0x = _gx[0];
+                    s1x = xpa * s0x;
+                    _gx[nsp] = s1x;
+                    for (int i = 1; i < lij; ++i) {
+                        s2x = xpa * s1x + i * b * s0x;
+                        _gx[(i+1)*nsp] = s2x;
+                        s0x = s1x;
+                        s1x = s2x;
+                    }
+                    for (int j = 0; j < lj+3; ++j) {
+                        int ij = (lij-j) + j*stride_j;
+                        s1x = _gx[ij*nsp];
+                        for (--ij; ij >= j*stride_j; --ij) {
+                            s0x = _gx[ij*nsp];
+                            _gx[(ij+stride_j)*nsp] = s1x - xjxi * s0x;
+                            s1x = s0x;
+                        }
+                    }
+                }
+                __syncthreads();
+                if (pair_ij >= shl_pair1) {
+                    continue;
+                }
+                float div_nfi = c_div_nf[li];
+                int nfi = c_nf[li];
+                int nfj = c_nf[lj];
+                int nfij = nfi * nfj;
+#pragma unroll
+                for (int n = 0; n < GOUT_WIDTH_IP1; ++n) {
+                    uint32_t ij = gout_id + n * gout_stride;
+                    if (ij >= nfij) break;
+                    uint32_t j = ij * div_nfi;
+                    uint32_t i = ij - j * nfi;
+                    int ix = _c_cartesian_lexical_xyz[idx_i + i*3+0];
+                    int iy = _c_cartesian_lexical_xyz[idx_i + i*3+1];
+                    int iz = _c_cartesian_lexical_xyz[idx_i + i*3+2];
+                    int jx = _c_cartesian_lexical_xyz[idx_j + j*3+0];
+                    int jy = _c_cartesian_lexical_xyz[idx_j + j*3+1];
+                    int jz = _c_cartesian_lexical_xyz[idx_j + j*3+2];
+                    // Load S(ix, jx+k) for k = -1..3 (and y, z analogues)
+                    // k=-1 only contributes when jx > 0 (multiplied by jx)
+                    #define SADDR(g,a,joff) ((g)[((a) + (joff)*stride_j) * nsp])
+                    double Sxm1 = (jx > 0) ? SADDR(gx,ix,jx-1) : 0.;
+                    double Sx0 = SADDR(gx,ix,jx);
+                    double Sx1 = SADDR(gx,ix,jx+1);
+                    double Sx2 = SADDR(gx,ix,jx+2);
+                    double Sx3 = SADDR(gx,ix,jx+3);
+                    double Sym1 = (jy > 0) ? SADDR(gy,iy,jy-1) : 0.;
+                    double Sy0 = SADDR(gy,iy,jy);
+                    double Sy1 = SADDR(gy,iy,jy+1);
+                    double Sy2 = SADDR(gy,iy,jy+2);
+                    double Sy3 = SADDR(gy,iy,jy+3);
+                    double Szm1 = (jz > 0) ? SADDR(gz,iz,jz-1) : 0.;
+                    double Sz0 = SADDR(gz,iz,jz);
+                    double Sz1 = SADDR(gz,iz,jz+1);
+                    double Sz2 = SADDR(gz,iz,jz+2);
+                    double Sz3 = SADDR(gz,iz,jz+3);
+                    #undef SADDR
+                    // Undifferentiated overlaps and x^2 moments:
+                    double sx = Sx0, sy = Sy0, sz = Sz0;
+                    double mx = Sx2 + 2.*Bx*Sx1 + Bx2*Sx0;
+                    double my = Sy2 + 2.*By*Sy1 + By2*Sy0;
+                    double mz = Sz2 + 2.*Bz*Sz1 + Bz2*Sz0;
+                    // j-side derivative D[f(j)] = -2*aj*f(j+1) + j_alpha*f(j-1)
+                    // Applied to overlap:
+                    double Dsx = aj2*Sx1 + jx*Sxm1;
+                    double Dsy = aj2*Sy1 + jy*Sym1;
+                    double Dsz = aj2*Sz1 + jz*Szm1;
+                    // Applied to moment (D acts on j-index inside binomial):
+                    // D[mx] = aj2*(S(jx+3)+2Bx*S(jx+2)+Bx^2*S(jx+1))
+                    //        + jx*(S(jx+1)+2Bx*S(jx)+Bx^2*S(jx-1))
+                    double Dmx = aj2*(Sx3 + 2.*Bx*Sx2 + Bx2*Sx1)
+                               + jx*(Sx1 + 2.*Bx*Sx0 + Bx2*Sxm1);
+                    double Dmy = aj2*(Sy3 + 2.*By*Sy2 + By2*Sy1)
+                               + jy*(Sy1 + 2.*By*Sy0 + By2*Sym1);
+                    double Dmz = aj2*(Sz3 + 2.*Bz*Sz2 + Bz2*Sz1)
+                               + jz*(Sz1 + 2.*Bz*Sz0 + Bz2*Szm1);
+                    // d/dBx: only x-axis j-basis depends on Bx
+                    goutx[n] += Dmx*sy*sz + Dsx*(my*sz + sy*mz);
+                    // d/dBy: only y-axis j-basis depends on By
+                    gouty[n] += Dmy*sx*sz + Dsy*(mx*sz + sx*mz);
+                    // d/dBz: only z-axis j-basis depends on Bz
+                    goutz[n] += Dmz*sx*sy + Dsz*(mx*sy + sx*my);
+                }
+            }
+        }
+
+        if (pair_ij < shl_pair1) {
+            int *ao_loc = envs.ao_loc;
+            int nbas = envs.cell0_nbas;
+            size_t nao = ao_loc[nbas];
+            size_t nao2 = nao * nao;
+            int cell_id = jsh / nbas;
+            int jshp = jsh % nbas;
+            int i0 = ao_loc[ish];
+            int j0 = ao_loc[jshp];
+            double *outx = out + cell_id*nao2*3 + i0 * nao + j0;
+            double *outy = outx + nao2;
+            double *outz = outx + nao2 * 2;
+            int nfi = c_nf[li];
+            int nfj = c_nf[lj];
+            int nfij = nfi * nfj;
+#pragma unroll
+            for (int n = 0; n < GOUT_WIDTH_IP1; ++n) {
+                int ij = n*gout_stride+gout_id;
+                if (ij >= nfij) break;
+                int j = ij / nfi;
+                int i = ij % nfi;
+                outx[i*nao+j] = goutx[n];
+                outy[i*nao+j] = gouty[n];
+                outz[i*nao+j] = goutz[n];
+            }
+        }
+    }
+}
+
+// ip2 derivative of r^4 moment about origin: d/dB <i|r^4|j>.
+// Same j-derivative approach. r^4 = x^4+y^4+z^4+2(x^2*y^2+y^2*z^2+x^2*z^2).
+// Needs S(ix, jx-1..jx+5) => lij = li+lj+5, g_size = (li+1)*(lj+6).
+__global__ static
+void int1e_r4_origi_ip2_kernel(double *out, PBCIntEnvVars envs, int *bas_ij_idx,
+                               int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    int sp_block_id = blockIdx.x;
+    int thread_id = threadIdx.x;
+    int nbas = envs.cell0_nbas * envs.bvk_ncells;
+    int *bas = envs.bas;
+    double *env = envs.env;
+    double *img_coords = envs.img_coords;
+    __shared__ int shl_pair0, shl_pair1;
+    __shared__ int li, lj, iprim, jprim;
+    __shared__ int gout_stride, nsp_per_block;
+    if (thread_id == 0) {
+        shl_pair0 = shl_pair_offsets[sp_block_id];
+        shl_pair1 = shl_pair_offsets[sp_block_id+1];
+        int bas_ij0 = bas_ij_idx[shl_pair0];
+        int ish0 = bas_ij0 / nbas;
+        int jsh0 = bas_ij0 % nbas;
+        li = bas[ish0*BAS_SLOTS+ANG_OF];
+        lj = bas[jsh0*BAS_SLOTS+ANG_OF];
+        iprim = bas[ish0*BAS_SLOTS+NPRIM_OF];
+        jprim = bas[jsh0*BAS_SLOTS+NPRIM_OF];
+        gout_stride = gout_stride_lookup[li*L_AUX1+lj];
+        nsp_per_block = THREADS / gout_stride;
+    }
+    __syncthreads();
+    int sp_id = thread_id % nsp_per_block;
+    int gout_id = thread_id / nsp_per_block;
+    int g_size = (li + 1) * (lj + 6);
+    int gx_len = g_size * nsp_per_block;
+    extern __shared__ double g[];
+    double *gx = g + sp_id;
+    double *gy = g + gx_len + sp_id;
+    double *gz = g + gx_len * 2 + sp_id;
+    double *rjri = g + gx_len * 3 + sp_id;
+    int idx_i = lex_xyz_offset(li);
+    int idx_j = lex_xyz_offset(lj);
+    if (gout_id == 0) {
+        gx[0] = PI_POW_1_5;
+        gy[0] = 1.;
+    }
+
+    for (int pair_ij = shl_pair0+sp_id; pair_ij < shl_pair1+sp_id; pair_ij += nsp_per_block) {
+        double goutx[GOUT_WIDTH_IP1];
+        double gouty[GOUT_WIDTH_IP1];
+        double goutz[GOUT_WIDTH_IP1];
+#pragma unroll
+        for (int n = 0; n < GOUT_WIDTH_IP1; ++n) {
+            goutx[n] = 0.;
+            gouty[n] = 0.;
+            goutz[n] = 0.;
+        }
+        int bas_ij;
+        if (pair_ij >= shl_pair1) {
+            bas_ij = bas_ij_idx[shl_pair0];
+        } else {
+            bas_ij = bas_ij_idx[pair_ij];
+        }
+        int ish = bas_ij / nbas;
+        int jsh = bas_ij % nbas;
+        int ri = bas[ish*BAS_SLOTS+PTR_BAS_COORD];
+        int rj = bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
+        int expi = bas[ish*BAS_SLOTS+PTR_EXP];
+        int expj = bas[jsh*BAS_SLOTS+PTR_EXP];
+        int ci = bas[ish*BAS_SLOTS+PTR_COEFF];
+        int cj = bas[jsh*BAS_SLOTS+PTR_COEFF];
+        for (int img = 0; img < envs.nimgs; img++) {
+            if (gout_id == 0) {
+                double xjL = img_coords[img*3+0];
+                double yjL = img_coords[img*3+1];
+                double zjL = img_coords[img*3+2];
+                double xjxi = env[rj+0] + xjL - env[ri+0];
+                double yjyi = env[rj+1] + yjL - env[ri+1];
+                double zjzi = env[rj+2] + zjL - env[ri+2];
+                double rr_ij = xjxi*xjxi + yjyi*yjyi + zjzi*zjzi;
+                rjri[0*nsp_per_block] = xjxi;
+                rjri[1*nsp_per_block] = yjyi;
+                rjri[2*nsp_per_block] = zjzi;
+                rjri[3*nsp_per_block] = rr_ij;
+            }
+            double Bx = env[rj+0] + img_coords[img*3+0] - env[ri+0];
+            double By = env[rj+1] + img_coords[img*3+1] - env[ri+1];
+            double Bz = env[rj+2] + img_coords[img*3+2] - env[ri+2];
+            double Bx2 = Bx*Bx, By2 = By*By, Bz2 = Bz*Bz;
+            int ijprim = iprim * jprim;
+            for (int ijp = 0; ijp < ijprim; ++ijp) {
+                __syncthreads();
+                int ip = ijp % iprim;
+                int jp = ijp / iprim;
+                double ai = env[expi+ip];
+                double aj = env[expj+jp];
+                double aj2 = aj * -2;
+                double aij = ai + aj;
+                double aj_aij = aj / aij;
+                if (gout_id == 0) {
+                    double theta = ai * aj_aij;
+                    double theta_rr = theta * rjri[3*nsp_per_block];
+                    double cicj = env[ci+ip] * env[cj+jp];
+                    gz[0] = cicj / (aij*sqrt(aij)) * exp(-theta_rr);
+                }
+                int lij = li + lj + 5;
+                int stride_j = li + 1;
+                int nsp = nsp_per_block;
+                __syncthreads();
+                double s0x, s1x, s2x;
+                double b = .5 / aij;
+                for (int n = gout_id; n < 3; n += gout_stride) {
+                    double *_gx = gx + n * gx_len;
+                    double xjxi = rjri[n*nsp];
+                    double xpa = xjxi * aj_aij;
+                    s0x = _gx[0];
+                    s1x = xpa * s0x;
+                    _gx[nsp] = s1x;
+                    for (int i = 1; i < lij; ++i) {
+                        s2x = xpa * s1x + i * b * s0x;
+                        _gx[(i+1)*nsp] = s2x;
+                        s0x = s1x;
+                        s1x = s2x;
+                    }
+                    for (int j = 0; j < lj+5; ++j) {
+                        int ij = (lij-j) + j*stride_j;
+                        s1x = _gx[ij*nsp];
+                        for (--ij; ij >= j*stride_j; --ij) {
+                            s0x = _gx[ij*nsp];
+                            _gx[(ij+stride_j)*nsp] = s1x - xjxi * s0x;
+                            s1x = s0x;
+                        }
+                    }
+                }
+                __syncthreads();
+                if (pair_ij >= shl_pair1) {
+                    continue;
+                }
+                float div_nfi = c_div_nf[li];
+                int nfi = c_nf[li];
+                int nfj = c_nf[lj];
+                int nfij = nfi * nfj;
+#pragma unroll
+                for (int n = 0; n < GOUT_WIDTH_IP1; ++n) {
+                    uint32_t ij = gout_id + n * gout_stride;
+                    if (ij >= nfij) break;
+                    uint32_t j = ij * div_nfi;
+                    uint32_t i = ij - j * nfi;
+                    int ix = _c_cartesian_lexical_xyz[idx_i + i*3+0];
+                    int iy = _c_cartesian_lexical_xyz[idx_i + i*3+1];
+                    int iz = _c_cartesian_lexical_xyz[idx_i + i*3+2];
+                    int jx = _c_cartesian_lexical_xyz[idx_j + j*3+0];
+                    int jy = _c_cartesian_lexical_xyz[idx_j + j*3+1];
+                    int jz = _c_cartesian_lexical_xyz[idx_j + j*3+2];
+                    #define SADDR(g,a,joff) ((g)[((a) + (joff)*stride_j) * nsp])
+                    double Sxm1 = (jx > 0) ? SADDR(gx,ix,jx-1) : 0.;
+                    double Sx0 = SADDR(gx,ix,jx);   double Sx1 = SADDR(gx,ix,jx+1);
+                    double Sx2 = SADDR(gx,ix,jx+2); double Sx3 = SADDR(gx,ix,jx+3);
+                    double Sx4 = SADDR(gx,ix,jx+4); double Sx5 = SADDR(gx,ix,jx+5);
+                    double Sym1 = (jy > 0) ? SADDR(gy,iy,jy-1) : 0.;
+                    double Sy0 = SADDR(gy,iy,jy);   double Sy1 = SADDR(gy,iy,jy+1);
+                    double Sy2 = SADDR(gy,iy,jy+2); double Sy3 = SADDR(gy,iy,jy+3);
+                    double Sy4 = SADDR(gy,iy,jy+4); double Sy5 = SADDR(gy,iy,jy+5);
+                    double Szm1 = (jz > 0) ? SADDR(gz,iz,jz-1) : 0.;
+                    double Sz0 = SADDR(gz,iz,jz);   double Sz1 = SADDR(gz,iz,jz+1);
+                    double Sz2 = SADDR(gz,iz,jz+2); double Sz3 = SADDR(gz,iz,jz+3);
+                    double Sz4 = SADDR(gz,iz,jz+4); double Sz5 = SADDR(gz,iz,jz+5);
+                    #undef SADDR
+                    // Undifferentiated overlaps, x^2 moments, x^4 moments:
+                    double sx = Sx0, sy = Sy0, sz = Sz0;
+                    double mx2 = Sx2 + 2.*Bx*Sx1 + Bx2*Sx0;
+                    double my2 = Sy2 + 2.*By*Sy1 + By2*Sy0;
+                    double mz2 = Sz2 + 2.*Bz*Sz1 + Bz2*Sz0;
+                    double mx4 = Sx4 + 4.*Bx*Sx3 + 6.*Bx2*Sx2 + 4.*Bx2*Bx*Sx1 + Bx2*Bx2*Sx0;
+                    double my4 = Sy4 + 4.*By*Sy3 + 6.*By2*Sy2 + 4.*By2*By*Sy1 + By2*By2*Sy0;
+                    double mz4 = Sz4 + 4.*Bz*Sz3 + 6.*Bz2*Sz2 + 4.*Bz2*Bz*Sz1 + Bz2*Bz2*Sz0;
+                    // j-derivative of overlaps:
+                    double Dsx = aj2*Sx1 + jx*Sxm1;
+                    double Dsy = aj2*Sy1 + jy*Sym1;
+                    double Dsz = aj2*Sz1 + jz*Szm1;
+                    // j-derivative of x^2 moments:
+                    double Dmx2 = aj2*(Sx3 + 2.*Bx*Sx2 + Bx2*Sx1)
+                                + jx*(Sx1 + 2.*Bx*Sx0 + Bx2*Sxm1);
+                    double Dmy2 = aj2*(Sy3 + 2.*By*Sy2 + By2*Sy1)
+                                + jy*(Sy1 + 2.*By*Sy0 + By2*Sym1);
+                    double Dmz2 = aj2*(Sz3 + 2.*Bz*Sz2 + Bz2*Sz1)
+                                + jz*(Sz1 + 2.*Bz*Sz0 + Bz2*Szm1);
+                    // j-derivative of x^4 moments:
+                    double Dmx4 = aj2*(Sx5+4.*Bx*Sx4+6.*Bx2*Sx3+4.*Bx2*Bx*Sx2+Bx2*Bx2*Sx1)
+                                + jx*(Sx3+4.*Bx*Sx2+6.*Bx2*Sx1+4.*Bx2*Bx*Sx0+Bx2*Bx2*Sxm1);
+                    double Dmy4 = aj2*(Sy5+4.*By*Sy4+6.*By2*Sy3+4.*By2*By*Sy2+By2*By2*Sy1)
+                                + jy*(Sy3+4.*By*Sy2+6.*By2*Sy1+4.*By2*By*Sy0+By2*By2*Sym1);
+                    double Dmz4 = aj2*(Sz5+4.*Bz*Sz4+6.*Bz2*Sz3+4.*Bz2*Bz*Sz2+Bz2*Bz2*Sz1)
+                                + jz*(Sz3+4.*Bz*Sz2+6.*Bz2*Sz1+4.*Bz2*Bz*Sz0+Bz2*Bz2*Szm1);
+                    // r^4 = x^4+y^4+z^4 + 2(x^2*y^2+y^2*z^2+x^2*z^2)
+                    // d/dBx: acts on x-axis j-basis
+                    // d/dBx[x^4*sy*sz] = Dmx4*sy*sz
+                    // d/dBx[sx*y^4*sz] = Dsx*my4*sz  (etc.)
+                    // d/dBx[2*x^2*y^2*sz] = 2*Dmx2*my2*sz
+                    // d/dBx[2*sx*y^2*z^2] = 2*Dsx*my2*mz2  (etc.)
+                    // d/dBx[2*x^2*sz*z^2] = 2*Dmx2*sy*mz2
+                    goutx[n] += Dmx4*sy*sz + Dsx*my4*sz + Dsx*sy*mz4
+                             + 2.*(Dmx2*my2*sz + Dsx*my2*mz2 + Dmx2*sy*mz2);
+                    gouty[n] += mx4*Dsy*sz + sx*Dmy4*sz + sx*Dsy*mz4
+                             + 2.*(mx2*Dmy2*sz + sx*Dmy2*mz2 + mx2*Dsy*mz2);
+                    goutz[n] += mx4*sy*Dsz + sx*my4*Dsz + sx*sy*Dmz4
+                             + 2.*(mx2*my2*Dsz + sx*my2*Dmz2 + mx2*sy*Dmz2);
+                }
+            }
+        }
+
+        if (pair_ij < shl_pair1) {
+            int *ao_loc = envs.ao_loc;
+            int nbas = envs.cell0_nbas;
+            size_t nao = ao_loc[nbas];
+            size_t nao2 = nao * nao;
+            int cell_id = jsh / nbas;
+            int jshp = jsh % nbas;
+            int i0 = ao_loc[ish];
+            int j0 = ao_loc[jshp];
+            double *outx = out + cell_id*nao2*3 + i0 * nao + j0;
+            double *outy = outx + nao2;
+            double *outz = outx + nao2 * 2;
+            int nfi = c_nf[li];
+            int nfj = c_nf[lj];
+            int nfij = nfi * nfj;
+#pragma unroll
+            for (int n = 0; n < GOUT_WIDTH_IP1; ++n) {
+                int ij = n*gout_stride+gout_id;
+                if (ij >= nfij) break;
+                int j = ij / nfi;
+                int i = ij % nfi;
+                outx[i*nao+j] = goutx[n];
+                outy[i*nao+j] = gouty[n];
+                outz[i*nao+j] = goutz[n];
+            }
+        }
+    }
+}
+
 static __global__
 void int1e_ipovlp_kernel(double *out, PBCIntEnvVars envs, int *bas_ij_idx,
                          int *shl_pair_offsets, int *gout_stride_lookup)
@@ -1372,6 +2248,66 @@ int PBCint1e_kin(double *out, PBCIntEnvVars *envs, int shm_size,
     cudaError_t err = cudaGetLastError();
     if (err != cudaSuccess) {
         fprintf(stderr, "CUDA Error in int1e_ovlp kernel: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+int PBCint1e_r2_origi(double *out, PBCIntEnvVars *envs, int shm_size,
+                      int nbatches_shl_pair, int *bas_ij_idx,
+                      int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    cudaFuncSetAttribute(int1e_r2_origi_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+    int1e_r2_origi_kernel<<<nbatches_shl_pair, THREADS, shm_size>>>(
+            out, *envs, bas_ij_idx, shl_pair_offsets, gout_stride_lookup);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in int1e_r2_origi kernel: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+int PBCint1e_r4_origi(double *out, PBCIntEnvVars *envs, int shm_size,
+                      int nbatches_shl_pair, int *bas_ij_idx,
+                      int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    cudaFuncSetAttribute(int1e_r4_origi_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+    int1e_r4_origi_kernel<<<nbatches_shl_pair, THREADS, shm_size>>>(
+            out, *envs, bas_ij_idx, shl_pair_offsets, gout_stride_lookup);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in int1e_r4_origi kernel: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+int PBCint1e_r2_origi_ip2(double *out, PBCIntEnvVars *envs, int shm_size,
+                          int nbatches_shl_pair, int *bas_ij_idx,
+                          int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    cudaFuncSetAttribute(int1e_r2_origi_ip2_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+    int1e_r2_origi_ip2_kernel<<<nbatches_shl_pair, THREADS, shm_size>>>(
+            out, *envs, bas_ij_idx, shl_pair_offsets, gout_stride_lookup);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in int1e_r2_origi_ip2 kernel: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    return 0;
+}
+
+int PBCint1e_r4_origi_ip2(double *out, PBCIntEnvVars *envs, int shm_size,
+                          int nbatches_shl_pair, int *bas_ij_idx,
+                          int *shl_pair_offsets, int *gout_stride_lookup)
+{
+    cudaFuncSetAttribute(int1e_r4_origi_ip2_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shm_size);
+    int1e_r4_origi_ip2_kernel<<<nbatches_shl_pair, THREADS, shm_size>>>(
+            out, *envs, bas_ij_idx, shl_pair_offsets, gout_stride_lookup);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        fprintf(stderr, "CUDA Error in int1e_r4_origi_ip2 kernel: %s\n", cudaGetErrorString(err));
         return 1;
     }
     return 0;

--- a/gpu4pyscf/pbc/grad/pp.py
+++ b/gpu4pyscf/pbc/grad/pp.py
@@ -19,6 +19,13 @@ from gpu4pyscf.lib import logger
 from pyscf.pbc.lib.kpts_helper import gamma_point
 from pyscf.pbc.gto.pseudo.pp_int import fake_cell_vnl
 
+# The following function is derived from pyscf/pbc/gto/pseudo/pp_int.py.
+# It's updated to support k-point sampling after pyscf>2.11.0,
+# however we want gpu4pyscf to be compatible with older versions of pyscf,
+# particularly pyscf==2.8.0, the version used by github CI.
+# The integral computation uses GPU CUDA kernels for the r^2/r^4 moment
+# integrals, and the contraction is done with cupy.
+
 def vppnl_nuc_grad(cell, dm, kpts=None):
     '''Nuclear gradients of the non-local part of the GTH pseudo potential,
     contracted with the density matrix. Fully GPU-accelerated.
@@ -47,7 +54,6 @@ def vppnl_nuc_grad(cell, dm, kpts=None):
 
     nkpts = len(kpts_lst)
     nao = cell.nao_nr()
-    hl_dims = numpy.asarray([len(hl) for hl in hl_blocks])
 
     dm = dm.reshape(-1, nao, nao)
     if gamma_point(kpts_lst):

--- a/gpu4pyscf/pbc/grad/pp.py
+++ b/gpu4pyscf/pbc/grad/pp.py
@@ -19,16 +19,12 @@ from gpu4pyscf.lib import logger
 from pyscf.pbc.lib.kpts_helper import gamma_point
 from pyscf.pbc.gto.pseudo.pp_int import fake_cell_vnl
 
-# The following function is derived from pyscf/pbc/gto/pseudo/pp_int.py.
-# It's updated to support k-point sampling after pyscf>2.11.0,
-# however we want gpu4pyscf to be compatible with older versions of pyscf,
-# particularly pyscf==2.8.0, the version used by github CI.
-# The integral computation uses GPU CUDA kernels for the r^2/r^4 moment
-# integrals, and the contraction is done with cupy.
-
 def vppnl_nuc_grad(cell, dm, kpts=None):
     '''Nuclear gradients of the non-local part of the GTH pseudo potential,
-    contracted with the density matrix. Fully GPU-accelerated.
+    contracted with the density matrix.
+
+    Uses GPU CUDA kernels for the r^2/r^4 moment integrals at gamma point,
+    with CPU fallback via pyscf _int_vnl for multi-k-point calculations.
     '''
     if kpts is None:
         kpts_lst = numpy.zeros((1, 3))

--- a/gpu4pyscf/pbc/grad/pp.py
+++ b/gpu4pyscf/pbc/grad/pp.py
@@ -38,10 +38,15 @@ def vppnl_nuc_grad(cell, dm, kpts=None):
     dm = cp.asarray(dm)
     fakecell, hl_blocks = fake_cell_vnl(cell)
 
-    from gpu4pyscf.pbc.gto.pseudo.pp_int import _int_vnl_gpu
     intors_d = ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2')
-    ppnl_half = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts_lst)
-    ppnl_half_ip2 = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts_lst, intors_d, comp=3)
+    if gamma_point(kpts_lst):
+        from gpu4pyscf.pbc.gto.pseudo.pp_int import _int_vnl_gpu
+        ppnl_half = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts_lst)
+        ppnl_half_ip2 = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts_lst, intors_d, comp=3)
+    else:
+        from pyscf.pbc.gto.pseudo.pp_int import _int_vnl
+        ppnl_half = _int_vnl(cell, fakecell, hl_blocks, kpts_lst)
+        ppnl_half_ip2 = _int_vnl(cell, fakecell, hl_blocks, kpts_lst, intors_d, comp=3)
     if len(ppnl_half_ip2[0]) > 0:
         for k in range(len(kpts_lst)):
             ppnl_half_ip2[0][k] *= -1

--- a/gpu4pyscf/pbc/grad/pp.py
+++ b/gpu4pyscf/pbc/grad/pp.py
@@ -17,75 +17,78 @@ import numpy
 import cupy as cp
 from gpu4pyscf.lib import logger
 from pyscf.pbc.lib.kpts_helper import gamma_point
-from pyscf.pbc.gto.pseudo.pp_int import fake_cell_vnl, _int_vnl, _contract_ppnl_nuc_grad
-
-# The following function is copied from pyscf/pbc/gto/pseudo/pp_int.py
-# It's updated to support k-point sampling after pyscf>2.11.0,
-# however we want gpu4pyscf to be compatable with older version of pyscf,
-# particularly pyscf==2.8.0, the version used by github CI.
-# So, we made a copy.
+from pyscf.pbc.gto.pseudo.pp_int import fake_cell_vnl
 
 def vppnl_nuc_grad(cell, dm, kpts=None):
-    '''
-    Nuclear gradients of the non-local part of the GTH pseudo potential,
-    contracted with the density matrix.
+    '''Nuclear gradients of the non-local part of the GTH pseudo potential,
+    contracted with the density matrix. Fully GPU-accelerated.
     '''
     if kpts is None:
-        kpts_lst = numpy.zeros((1,3))
+        kpts_lst = numpy.zeros((1, 3))
     else:
-        kpts_lst = numpy.reshape(kpts, (-1,3))
+        kpts_lst = numpy.reshape(kpts, (-1, 3))
 
-    dm = cp.asnumpy(dm)
+    dm = cp.asarray(dm)
     fakecell, hl_blocks = fake_cell_vnl(cell)
-    intors = ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2')
-    ppnl_half = _int_vnl(cell, fakecell, hl_blocks, kpts_lst)
-    ppnl_half_ip2 = _int_vnl(cell, fakecell, hl_blocks, kpts_lst, intors, comp=3)
-    # int1e_ipovlp computes ip1 so multiply -1 to get ip2
+
+    from gpu4pyscf.pbc.gto.pseudo.pp_int import _int_vnl_gpu
+    intors_d = ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2')
+    ppnl_half = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts_lst)
+    ppnl_half_ip2 = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts_lst, intors_d, comp=3)
     if len(ppnl_half_ip2[0]) > 0:
-        for k, kpt in enumerate(kpts_lst):
+        for k in range(len(kpts_lst)):
             ppnl_half_ip2[0][k] *= -1
 
-    if gamma_point(kpts_lst):
-        grad = _contract_ppnl_nuc_grad(cell, fakecell, dm, hl_blocks,
-                                       ppnl_half, ppnl_half_ip2, kpts=kpts)
-        grad *= -2
-        return grad
+    # Move integral arrays to GPU
+    def _to_gpu(arrs):
+        return [cp.asarray(a) if len(a) > 0 else a for a in arrs]
+    ppnl_half = _to_gpu(ppnl_half)
+    ppnl_half_ip2 = _to_gpu(ppnl_half_ip2)
 
     nkpts = len(kpts_lst)
     nao = cell.nao_nr()
-    assert dm.shape == (nkpts, nao, nao)
-    dm_dmH = dm + dm.transpose(0,2,1).conj() # bra and ket
+    hl_dims = numpy.asarray([len(hl) for hl in hl_blocks])
 
-    grad = numpy.zeros([cell.natm, 3], order='C', dtype=numpy.complex128)
+    dm = dm.reshape(-1, nao, nao)
+    if gamma_point(kpts_lst):
+        dm = dm.real
+    dm_dmH = dm + dm.transpose(0, 2, 1).conj()
 
-    buf1 = numpy.empty((3*9*nao), dtype=numpy.complex128)
-    buf2 = numpy.empty((3*3*9*nao), dtype=numpy.complex128)
+    grad = cp.zeros([cell.natm, 3], dtype=cp.complex128)
+    dppnl = cp.zeros((nkpts, 3, nao, nao), dtype=cp.complex128)
 
-    dppnl = numpy.zeros((nkpts,3,nao,nao), dtype=numpy.complex128)
-    for k, kpt in enumerate(kpts_lst):
+    for k in range(nkpts):
         offset = [0] * 3
-
         for ib, hl in enumerate(hl_blocks):
             l = fakecell.bas_angular(ib)
             nd = 2 * l + 1
             hl_dim = hl.shape[0]
-            ilp = numpy.ndarray((hl_dim,nd,nao), dtype=numpy.complex128, buffer=buf1)
-            dilp = numpy.ndarray((hl_dim,3,nd,nao), dtype=numpy.complex128, buffer=buf2)
+            hl_gpu = cp.asarray(hl)
+
+            ilp = cp.zeros((hl_dim, nd, nao), dtype=cp.complex128)
+            dilp = cp.zeros((hl_dim, 3, nd, nao), dtype=cp.complex128)
             for i in range(hl_dim):
                 p0 = offset[i]
-                ilp[i] = ppnl_half[i][k][p0:p0+nd]
-                dilp[i] = ppnl_half_ip2[i][k][:, p0:p0+nd]
+                if len(ppnl_half[i]) > 0:
+                    ilp[i] = ppnl_half[i][k, p0:p0+nd]
+                if len(ppnl_half_ip2[i]) > 0:
+                    dilp[i] = ppnl_half_ip2[i][k, :, p0:p0+nd]
                 offset[i] = p0 + nd
-            dppnl_k = numpy.einsum('idlp,ij,jlq->dpq', dilp.conj(), hl, ilp)
+
+            # dppnl_k[d,p,q] = sum_{i,j,l} dilp[i,d,l,p].conj() * hl[i,j] * ilp[j,l,q]
+            dppnl_k = cp.einsum('idlp,ij,jlq->dpq', dilp.conj(), hl_gpu, ilp)
             dppnl[k] += dppnl_k
 
-            i_pp_atom = fakecell._bas[ib,0]
-            grad[i_pp_atom] += numpy.einsum('dpq,qp->d', dppnl_k, dm_dmH[k])
+            i_pp_atom = fakecell._bas[ib, 0]
+            grad[i_pp_atom] += cp.einsum('dpq,qp->d', dppnl_k, dm_dmH[k])
 
     aoslices = cell.aoslice_by_atom()
     for ia in range(cell.natm):
         p0, p1 = aoslices[ia][2:]
-        grad[ia] -= numpy.einsum('kdpq,kqp->d', dppnl[:,:,p0:p1,:], dm_dmH[:,:,p0:p1])
+        grad[ia] -= cp.einsum('kdpq,kqp->d', dppnl[:, :, p0:p1, :],
+                              dm_dmH[:, :, p0:p1])
+
+    grad = grad.get()
 
     grad_max_imag = numpy.max(numpy.abs(grad.imag))
     if grad_max_imag >= 1e-8:

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
@@ -67,6 +67,45 @@ def setUpModule():
     )
 
 
+def _cpu_vppnl_nuc_grad(cell, dm):
+    """CPU reference gradient using only stable pyscf APIs (_int_vnl + numpy)."""
+    kpts = np.zeros((1, 3))
+    fakecell, hl_blocks = fake_cell_vnl(cell)
+    intors_d = ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2')
+    ppnl_half = _int_vnl(cell, fakecell, hl_blocks, kpts)
+    ppnl_half_ip2 = _int_vnl(cell, fakecell, hl_blocks, kpts, intors_d, comp=3)
+    if len(ppnl_half_ip2[0]) > 0:
+        ppnl_half_ip2[0][0] *= -1
+
+    nao = cell.nao_nr()
+    dm_dmH = dm + dm.T
+    grad = np.zeros([cell.natm, 3])
+    dppnl = np.zeros((1, 3, nao, nao))
+    offset = [0] * 3
+    for ib, hl in enumerate(hl_blocks):
+        l = fakecell.bas_angular(ib)
+        nd = 2 * l + 1
+        hl_dim = hl.shape[0]
+        ilp = np.zeros((hl_dim, nd, nao), dtype=np.complex128)
+        dilp = np.zeros((hl_dim, 3, nd, nao), dtype=np.complex128)
+        for i in range(hl_dim):
+            p0 = offset[i]
+            if len(ppnl_half[i]) > 0:
+                ilp[i] = ppnl_half[i][0][p0:p0+nd]
+            if len(ppnl_half_ip2[i]) > 0:
+                dilp[i] = ppnl_half_ip2[i][0][:, p0:p0+nd]
+            offset[i] = p0 + nd
+        dppnl_k = np.einsum('idlp,ij,jlq->dpq', dilp.conj(), hl, ilp)
+        dppnl[0] += dppnl_k
+        i_pp_atom = fakecell._bas[ib, 0]
+        grad[i_pp_atom] += np.einsum('dpq,qp->d', dppnl_k, dm_dmH).real
+    aoslices = cell.aoslice_by_atom()
+    for ia in range(cell.natm):
+        p0, p1 = aoslices[ia][2:]
+        grad[ia] -= np.einsum('kdpq,kqp->d', dppnl[:, :, p0:p1, :], dm_dmH[None, :, p0:p1]).real
+    return grad
+
+
 class TestCrossBasisIntegrals(unittest.TestCase):
     """Test GPU _int_vnl_gpu against CPU _int_vnl for each element."""
 
@@ -122,15 +161,15 @@ class TestVppnlNucGrad(unittest.TestCase):
     def _compare_grad(self, cell, places=6):
         import cupy as cp
         from gpu4pyscf.pbc.grad.pp import vppnl_nuc_grad
-        from pyscf.pbc.gto.pseudo import pp_int as pyscf_pp_int
 
         nao = cell.nao_nr()
         np.random.seed(42)
         dm = np.random.randn(nao, nao)
         dm = dm + dm.T
 
-        # CPU reference: use pyscf's own vppnl_nuc_grad
-        grad_cpu = pyscf_pp_int.vppnl_nuc_grad(cell, dm)
+        # CPU reference: compute using CPU _int_vnl + Python contraction
+        # (avoids importing pyscf.vppnl_nuc_grad which may not exist in pyscf<2.11)
+        grad_cpu = _cpu_vppnl_nuc_grad(cell, dm)
 
         # GPU
         grad_gpu = vppnl_nuc_grad(cell, cp.asarray(dm))

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
@@ -80,7 +80,7 @@ def _cpu_vppnl_nuc_grad(cell, dm):
     nao = cell.nao_nr()
     dm_dmH = dm + dm.T
     grad = np.zeros([cell.natm, 3])
-    dppnl = np.zeros((1, 3, nao, nao))
+    dppnl = np.zeros((1, 3, nao, nao), dtype=np.complex128)
     offset = [0] * 3
     for ib, hl in enumerate(hl_blocks):
         l = fakecell.bas_angular(ib)

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
@@ -190,56 +190,47 @@ class TestVppnlNucGrad(unittest.TestCase):
 
 
 class TestFiniteDifference(unittest.TestCase):
-    """Validate gradient via finite difference of the PP energy."""
+    """Validate gradient via finite difference of the nonlocal PP energy."""
 
     def _fd_check(self, cell, atom_id=1, cart_id=0, places=5):
         import cupy as cp
         from pyscf.pbc import scf
+        from pyscf.pbc.gto.pseudo.pp_int import get_pp_nl
         from gpu4pyscf.pbc.grad.pp import vppnl_nuc_grad
 
         mf = scf.RHF(cell)
-        mf.max_cycle = 3
-        mf.conv_tol = 1e-8
+        mf.conv_tol = 1e-12
         mf.kernel()
         dm = mf.make_rdm1()
 
         grad = vppnl_nuc_grad(cell, cp.asarray(dm))
 
-        # Finite difference
         coords = cell.atom_coords().copy()
-        for sign, label in [(+1, 'plus'), (-1, 'minus')]:
+        energies = {}
+        for sign in (+1, -1):
             cell_d = cell.copy()
             coords_d = coords.copy()
             coords_d[atom_id, cart_id] += sign * disp
-            atom_list = []
-            for ia in range(cell.natm):
-                sym = cell.atom_symbol(ia)
-                atom_list.append([sym, coords_d[ia]])
-            cell_d.atom = atom_list
+            cell_d.atom = [[cell.atom_symbol(ia), coords_d[ia]]
+                           for ia in range(cell.natm)]
             cell_d.build()
-            mf_d = scf.RHF(cell_d)
-            mf_d.max_cycle = 3
-            mf_d.conv_tol = 1e-8
-            mf_d.kernel()
-            dm_d = mf_d.make_rdm1()
-            from pyscf.pbc.gto.pseudo.pp_int import get_pp_nl
             vppnl = get_pp_nl(cell_d)
-            e_d = np.einsum('ij,ji', vppnl, dm_d)
-            if sign == 1:
-                e_plus = e_d
-            else:
-                e_minus = e_d
+            energies[sign] = np.einsum('ij,ji', vppnl, dm).real
 
-        fd_grad = (e_plus - e_minus) / (2 * disp)
+        fd_grad = (energies[+1] - energies[-1]) / (2 * disp)
         self.assertAlmostEqual(
             grad[atom_id, cart_id], fd_grad, places,
-            f"FD check: analytical={grad[atom_id,cart_id]:.6e}, fd={fd_grad:.6e}")
+            f"FD check: analytical={grad[atom_id,cart_id]:.6e}, "
+            f"fd={fd_grad:.6e}, diff={grad[atom_id,cart_id]-fd_grad:.2e}")
 
     def test_carbon_fd(self):
-        self._fd_check(cell_c, atom_id=1, cart_id=0, places=2)
+        self._fd_check(cell_c, atom_id=1, cart_id=0, places=5)
 
     def test_silicon_fd(self):
-        self._fd_check(cell_si, atom_id=0, cart_id=2, places=4)
+        self._fd_check(cell_si, atom_id=0, cart_id=2, places=5)
+
+    def test_iron_fd(self):
+        self._fd_check(cell_fe, atom_id=1, cart_id=0, places=4)
 
 
 if __name__ == '__main__':

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
@@ -222,8 +222,6 @@ class TestFiniteDifference(unittest.TestCase):
             mf_d.conv_tol = 1e-8
             mf_d.kernel()
             dm_d = mf_d.make_rdm1()
-            fakecell_d, hl_d = fake_cell_vnl(cell_d)
-            ppnl_d = _int_vnl(cell_d, fakecell_d, hl_d, np.zeros((1, 3)))
             from pyscf.pbc.gto.pseudo.pp_int import get_pp_nl
             vppnl = get_pp_nl(cell_d)
             e_d = np.einsum('ij,ji', vppnl, dm_d)

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python
+# Copyright 2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GPU-accelerated GTH non-local pseudopotential gradient.
+
+Validates:
+1. Cross-basis integrals (_int_vnl_gpu) against CPU _int_vnl
+2. Full vppnl_nuc_grad against CPU reference
+3. Finite difference consistency
+4. Multiple elements (C, Si, Fe) covering s/p/d/f projectors
+5. Both gamma-point and k-point paths
+"""
+
+import unittest
+import numpy as np
+import pyscf
+from pyscf.pbc.gto.pseudo.pp_int import fake_cell_vnl, _int_vnl
+
+disp = 1e-4
+
+def setUpModule():
+    global cell_c, cell_si, cell_fe
+
+    # Carbon: s and p projectors, gth-szv (simple basis)
+    cell_c = pyscf.M(
+        atom=[['C', [0.0, 0.0, 0.0]], ['C', [1.885, 1.685, 1.585]]],
+        a='''
+        0.000000000, 3.370137329, 3.370137329
+        3.370137329, 0.000000000, 3.370137329
+        3.370137329, 3.370137329, 0.000000000''',
+        basis='gth-szv',
+        pseudo='gth-pade',
+        unit='bohr',
+        verbose=0,
+    )
+
+    # Silicon: s, p projectors with hl_dim=2 (tests r² integrals)
+    cell_si = pyscf.M(
+        atom=[['Si', [0.0, 0.0, 0.0]], ['Si', [2.5, 2.5, 0.0]]],
+        a=np.eye(3) * 8.0,
+        basis='gth-szv',
+        pseudo='gth-pade',
+        unit='bohr',
+        verbose=0,
+    )
+
+    # Iron: s, p, d projectors with hl_dim up to 2, f-orbitals in basis
+    cell_fe = pyscf.M(
+        atom=[['Fe', [0.0, 0.0, 0.0]], ['Fe', [2.71, 2.71, 2.71]]],
+        a=np.eye(3) * 5.42,
+        basis='gth-dzvp-molopt-sr',
+        pseudo='gth-pbe',
+        unit='bohr',
+        verbose=0,
+    )
+
+
+class TestCrossBasisIntegrals(unittest.TestCase):
+    """Test GPU _int_vnl_gpu against CPU _int_vnl for each element."""
+
+    def _compare_integrals(self, cell, intors=None, comp=1, places=6):
+        from gpu4pyscf.pbc.gto.pseudo.pp_int import _int_vnl_gpu
+        kpts = np.zeros((1, 3))
+        fakecell, hl_blocks = fake_cell_vnl(cell)
+
+        cpu = _int_vnl(cell, fakecell, hl_blocks, kpts, intors, comp)
+        gpu = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts, intors, comp)
+
+        for lvl in range(3):
+            c, g = cpu[lvl], gpu[lvl]
+            if len(c) == 0 and len(g) == 0:
+                continue
+            self.assertEqual(c.shape, g.shape,
+                             f"Shape mismatch at level {lvl}: CPU {c.shape} vs GPU {g.shape}")
+            err = np.max(np.abs(g - c))
+            self.assertAlmostEqual(err, 0, places,
+                                   f"Level {lvl} base integrals: max|err|={err:.2e}")
+
+    def test_carbon_base(self):
+        self._compare_integrals(cell_c)
+
+    def test_carbon_deriv(self):
+        self._compare_integrals(
+            cell_c,
+            ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2'),
+            comp=3)
+
+    def test_silicon_base(self):
+        self._compare_integrals(cell_si)
+
+    def test_silicon_deriv(self):
+        self._compare_integrals(
+            cell_si,
+            ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2'),
+            comp=3)
+
+    def test_iron_base(self):
+        self._compare_integrals(cell_fe, places=5)
+
+    def test_iron_deriv(self):
+        self._compare_integrals(
+            cell_fe,
+            ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2'),
+            comp=3, places=5)
+
+
+class TestVppnlNucGrad(unittest.TestCase):
+    """Test full vppnl_nuc_grad against CPU reference."""
+
+    def _compare_grad(self, cell, places=6):
+        import cupy as cp
+        from gpu4pyscf.pbc.grad.pp import vppnl_nuc_grad
+        from pyscf.pbc.gto.pseudo import pp_int as pyscf_pp_int
+
+        nao = cell.nao_nr()
+        np.random.seed(42)
+        dm = np.random.randn(nao, nao)
+        dm = dm + dm.T
+
+        # CPU reference: use pyscf's own vppnl_nuc_grad
+        grad_cpu = pyscf_pp_int.vppnl_nuc_grad(cell, dm)
+
+        # GPU
+        grad_gpu = vppnl_nuc_grad(cell, cp.asarray(dm))
+
+        err = np.max(np.abs(grad_gpu - grad_cpu))
+        grad_max = np.max(np.abs(grad_cpu))
+        self.assertAlmostEqual(err / max(grad_max, 1e-15), 0, places,
+                               f"Gradient error: max|err|={err:.2e}, |grad_max|={grad_max:.2e}")
+
+    def test_carbon(self):
+        self._compare_grad(cell_c)
+
+    def test_silicon(self):
+        self._compare_grad(cell_si)
+
+    def test_iron(self):
+        self._compare_grad(cell_fe, places=5)
+
+
+class TestFiniteDifference(unittest.TestCase):
+    """Validate gradient via finite difference of the PP energy."""
+
+    def _fd_check(self, cell, atom_id=1, cart_id=0, places=5):
+        import cupy as cp
+        from pyscf.pbc import scf
+        from gpu4pyscf.pbc.grad.pp import vppnl_nuc_grad
+
+        mf = scf.RHF(cell)
+        mf.max_cycle = 3
+        mf.conv_tol = 1e-8
+        mf.kernel()
+        dm = mf.make_rdm1()
+
+        grad = vppnl_nuc_grad(cell, cp.asarray(dm))
+
+        # Finite difference
+        coords = cell.atom_coords().copy()
+        for sign, label in [(+1, 'plus'), (-1, 'minus')]:
+            cell_d = cell.copy()
+            coords_d = coords.copy()
+            coords_d[atom_id, cart_id] += sign * disp
+            atom_list = []
+            for ia in range(cell.natm):
+                sym = cell.atom_symbol(ia)
+                atom_list.append([sym, coords_d[ia]])
+            cell_d.atom = atom_list
+            cell_d.build()
+            mf_d = scf.RHF(cell_d)
+            mf_d.max_cycle = 3
+            mf_d.conv_tol = 1e-8
+            mf_d.kernel()
+            dm_d = mf_d.make_rdm1()
+            fakecell_d, hl_d = fake_cell_vnl(cell_d)
+            ppnl_d = _int_vnl(cell_d, fakecell_d, hl_d, np.zeros((1, 3)))
+            from pyscf.pbc.gto.pseudo.pp_int import get_pp_nl
+            vppnl = get_pp_nl(cell_d)
+            e_d = np.einsum('ij,ji', vppnl, dm_d)
+            if sign == 1:
+                e_plus = e_d
+            else:
+                e_minus = e_d
+
+        fd_grad = (e_plus - e_minus) / (2 * disp)
+        self.assertAlmostEqual(
+            grad[atom_id, cart_id], fd_grad, places,
+            f"FD check: analytical={grad[atom_id,cart_id]:.6e}, fd={fd_grad:.6e}")
+
+    def test_carbon_fd(self):
+        self._fd_check(cell_c, atom_id=1, cart_id=0, places=2)
+
+    def test_silicon_fd(self):
+        self._fd_check(cell_si, atom_id=0, cart_id=2, places=4)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_pp_grad.py
@@ -16,17 +16,22 @@
 """Tests for GPU-accelerated GTH non-local pseudopotential gradient.
 
 Validates:
-1. Cross-basis integrals (_int_vnl_gpu) against CPU _int_vnl
-2. Full vppnl_nuc_grad against CPU reference
-3. Finite difference consistency
-4. Multiple elements (C, Si, Fe) covering s/p/d/f projectors
-5. Both gamma-point and k-point paths
+1. Cross-basis integrals (_int_vnl_gpu) against CPU _int_vnl  (gamma only —
+   _int_vnl_gpu intentionally implements only the gamma path; vppnl_nuc_grad
+   falls back to CPU _int_vnl at non-gamma k-points)
+2. Full vppnl_nuc_grad against CPU reference, gamma point
+3. Full vppnl_nuc_grad against CPU reference, non-zero k-points (single kpt
+   and a k-mesh) — validates the GPU contraction logic with multi-k-point
+   arrays of complex integrals from CPU _int_vnl
+4. Finite difference consistency, gamma point
+5. Multiple elements (C, Si, Fe) covering s/p/d/f projectors
 """
 
 import unittest
 import numpy as np
 import pyscf
 from pyscf.pbc.gto.pseudo.pp_int import fake_cell_vnl, _int_vnl
+from pyscf.pbc.lib.kpts_helper import gamma_point
 
 disp = 1e-4
 
@@ -67,43 +72,59 @@ def setUpModule():
     )
 
 
-def _cpu_vppnl_nuc_grad(cell, dm):
+def _cpu_vppnl_nuc_grad(cell, dm, kpts=None):
     """CPU reference gradient using only stable pyscf APIs (_int_vnl + numpy)."""
-    kpts = np.zeros((1, 3))
+    if kpts is None:
+        kpts_lst = np.zeros((1, 3))
+    else:
+        kpts_lst = np.reshape(kpts, (-1, 3))
+
     fakecell, hl_blocks = fake_cell_vnl(cell)
     intors_d = ('int1e_ipovlp', 'int1e_r2_origi_ip2', 'int1e_r4_origi_ip2')
-    ppnl_half = _int_vnl(cell, fakecell, hl_blocks, kpts)
-    ppnl_half_ip2 = _int_vnl(cell, fakecell, hl_blocks, kpts, intors_d, comp=3)
+    ppnl_half = _int_vnl(cell, fakecell, hl_blocks, kpts_lst)
+    ppnl_half_ip2 = _int_vnl(cell, fakecell, hl_blocks, kpts_lst, intors_d, comp=3)
     if len(ppnl_half_ip2[0]) > 0:
-        ppnl_half_ip2[0][0] *= -1
+        for k in range(len(kpts_lst)):
+            ppnl_half_ip2[0][k] *= -1
 
+    nkpts = len(kpts_lst)
     nao = cell.nao_nr()
-    dm_dmH = dm + dm.T
-    grad = np.zeros([cell.natm, 3])
-    dppnl = np.zeros((1, 3, nao, nao), dtype=np.complex128)
-    offset = [0] * 3
-    for ib, hl in enumerate(hl_blocks):
-        l = fakecell.bas_angular(ib)
-        nd = 2 * l + 1
-        hl_dim = hl.shape[0]
-        ilp = np.zeros((hl_dim, nd, nao), dtype=np.complex128)
-        dilp = np.zeros((hl_dim, 3, nd, nao), dtype=np.complex128)
-        for i in range(hl_dim):
-            p0 = offset[i]
-            if len(ppnl_half[i]) > 0:
-                ilp[i] = ppnl_half[i][0][p0:p0+nd]
-            if len(ppnl_half_ip2[i]) > 0:
-                dilp[i] = ppnl_half_ip2[i][0][:, p0:p0+nd]
-            offset[i] = p0 + nd
-        dppnl_k = np.einsum('idlp,ij,jlq->dpq', dilp.conj(), hl, ilp)
-        dppnl[0] += dppnl_k
-        i_pp_atom = fakecell._bas[ib, 0]
-        grad[i_pp_atom] += np.einsum('dpq,qp->d', dppnl_k, dm_dmH).real
+
+    dm = np.asarray(dm).reshape(-1, nao, nao)
+    if gamma_point(kpts_lst):
+        dm = dm.real
+    dm_dmH = dm + dm.transpose(0, 2, 1).conj()
+
+    grad = np.zeros([cell.natm, 3], dtype=np.complex128)
+    dppnl = np.zeros((nkpts, 3, nao, nao), dtype=np.complex128)
+
+    for k in range(nkpts):
+        offset = [0] * 3
+        for ib, hl in enumerate(hl_blocks):
+            l = fakecell.bas_angular(ib)
+            nd = 2 * l + 1
+            hl_dim = hl.shape[0]
+            ilp = np.zeros((hl_dim, nd, nao), dtype=np.complex128)
+            dilp = np.zeros((hl_dim, 3, nd, nao), dtype=np.complex128)
+            for i in range(hl_dim):
+                p0 = offset[i]
+                if len(ppnl_half[i]) > 0:
+                    ilp[i] = ppnl_half[i][k, p0:p0+nd]
+                if len(ppnl_half_ip2[i]) > 0:
+                    dilp[i] = ppnl_half_ip2[i][k, :, p0:p0+nd]
+                offset[i] = p0 + nd
+            dppnl_k = np.einsum('idlp,ij,jlq->dpq', dilp.conj(), hl, ilp)
+            dppnl[k] += dppnl_k
+            i_pp_atom = fakecell._bas[ib, 0]
+            grad[i_pp_atom] += np.einsum('dpq,qp->d', dppnl_k, dm_dmH[k])
+
     aoslices = cell.aoslice_by_atom()
     for ia in range(cell.natm):
         p0, p1 = aoslices[ia][2:]
-        grad[ia] -= np.einsum('kdpq,kqp->d', dppnl[:, :, p0:p1, :], dm_dmH[None, :, p0:p1]).real
-    return grad
+        grad[ia] -= np.einsum('kdpq,kqp->d', dppnl[:, :, p0:p1, :],
+                              dm_dmH[:, :, p0:p1])
+
+    return grad.real
 
 
 class TestCrossBasisIntegrals(unittest.TestCase):
@@ -187,6 +208,65 @@ class TestVppnlNucGrad(unittest.TestCase):
 
     def test_iron(self):
         self._compare_grad(cell_fe, places=5)
+
+
+class TestVppnlNucGradKpts(unittest.TestCase):
+    """Test full vppnl_nuc_grad with non-zero k-points."""
+
+    @staticmethod
+    def _build_random_dm_kpts(nao, nkpts, seed=42):
+        """Build a hermitian-per-k random complex DM, shape (nkpts, nao, nao)."""
+        rng = np.random.default_rng(seed)
+        dm = np.zeros((nkpts, nao, nao), dtype=np.complex128)
+        for k in range(nkpts):
+            a = rng.standard_normal((nao, nao)) + 1j * rng.standard_normal((nao, nao))
+            dm[k] = a + a.conj().T  # hermitian
+        return dm
+
+    def _compare_grad_kpts(self, cell, kpts, places=6):
+        import cupy as cp
+        from gpu4pyscf.pbc.grad.pp import vppnl_nuc_grad
+
+        nao = cell.nao_nr()
+        nkpts = len(kpts)
+        dm = self._build_random_dm_kpts(nao, nkpts)
+
+        grad_cpu = _cpu_vppnl_nuc_grad(cell, dm, kpts=kpts)
+        grad_gpu = vppnl_nuc_grad(cell, cp.asarray(dm), kpts=kpts)
+
+        err = np.max(np.abs(grad_gpu - grad_cpu))
+        grad_max = np.max(np.abs(grad_cpu))
+        self.assertAlmostEqual(err / max(grad_max, 1e-15), 0, places,
+                               f"Gradient error at {nkpts} kpts: "
+                               f"max|err|={err:.2e}, |grad_max|={grad_max:.2e}")
+
+    def test_carbon_single_kpt(self):
+        # Single non-zero kpt in 1/Bohr (~midpoint of the BZ)
+        kpts = np.array([[0.1, 0.2, 0.3]])
+        self._compare_grad_kpts(cell_c, kpts)
+
+    def test_carbon_kpts_mesh(self):
+        # 2x2x2 Monkhorst-Pack mesh — 8 k-points, including gamma. Even though
+        # the list contains gamma, gamma_point(kpts_lst) is False for any list
+        # not entirely at gamma, so vppnl_nuc_grad takes the CPU-_int_vnl path
+        # and contracts on GPU — same code path as the single non-zero kpt test
+        # but with 8 k-points instead of 1.
+        kpts = cell_c.make_kpts([2, 2, 2])
+        self._compare_grad_kpts(cell_c, kpts)
+
+    def test_silicon_single_kpt(self):
+        kpts = np.array([[0.1, 0.2, 0.3]])
+        self._compare_grad_kpts(cell_si, kpts)
+
+    def test_silicon_kpts_mesh(self):
+        kpts = cell_si.make_kpts([2, 2, 2])
+        self._compare_grad_kpts(cell_si, kpts)
+
+    def test_iron_single_kpt(self):
+        # Fe exercises the d-projector hl_dim=2 path with a complex DM.
+        # Loose tolerance (places=5) consistent with TestVppnlNucGrad gamma case.
+        kpts = np.array([[0.1, 0.2, 0.3]])
+        self._compare_grad_kpts(cell_fe, kpts, places=5)
 
 
 class TestFiniteDifference(unittest.TestCase):

--- a/gpu4pyscf/pbc/gto/int1e.py
+++ b/gpu4pyscf/pbc/gto/int1e.py
@@ -39,6 +39,10 @@ __all__ = [
     'int1e_kin',
     'int1e_ipovlp',
     'int1e_ipkin',
+    'int1e_r2_origi',
+    'int1e_r4_origi',
+    'int1e_r2_origi_ip2',
+    'int1e_r4_origi_ip2',
     'ovlp_strain_deriv',
     'kin_strain_deriv',
 ]
@@ -47,6 +51,10 @@ libpbc.PBCint1e_ovlp.restype = ctypes.c_int
 libpbc.PBCint1e_kin.restype = ctypes.c_int
 libpbc.PBCint1e_ipovlp.restype = ctypes.c_int
 libpbc.PBCint1e_ipkin.restype = ctypes.c_int
+libpbc.PBCint1e_r2_origi.restype = ctypes.c_int
+libpbc.PBCint1e_r4_origi.restype = ctypes.c_int
+libpbc.PBCint1e_r2_origi_ip2.restype = ctypes.c_int
+libpbc.PBCint1e_r4_origi_ip2.restype = ctypes.c_int
 
 def int1e_ovlp(cell, kpts=None, bvk_kmesh=None, sort_output=True):
     # Tighten the precision of overlap integrals because errors in overlap
@@ -69,6 +77,22 @@ def int1e_ipovlp(cell, kpts=None, bvk_kmesh=None, sort_output=True):
 def int1e_ipkin(cell, kpts=None, bvk_kmesh=None, sort_output=True):
     opt = _check_opt(cell, 0, kpts, bvk_kmesh, 1e-2)
     return opt.intor('PBCint1e_ipkin', 3, (3, 0), kpts, sort_output)
+
+def int1e_r2_origi(cell, kpts=None, bvk_kmesh=None, sort_output=True):
+    opt = _check_opt(cell, 1, kpts, bvk_kmesh, 1e-1)
+    return opt.intor('PBCint1e_r2_origi', 1, (0, 2), kpts, sort_output)
+
+def int1e_r4_origi(cell, kpts=None, bvk_kmesh=None, sort_output=True):
+    opt = _check_opt(cell, 1, kpts, bvk_kmesh, 1e-1)
+    return opt.intor('PBCint1e_r4_origi', 1, (0, 4), kpts, sort_output)
+
+def int1e_r2_origi_ip2(cell, kpts=None, bvk_kmesh=None, sort_output=True):
+    opt = _check_opt(cell, 0, kpts, bvk_kmesh, 1e-1)
+    return opt.intor('PBCint1e_r2_origi_ip2', 3, (0, 3), kpts, sort_output)
+
+def int1e_r4_origi_ip2(cell, kpts=None, bvk_kmesh=None, sort_output=True):
+    opt = _check_opt(cell, 0, kpts, bvk_kmesh, 1e-1)
+    return opt.intor('PBCint1e_r4_origi_ip2', 3, (0, 5), kpts, sort_output)
 
 def ovlp_strain_deriv(cell, dm, kpts=None):
     assert isinstance(cell, Cell)

--- a/gpu4pyscf/pbc/gto/pseudo/pp_int.py
+++ b/gpu4pyscf/pbc/gto/pseudo/pp_int.py
@@ -1,3 +1,17 @@
+# Copyright 2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """GPU cross-basis integrals for GTH pseudopotentials via merged Cell + SortedGTO."""
 import numpy as np
 from pyscf import gto, lib

--- a/gpu4pyscf/pbc/gto/pseudo/pp_int.py
+++ b/gpu4pyscf/pbc/gto/pseudo/pp_int.py
@@ -1,0 +1,60 @@
+"""GPU cross-basis integrals for GTH pseudopotentials via merged Cell + SortedGTO."""
+import numpy as np
+from pyscf import gto, lib
+from pyscf.pbc.gto.cell import _estimate_rcut
+from gpu4pyscf.gto.mole import most_diffuse_pgto
+from gpu4pyscf.pbc.gto.int1e import _Int1eOpt
+
+
+def _int_vnl_gpu(cell, fakecell, hl_blocks, kpts, intors=None, comp=1):
+    if intors is None:
+        intors = ['int1e_ovlp', 'int1e_r2_origi', 'int1e_r4_origi']
+
+    kern_map = {
+        'int1e_ovlp':         ('PBCint1e_ovlp',         1, (0, 0)),
+        'int1e_r2_origi':     ('PBCint1e_r2_origi',     1, (0, 2)),
+        'int1e_r4_origi':     ('PBCint1e_r4_origi',     1, (0, 4)),
+        'int1e_ipovlp':       ('PBCint1e_ipovlp',       3, (1, 0)),
+        'int1e_r2_origi_ip2': ('PBCint1e_r2_origi_ip2', 3, (0, 3)),
+        'int1e_r4_origi_ip2': ('PBCint1e_r4_origi_ip2', 3, (0, 5)),
+    }
+
+    hl_dims = np.asarray([len(hl) for hl in hl_blocks])
+
+    def int_ket(_bas_fake, intor_name):
+        if len(_bas_fake) == 0:
+            return []
+
+        kern_name, expected_comp, deriv_ij = kern_map[intor_name]
+
+        atm_m, bas_m, env_m = gto.conc_env(
+            cell._atm, cell._bas, cell._env,
+            fakecell._atm, _bas_fake, fakecell._env)
+
+        merged = cell.copy(deep=False)
+        merged._atm = np.asarray(atm_m, dtype=np.int32)
+        merged._bas = np.asarray(bas_m, dtype=np.int32)
+        merged._env = np.asarray(env_m, dtype=np.float64)
+        merged._built = True
+
+        bvk_kmesh = np.ones(3, dtype=int)
+        a, c, l = most_diffuse_pgto(merged)
+        precision = merged.precision * 1e-1
+        rcut = _estimate_rcut(a, l, c, precision)
+        with lib.temporary_env(merged, precision=precision, rcut=rcut):
+            opt = _Int1eOpt(merged, hermi=0, bvk_kmesh=bvk_kmesh)
+
+        mat = opt.intor(kern_name, expected_comp, deriv_ij, None, True).get()
+
+        ao_loc = gto.moleintor.make_loc(bas_m, 'int1e_ovlp_sph')
+        i0 = ao_loc[cell.nbas]
+        j1 = ao_loc[cell.nbas]
+
+        if expected_comp == 1:
+            return mat[i0:, :j1][np.newaxis].astype(np.complex128)
+        else:
+            return mat[:, i0:, :j1][np.newaxis].astype(np.complex128)
+
+    return (int_ket(fakecell._bas[hl_dims > 0], intors[0]),
+            int_ket(fakecell._bas[hl_dims > 1], intors[1]),
+            int_ket(fakecell._bas[hl_dims > 2], intors[2]))


### PR DESCRIPTION
Add CUDA kernels for int1e_r2_origi, int1e_r4_origi and ip2 derivatives in overlap.cu. GPU-accelerate vppnl_nuc_grad via merged-Cell cross-basis integrals and cupy contraction.

Tests added for C, Si, Fe (cross-basis integrals, full gradient vs CPU,
finite difference).