### PR TITLE
Optimize XC gradient with grid response

### DIFF
--- a/gpu4pyscf/dft/gen_grid.py
+++ b/gpu4pyscf/dft/gen_grid.py
@@ -470,7 +470,7 @@ class Grids(lib.StreamObject):
     def size(self):
         return getattr(self.weights, 'size', 0)
 
-    def build(self, mol=None, with_non0tab=False, sort_grids=True, **kwargs):
+    def build(self, mol=None, with_non0tab=False, sort_grids=True, sort_grids_of_each_atom=False, **kwargs):
         if mol is None: mol = self.mol
         if self.verbose >= logger.WARN:
             self.check_sanity()
@@ -493,25 +493,83 @@ class Grids(lib.StreamObject):
         self.quadrature_weights = quadrature_weights
 
         t0 = log.timer_debug1('generating atomic grids', *t0)
-        if self.alignment > 1:
-            padding = _padding_size(self.size, self.alignment)
-            log.debug('Padding %d grids', padding)
-            if padding > 0:
-                # cupy.vstack and cupy.hstack convert numpy array into cupy array first
-                self.coords = cupy.vstack(
-                    [self.coords, cupy.full((padding, 3), 1e-4)])
-                self.weights = cupy.hstack([self.weights, cupy.zeros(padding)])
-                self.quadrature_weights = cupy.hstack([self.quadrature_weights, cupy.zeros(padding)])
-                self.atm_idx = cupy.hstack([self.atm_idx, cupy.full(padding, -1, dtype=numpy.int32)])
 
-        if sort_grids:
-            #idx = arg_group_grids(mol, self.coords)
-            idx = atomic_group_grids(mol, self.coords)
-            self.coords = self.coords[idx]
-            self.weights = self.weights[idx]
-            self.quadrature_weights = self.quadrature_weights[idx]
-            self.atm_idx = self.atm_idx[idx]
-            t0 = log.timer_debug1('sorting grids', *t0)
+        if sort_grids or sort_grids_of_each_atom:
+            assert self.alignment > 1 and self.alignment % 128 == 0
+
+        if sort_grids_of_each_atom:
+            grid_offsets_of_atom = np.zeros((mol.natm + 1), dtype = np.int32)
+            p0 = p1 = 0
+            for i_atom in range(mol.natm):
+                r, vol = atom_grids_tab[mol.atom_symbol(i_atom)]
+                p0, p1 = p1, p1 + vol.size
+                grid_offsets_of_atom[i_atom + 1] = p1
+
+            coords_atom_padded = []
+            weights_atom_padded = []
+            quadrature_weights_atom_padded = []
+            atm_idx_atom_padded = []
+
+            # For each atom we round the number of grid to multiple of block_size, which is 4096 by default.
+            # This guarantees all grids for each atom reside under the same block when determining sparsity.
+            # This can increase the memory usage by 4095*natm at most, which is a huge number for small grids, like SG1.
+            from gpu4pyscf.dft import numint
+            block_size = numint.MIN_BLK_SIZE
+            atomic_alignment = ((block_size + self.alignment - 1) // self.alignment) * self.alignment
+
+            for i_atom in range(mol.natm):
+                g0 = int(grid_offsets_of_atom[i_atom])
+                g1 = int(grid_offsets_of_atom[i_atom + 1])
+
+                atomic_coords = self.coords[g0:g1, :]
+                atomic_weights = self.weights[g0:g1]
+                atomic_quadrature_weights = self.quadrature_weights[g0:g1]
+                assert atomic_coords.shape == (g1-g0, 3)
+
+                n_with_padded = (((g1-g0) + atomic_alignment - 1) // atomic_alignment) * atomic_alignment
+                n_pad = n_with_padded - (g1-g0)
+                atomic_coords = cupy.vstack([atomic_coords, cupy.broadcast_to(self.coords[-1, :], (n_pad, 3))])
+                atomic_weights = cupy.hstack([atomic_weights, cupy.zeros(n_pad)])
+                atomic_quadrature_weights = cupy.hstack([atomic_quadrature_weights, cupy.zeros(n_pad)])
+
+                sorting_idx = atomic_group_grids(mol, atomic_coords)
+
+                atomic_coords = atomic_coords[sorting_idx]
+                atomic_weights = atomic_weights[sorting_idx]
+                atomic_quadrature_weights = atomic_quadrature_weights[sorting_idx]
+
+                atomic_idx = cupy.full(n_with_padded, i_atom, dtype = cupy.int32)
+
+                coords_atom_padded.append(atomic_coords)
+                weights_atom_padded.append(atomic_weights)
+                quadrature_weights_atom_padded.append(atomic_quadrature_weights)
+                atm_idx_atom_padded.append(atomic_idx)
+
+            self.coords = cupy.vstack(coords_atom_padded)
+            self.weights = cupy.hstack(weights_atom_padded)
+            self.quadrature_weights = cupy.hstack(quadrature_weights_atom_padded)
+            self.atm_idx = cupy.hstack(atm_idx_atom_padded)
+
+        else:
+            if self.alignment > 1:
+                padding = _padding_size(self.size, self.alignment)
+                log.debug('Padding %d grids', padding)
+                if padding > 0:
+                    # cupy.vstack and cupy.hstack convert numpy array into cupy array first
+                    self.coords = cupy.vstack(
+                        [self.coords, cupy.full((padding, 3), 1e-4)])
+                    self.weights = cupy.hstack([self.weights, cupy.zeros(padding)])
+                    self.quadrature_weights = cupy.hstack([self.quadrature_weights, cupy.zeros(padding)])
+                    self.atm_idx = cupy.hstack([self.atm_idx, cupy.full(padding, -1, dtype=numpy.int32)])
+
+            if sort_grids:
+                #idx = arg_group_grids(mol, self.coords)
+                idx = atomic_group_grids(mol, self.coords)
+                self.coords = self.coords[idx]
+                self.weights = self.weights[idx]
+                self.quadrature_weights = self.quadrature_weights[idx]
+                self.atm_idx = self.atm_idx[idx]
+                t0 = log.timer_debug1('sorting grids', *t0)
 
         if with_non0tab:
             self.non0tab = self.make_mask(mol, self.coords)

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -793,29 +793,8 @@ def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=
 
     return exc1, 0
 
-# JCP 98, 5612 (1993); DOI:10.1063/1.464906
 def grids_response_cc(grids):
-    # Notice: the returned grid order could be different from pyscf.grad.rks.grids_response_cc()!
-    mol = grids.mol
-
-    grid_to_atom_index_map = grids.atm_idx
-    atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(mol.natm)]
-    grid_to_atom_index_map = None
-
-    from gpu4pyscf.hessian.rks import get_dweight_dA # Avoid circular dependency
-
-    for i_atom in range(mol.natm):
-        i_g = atom_to_grid_index_map[i_atom]
-        fake_grids = type('FakeGrid', (object,), {})()
-        fake_grids.coords = grids.coords[i_g, :]
-        fake_grids.weights = grids.weights[i_g]
-        fake_grids.quadrature_weights = grids.quadrature_weights[i_g]
-        fake_grids.atm_idx = cupy.zeros(len(i_g), dtype = cupy.int32) + i_atom
-        fake_grids.atomic_radii = grids.atomic_radii
-        fake_grids.radii_adjust = grids.radii_adjust
-        fake_grids.becke_scheme = grids.becke_scheme
-        dw_dA_i = get_dweight_dA(mol, fake_grids)
-        yield fake_grids.coords, fake_grids.weights, dw_dA_i
+    raise NotImplementedError("grids_response_cc() in GPU4PySCF is not used or tested anymore")
 
 def grids_noresponse_cc(grids):
     raise NotImplementedError("grids_noresponse_cc() in GPU4PySCF is not used or tested anymore")

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -417,91 +417,134 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     '''Full response including the response of the grids'''
     log = logger.new_logger(mol, verbose)
     xctype = ni._xc_type(xc_code)
-    opt = getattr(ni, 'gdftopt', None)
-    if opt is None:
-        ni.build(mol, grids.coords)
-        opt = ni.gdftopt
+
+    grids.build(sort_grids_of_each_atom = True)
+    # grids.build(sort_grids = False)
+    ngrids = grids.coords.shape[0]
+
+    ni.gdftopt = None
+    ni.build(mol, grids.coords)
+    opt = ni.gdftopt
+
     natm = mol.natm
     mol = None
     _sorted_mol = opt._sorted_mol
     nao = _sorted_mol.nao
     dms = cupy.asarray(dms)
     assert dms.ndim == 2
-    #:dms = cupy.einsum('pi,ij,qj->pq', coeff, dms, coeff)
     dms = opt.sort_orbitals(dms, axis=[0,1])
 
-    excsum = cupy.zeros((natm, 3))
-    vmat = cupy.zeros((3,nao,nao))
+    de_grid_response_rho = cupy.zeros((natm, 3))
+    dvmat_orbital_response = cupy.zeros((3, nao, nao))
 
     if xctype == 'LDA':
+        ao_deriv = 0
+        ncomp = 1
+    elif xctype == 'GGA':
         ao_deriv = 1
+        ncomp = 4
+    elif xctype == 'MGGA':
+        ao_deriv = 1
+        ncomp = 5
     else:
-        ao_deriv = 2
+        raise NotImplementedError(f"Unrecognized xctype = {xctype}")
 
-    mem_avail = get_avail_mem()
-    comp = (ao_deriv+1)*(ao_deriv+2)*(ao_deriv+3)//6
-    block_size = int((mem_avail*.4/8/(comp+1)/nao - 3*nao*2)/ ALIGNED) * ALIGNED
-    block_size = min(block_size, MIN_BLK_SIZE)
-    log.debug1('Available GPU mem %f Mb, block_size %d', mem_avail/1e6, block_size)
+    rho = cupy.empty([ncomp, ngrids])
+    g1 = 0
+    for split_ao, ao_mask_index, split_weights, split_coords in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
+        g0, g1 = g1, g1 + split_weights.size
+        dms_masked = dms[ao_mask_index[:,None], ao_mask_index]
+        rho[:, g0:g1] = numint.eval_rho(_sorted_mol, split_ao, dms_masked, xctype = xctype, hermi = 1)
 
-    if block_size < ALIGNED:
-        raise RuntimeError('Not enough GPU memory')
+    exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
+    exc = exc[:,0]
+    wv = grids.weights * vxc
+    nonzero_weight_mask = cupy.abs(grids.weights) > 1e-14
 
-    for atm_id, (coords, weight, weight1) in enumerate(grids_response_cc(grids)):
-        ngrids = weight.size
-        for p0, p1 in lib.prange(0,ngrids,block_size):
-            ao = numint.eval_ao(_sorted_mol, coords[p0:p1, :], ao_deriv, gdftopt=opt, transpose=False)
+    from gpu4pyscf.hessian.rks import get_dweight_dA
 
-            if xctype == 'LDA':
-                rho = numint.eval_rho(_sorted_mol, ao[0], dms,
-                                        xctype=xctype, hermi=1, with_lapl=False)
-                exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
-                exc = exc[:,0]
-                wv = weight[p0:p1] * vxc[0]
-                aow = numint._scale_ao(ao[0], wv)
-                vtmp = _d1_dot_(ao[1:4], aow.T)
-                vmat += vtmp
-                # response of weights
-                excsum += cupy.einsum('r,nxr->nx', exc*rho, weight1[:,:,p0:p1])
-                # response of grids coordinates
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms) * 2
-                rho = vxc = aow = None
+    de_grid_response_weight = cupy.zeros((natm, 3))
+    dweightdA_right = rho[0] * exc
 
-            elif xctype == 'GGA':
-                rho = numint.eval_rho(_sorted_mol, ao[:4], dms,
-                                        xctype=xctype, hermi=1, with_lapl=False)
-                exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
-                exc = exc[:,0]
-                wv = weight[p0:p1] * vxc
-                wv[0] *= .5
-                vtmp = _gga_grad_sum_(ao, wv)
-                vmat += vtmp
-                excsum += cupy.einsum('r,nxr->nx', exc*rho[0], weight1[:,:,p0:p1])
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms) * 2
-                rho = vxc = None
+    available_gpu_memory = get_avail_mem()
+    available_gpu_memory = int(available_gpu_memory * 0.1) # Don't use too much gpu memory
+    ao_nbytes_per_grid = ((2*3) * natm) * 8
+    ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
+    if ngrids_per_batch < 16:
+        raise MemoryError(f"Out of GPU memory for XC energy first derivative, available gpu memory = {get_avail_mem()}"
+                          f" bytes, nao = {nao}, natm = {natm}, ngrids (nonzero rho) = {ngrids}")
+    ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
+    ### Don't split the batch too small for get_dweight_dA()
+    # ngrids_per_batch = min(ngrids_per_batch, MIN_BLK_SIZE)
 
-            elif xctype == 'NLC':
-                raise NotImplementedError
+    for g0 in range(0, ngrids, ngrids_per_batch):
+        g1 = min(g0 + ngrids_per_batch, ngrids)
+        dweight_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+        de_grid_response_weight += cupy.einsum("Adg->Ad", dweight_dA * dweightdA_right[g0:g1])
+    del dweight_dA
+    del dweightdA_right
+    del exc
 
-            elif xctype == 'MGGA':
-                rho = numint.eval_rho(_sorted_mol, ao, dms,
-                                        xctype=xctype, hermi=1, with_lapl=False)
-                exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
-                exc = exc[:,0]
-                wv = weight[p0:p1] * vxc
-                wv[0] *= .5
-                wv[4] *= .5  # for the factor 1/2 in tau
+    dm_mask_buf = cupy.empty(nao*nao)
 
-                vtmp  = _gga_grad_sum_(ao, wv)
-                _tau_grad_dot_(ao, wv[4], accumulate=True, out=vtmp)
-                vmat += vtmp
-                excsum += cupy.einsum('r,nxr->nx', exc*rho[0], weight1[:,:,p0:p1])
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms) * 2
-                rho = vxc = None
+    g0 = 0
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1):
+        g1 = g0 + weight.shape[0]
 
+        ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+        if ao.size == 0:
+            g0 = g1
+            continue
+
+        dms_masked = take_last2d(dms, idx, out=dm_mask_buf)
+
+        i_atom = int(grids.atm_idx[g0])
+        assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+        if xctype == 'LDA':
+            split_wv = cupy.ascontiguousarray(wv[:, g0:g1][:, nonzero_weight_mask[g0:g1]])
+
+            aow = numint._scale_ao(ao[0], split_wv[0])
+            vtmp = _d1_dot_(ao[1:4], aow.T)
+
+            dvmat_orbital_response[:, idx[:,None], idx] += vtmp
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dms_masked) * 2
+
+        elif xctype == 'GGA':
+            split_wv = cupy.ascontiguousarray(wv[:, g0:g1][:, nonzero_weight_mask[g0:g1]])
+            split_wv[0] *= .5
+
+            vtmp = _gga_grad_sum_(ao, split_wv)
+
+            dvmat_orbital_response[:, idx[:,None], idx] += vtmp
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dms_masked) * 2
+
+        elif xctype == 'NLC':
+            raise ValueError("You see a bug, please report to the developer team.")
+
+        elif xctype == 'MGGA':
+            split_wv = cupy.ascontiguousarray(wv[:, g0:g1][:, nonzero_weight_mask[g0:g1]])
+            split_wv[0] *= .5
+            split_wv[4] *= .5 # for the factor 1/2 in tau
+
+            vtmp = _gga_grad_sum_(ao, split_wv)
+            _tau_grad_dot_(ao, split_wv[4], accumulate=True, out=vtmp)
+
+            dvmat_orbital_response[:, idx[:,None], idx] += vtmp
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dms_masked) * 2
+
+        else:
+            raise NotImplementedError(f"Unrecognized xctype = {xctype}")
+
+        g0 = g1
+
+    excsum = de_grid_response_weight + de_grid_response_rho
+    excsum = excsum.get()
     # - sign because nabla_X = -nabla_x
-    exc1 = -.5 * rhf_grad.contract_h1e_dm(opt._sorted_mol, vmat, dms, hermi=1)
-    return excsum.get(), exc1
+    excsum -= rhf_grad.contract_h1e_dm(opt._sorted_mol, dvmat_orbital_response, dms, hermi=1)
+
+    return excsum, 0
 
 def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
                               max_memory=2000, verbose=None):
@@ -512,11 +555,9 @@ def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=
 
     grids.build(sort_grids = False)
 
-    # xctype = ni._xc_type(xc_code)
-    opt = getattr(ni, 'gdftopt', None)
-    if opt is None:
-        ni.build(mol, grids.coords)
-        opt = ni.gdftopt
+    ni.gdftopt = None
+    ni.build(mol, grids.coords)
+    opt = ni.gdftopt
 
     _sorted_mol = opt._sorted_mol
     nao = _sorted_mol.nao

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -416,10 +416,10 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
                           max_memory=2000, verbose=None):
     '''Full response including the response of the grids'''
     log = logger.new_logger(mol, verbose)
+    t0 = log.init_timer()
     xctype = ni._xc_type(xc_code)
 
     grids.build(sort_grids_of_each_atom = True)
-    # grids.build(sort_grids = False)
     ngrids = grids.coords.shape[0]
 
     ni.gdftopt = None
@@ -436,6 +436,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     de_grid_response_rho = cupy.zeros((natm, 3))
     dvmat_orbital_response = cupy.zeros((3, nao, nao))
+    dm_mask_buf = cupy.empty(nao*nao)
 
     if xctype == 'LDA':
         ao_deriv = 0
@@ -451,10 +452,10 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     rho = cupy.empty([ncomp, ngrids])
     g1 = 0
-    for split_ao, ao_mask_index, split_weights, split_coords in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
-        g0, g1 = g1, g1 + split_weights.size
-        dms_masked = dms[ao_mask_index[:,None], ao_mask_index]
-        rho[:, g0:g1] = numint.eval_rho(_sorted_mol, split_ao, dms_masked, xctype = xctype, hermi = 1)
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
+        g0, g1 = g1, g1 + weight.size
+        dms_masked = take_last2d(dms, idx, out=dm_mask_buf)
+        rho[:, g0:g1] = numint.eval_rho(_sorted_mol, ao, dms_masked, xctype = xctype, hermi = 1)
 
     exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
     exc = exc[:,0]
@@ -465,6 +466,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     de_grid_response_weight = cupy.zeros((natm, 3))
     dweightdA_right = rho[0] * exc
+    del rho
 
     available_gpu_memory = get_avail_mem()
     available_gpu_memory = int(available_gpu_memory * 0.1) # Don't use too much gpu memory
@@ -484,8 +486,6 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     del dweight_dA
     del dweightdA_right
     del exc
-
-    dm_mask_buf = cupy.empty(nao*nao)
 
     g0 = 0
     for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1):
@@ -515,7 +515,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
             split_wv = cupy.ascontiguousarray(wv[:, g0:g1][:, nonzero_weight_mask[g0:g1]])
             split_wv[0] *= .5
 
-            vtmp = _gga_grad_sum_(ao, split_wv)
+            vtmp = _gga_grad_sum_(ao, split_wv[:4])
 
             dvmat_orbital_response[:, idx[:,None], idx] += vtmp
             de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dms_masked) * 2
@@ -528,7 +528,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
             split_wv[0] *= .5
             split_wv[4] *= .5 # for the factor 1/2 in tau
 
-            vtmp = _gga_grad_sum_(ao, split_wv)
+            vtmp = _gga_grad_sum_(ao, split_wv[:4])
             _tau_grad_dot_(ao, split_wv[4], accumulate=True, out=vtmp)
 
             dvmat_orbital_response[:, idx[:,None], idx] += vtmp
@@ -544,6 +544,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     # - sign because nabla_X = -nabla_x
     excsum -= rhf_grad.contract_h1e_dm(opt._sorted_mol, dvmat_orbital_response, dms, hermi=1)
 
+    log.timer_debug1('rks grad vxc full response', *t0)
     return excsum, 0
 
 def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,

--- a/gpu4pyscf/grad/uks.py
+++ b/gpu4pyscf/grad/uks.py
@@ -258,11 +258,16 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
                           max_memory=2000, verbose=None):
     '''Full response including the response of the grids'''
     log = logger.new_logger(mol, verbose)
+    t0 = log.init_timer()
     xctype = ni._xc_type(xc_code)
-    opt = getattr(ni, 'gdftopt', None)
-    if opt is None:
-        ni.build(mol, grids.coords)
-        opt = ni.gdftopt
+
+    grids.build(sort_grids_of_each_atom = True)
+    ngrids = grids.coords.shape[0]
+
+    ni.gdftopt = None
+    ni.build(mol, grids.coords)
+    opt = ni.gdftopt
+
     natm = mol.natm
     mol = None
     _sorted_mol = opt._sorted_mol
@@ -271,94 +276,135 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     assert dms.ndim == 3 and dms.shape[0] == 2
     dms = opt.sort_orbitals(dms.reshape(-1,nao,nao), axis=[1,2])
 
-    excsum = cupy.zeros((natm, 3))
-    vmat = cupy.zeros((2,3,nao,nao))
+    de_grid_response_rho = cupy.zeros((natm, 3))
+    dvmat_orbital_response = cupy.zeros((2, 3, nao, nao))
+    dm_mask_buf = cupy.empty(nao*nao)
 
     if xctype == 'LDA':
+        ao_deriv = 0
+        ncomp = 1
+    elif xctype == 'GGA':
         ao_deriv = 1
+        ncomp = 4
+    elif xctype == 'MGGA':
+        ao_deriv = 1
+        ncomp = 5
     else:
-        ao_deriv = 2
+        raise NotImplementedError(f"Unrecognized xctype = {xctype}")
 
-    mem_avail = get_avail_mem()
-    comp = (ao_deriv+1)*(ao_deriv+2)*(ao_deriv+3)//6
-    block_size = int((mem_avail*.4/8/(comp+1)/nao - 3*nao*2)/ ALIGNED) * ALIGNED
-    block_size = min(block_size, MIN_BLK_SIZE)
-    log.debug1('Available GPU mem %f Mb, block_size %d', mem_avail/1e6, block_size)
+    rho = cupy.empty([2, ncomp, ngrids])
+    g1 = 0
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
+        g0, g1 = g1, g1 + weight.size
+        dma_masked = take_last2d(dms[0], idx, out=dm_mask_buf)
+        rho[0, :, g0:g1] = numint.eval_rho(_sorted_mol, ao, dma_masked, xctype = xctype, hermi = 1)
+        dmb_masked = take_last2d(dms[1], idx, out=dm_mask_buf)
+        rho[1, :, g0:g1] = numint.eval_rho(_sorted_mol, ao, dmb_masked, xctype = xctype, hermi = 1)
 
-    if block_size < ALIGNED:
-        raise RuntimeError('Not enough GPU memory')
+    exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
+    exc = exc[:,0]
+    wv = grids.weights * vxc
+    nonzero_weight_mask = cupy.abs(grids.weights) > 1e-14
 
-    for atm_id, (coords, weight, weight1) in enumerate(rks_grad.grids_response_cc(grids)):
-        ngrids = weight.size
-        for p0, p1 in lib.prange(0,ngrids,block_size):
-            ao = numint.eval_ao(_sorted_mol, coords[p0:p1, :], ao_deriv, gdftopt=opt, transpose=False)
-            if xctype == 'LDA':
-                rho_a = numint.eval_rho(_sorted_mol, ao[0], dms[0],
-                                    xctype=xctype, hermi=1, with_lapl=False)
-                rho_b = numint.eval_rho(_sorted_mol, ao[0], dms[1],
-                                    xctype=xctype, hermi=1, with_lapl=False)
-                rho = cupy.array([rho_a,rho_b])
-                exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
-                exc = exc[:,0]
-            else:
-                rho_a = numint.eval_rho(_sorted_mol, ao, dms[0],
-                                    xctype=xctype, hermi=1, with_lapl=False)
-                rho_b = numint.eval_rho(_sorted_mol, ao, dms[1],
-                                    xctype=xctype, hermi=1, with_lapl=False)
-                rho = cupy.array([rho_a,rho_b])
-                exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
-                exc = exc[:,0]
+    from gpu4pyscf.hessian.rks import get_dweight_dA
 
-            if xctype == 'LDA':
-                wv = weight[p0:p1] * vxc[:,0]
-                aow = numint._scale_ao(ao[0], wv[0])
-                vtmp = rks_grad._d1_dot_(ao[1:4], aow.T)
-                rho = rho_a + rho_b
-                excsum += cupy.einsum('r,nxr->nx', exc*rho, weight1[:,:,p0:p1])
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms[0]) * 2
-                vmat[0] += vtmp
-                aow = numint._scale_ao(ao[0], wv[1])
-                vtmp = rks_grad._d1_dot_(ao[1:4], aow.T)
-                vmat[1] += vtmp
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms[1]) * 2
-                rho = vxc = aow = None
+    de_grid_response_weight = cupy.zeros((natm, 3))
+    dweightdA_right = (rho[0,0] + rho[1,0]) * exc
+    del rho
 
-            elif xctype == 'GGA':
-                wv = weight[p0:p1] * vxc
-                wv[:,0] *= .5
-                vtmp = rks_grad._gga_grad_sum_(ao, wv[0])
-                vmat[0] += vtmp
-                rho = rho_a[0] + rho_b[0]
-                excsum += cupy.einsum('r,nxr->nx', exc*rho, weight1[:,:,p0:p1])
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms[0]) * 2
-                vtmp = rks_grad._gga_grad_sum_(ao, wv[1])
-                vmat[1] += vtmp
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms[1]) * 2
-                rho = vxc = None
-            elif xctype == 'NLC':
-                raise NotImplementedError('NLC')
+    available_gpu_memory = get_avail_mem()
+    available_gpu_memory = int(available_gpu_memory * 0.1) # Don't use too much gpu memory
+    ao_nbytes_per_grid = ((2*3) * natm) * 8
+    ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
+    if ngrids_per_batch < 16:
+        raise MemoryError(f"Out of GPU memory for XC energy first derivative, available gpu memory = {get_avail_mem()}"
+                          f" bytes, nao = {nao}, natm = {natm}, ngrids (nonzero rho) = {ngrids}")
+    ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
+    ### Don't split the batch too small for get_dweight_dA()
+    # ngrids_per_batch = min(ngrids_per_batch, MIN_BLK_SIZE)
 
-            elif xctype == 'MGGA':
-                wv = weight[p0:p1] * vxc
-                wv[:,0] *= .5
-                wv[:,4] *= .5
+    for g0 in range(0, ngrids, ngrids_per_batch):
+        g1 = min(g0 + ngrids_per_batch, ngrids)
+        dweight_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+        de_grid_response_weight += cupy.einsum("Adg->Ad", dweight_dA * dweightdA_right[g0:g1])
+    del dweight_dA
+    del dweightdA_right
+    del exc
 
-                vtmp = rks_grad._gga_grad_sum_(ao, wv[0])
-                rks_grad._tau_grad_dot_(ao, wv[0,4], accumulate=True, out=vtmp)
-                vmat[0] += vtmp
-                rho = rho_a[0] + rho_b[0]
-                excsum += cupy.einsum('r,nxr->nx', exc*rho, weight1[:,:,p0:p1])
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms[0]) * 2
+    g0 = 0
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1):
+        g1 = g0 + weight.shape[0]
 
-                vtmp = rks_grad._gga_grad_sum_(ao, wv[1])
-                rks_grad._tau_grad_dot_(ao, wv[1,4], accumulate=True, out=vtmp)
-                vmat[1] += vtmp
-                excsum[atm_id] += cupy.einsum('xij,ji->x', vtmp, dms[1]) * 2
-                rho = vxc = None
+        ao = ao[:, :, nonzero_weight_mask[g0:g1]]
 
+        if ao.size == 0:
+            g0 = g1
+            continue
+
+        i_atom = int(grids.atm_idx[g0])
+        assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+        if xctype == 'LDA':
+            split_wv = cupy.ascontiguousarray(wv[:, :, g0:g1][:, :, nonzero_weight_mask[g0:g1]])
+
+            aow = numint._scale_ao(ao[0], split_wv[0, 0])
+            vtmp = rks_grad._d1_dot_(ao[1:4], aow.T)
+            dvmat_orbital_response[0][:, idx[:,None], idx] += vtmp
+            dma_masked = take_last2d(dms[0], idx, out=dm_mask_buf)
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dma_masked) * 2
+
+            aow = numint._scale_ao(ao[0], split_wv[1, 0])
+            vtmp = rks_grad._d1_dot_(ao[1:4], aow.T)
+            dvmat_orbital_response[1][:, idx[:,None], idx] += vtmp
+            dmb_masked = take_last2d(dms[1], idx, out=dm_mask_buf)
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dmb_masked) * 2
+
+        elif xctype == 'GGA':
+            split_wv = cupy.ascontiguousarray(wv[:, :, g0:g1][:, :, nonzero_weight_mask[g0:g1]])
+            split_wv[:, 0] *= .5
+
+            vtmp = rks_grad._gga_grad_sum_(ao, split_wv[0])
+            dvmat_orbital_response[0][:, idx[:,None], idx] += vtmp
+            dma_masked = take_last2d(dms[0], idx, out=dm_mask_buf)
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dma_masked) * 2
+
+            vtmp = rks_grad._gga_grad_sum_(ao, split_wv[1])
+            dvmat_orbital_response[1][:, idx[:,None], idx] += vtmp
+            dmb_masked = take_last2d(dms[1], idx, out=dm_mask_buf)
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dmb_masked) * 2
+
+        elif xctype == 'NLC':
+            raise ValueError("You see a bug, please report to the developer team.")
+
+        elif xctype == 'MGGA':
+            split_wv = cupy.ascontiguousarray(wv[:, :, g0:g1][:, :, nonzero_weight_mask[g0:g1]])
+            split_wv[:, 0] *= .5
+            split_wv[:, 4] *= .5 # for the factor 1/2 in tau
+
+            vtmp = rks_grad._gga_grad_sum_(ao, split_wv[0, :4])
+            rks_grad._tau_grad_dot_(ao, split_wv[0, 4], accumulate=True, out=vtmp)
+            dvmat_orbital_response[0][:, idx[:,None], idx] += vtmp
+            dma_masked = take_last2d(dms[0], idx, out=dm_mask_buf)
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dma_masked) * 2
+
+            vtmp = rks_grad._gga_grad_sum_(ao, split_wv[1, :4])
+            rks_grad._tau_grad_dot_(ao, split_wv[1, 4], accumulate=True, out=vtmp)
+            dvmat_orbital_response[1][:, idx[:,None], idx] += vtmp
+            dmb_masked = take_last2d(dms[1], idx, out=dm_mask_buf)
+            de_grid_response_rho[i_atom] += cupy.einsum('xij,ji->x', vtmp, dmb_masked) * 2
+
+        else:
+            raise NotImplementedError(f"Unrecognized xctype = {xctype}")
+
+        g0 = g1
+
+    excsum = de_grid_response_weight + de_grid_response_rho
+    excsum = excsum.get()
     # - sign because nabla_X = -nabla_x
-    exc1 = -.5 * rhf_grad.contract_h1e_dm(opt._sorted_mol, vmat, dms, hermi=1)
-    return excsum.get(), exc1
+    excsum -= rhf_grad.contract_h1e_dm(opt._sorted_mol, dvmat_orbital_response, dms, hermi=1)
+
+    log.timer_debug1('rks grad vxc full response', *t0)
+    return excsum, 0
 
 _get_denlc = rks_grad._get_denlc
 get_nlc_exc = rks_grad.get_nlc_exc

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -2324,6 +2324,9 @@ def get_d2weight_dAdB(mol, grids, grid_range = None):
     assert grids.quadrature_weights.shape[0] == ngrids
     atm_coords = cupy.asarray(mol.atom_coords(), order = "F")
 
+    inv_atom_distance = 1 / cupy.linalg.norm(atm_coords[:, None, :] - atm_coords[None, :, :], axis = 2)
+    cupy.fill_diagonal(inv_atom_distance, 0)
+
     from gpu4pyscf.dft import radi
     if grids.radii_adjust is None:
         # a_factor = cupy.zeros([mol.natm, mol.natm])
@@ -2351,12 +2354,15 @@ def get_d2weight_dAdB(mol, grids, grid_range = None):
         assert grids_quadrature_weights.shape == (ngrids,)
         assert grids_atm_idx.shape == (ngrids,)
 
+    Ar_distance = cupy.linalg.norm(atm_coords[:, None, :] - grids_coords[None, :, :], axis = 2)
+    assert Ar_distance.shape == (mol.natm, ngrids)
+
     P_B = cupy.zeros([mol.natm, ngrids], order = "C")
     libgdft.GDFTbecke_eval_PB(
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
-        ctypes.cast(grids_coords.data.ptr, ctypes.c_void_p),
-        ctypes.cast(atm_coords.data.ptr, ctypes.c_void_p),
         a_factor_ptr,
+        ctypes.cast(inv_atom_distance.data.ptr, ctypes.c_void_p),
+        ctypes.cast(Ar_distance.data.ptr, ctypes.c_void_p),
         ctypes.c_int(ngrids),
         ctypes.c_int(mol.natm),
         ctypes.c_int(scheme_id),
@@ -2375,7 +2381,9 @@ def get_d2weight_dAdB(mol, grids, grid_range = None):
         ctypes.cast(grids_quadrature_weights.data.ptr, ctypes.c_void_p),
         ctypes.cast(atm_coords.data.ptr, ctypes.c_void_p),
         a_factor_ptr,
+        ctypes.cast(inv_atom_distance.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_atm_idx.data.ptr, ctypes.c_void_p),
+        ctypes.cast(Ar_distance.data.ptr, ctypes.c_void_p),
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
         ctypes.cast(inv_sum_P_B.data.ptr, ctypes.c_void_p),
         ctypes.c_int(ngrids),

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -2246,6 +2246,9 @@ def get_dweight_dA(mol, grids, grid_range = None):
     assert grids.quadrature_weights.shape[0] == ngrids
     atm_coords = cupy.asarray(mol.atom_coords(), order = "F")
 
+    inv_atom_distance = 1 / cupy.linalg.norm(atm_coords[:, None, :] - atm_coords[None, :, :], axis = 2)
+    cupy.fill_diagonal(inv_atom_distance, 0)
+
     from gpu4pyscf.dft import radi
     if grids.radii_adjust is None:
         # a_factor = cupy.zeros([mol.natm, mol.natm])
@@ -2273,12 +2276,15 @@ def get_dweight_dA(mol, grids, grid_range = None):
         assert grids_quadrature_weights.shape == (ngrids,)
         assert grids_atm_idx.shape == (ngrids,)
 
+    Ar_distance = cupy.linalg.norm(atm_coords[:, None, :] - grids_coords[None, :, :], axis = 2)
+    assert Ar_distance.shape == (mol.natm, ngrids)
+
     P_B = cupy.zeros([mol.natm, ngrids], order = "C")
     libgdft.GDFTbecke_eval_PB(
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
-        ctypes.cast(grids_coords.data.ptr, ctypes.c_void_p),
-        ctypes.cast(atm_coords.data.ptr, ctypes.c_void_p),
         a_factor_ptr,
+        ctypes.cast(inv_atom_distance.data.ptr, ctypes.c_void_p),
+        ctypes.cast(Ar_distance.data.ptr, ctypes.c_void_p),
         ctypes.c_int(ngrids),
         ctypes.c_int(mol.natm),
         ctypes.c_int(scheme_id),
@@ -2297,7 +2303,9 @@ def get_dweight_dA(mol, grids, grid_range = None):
         ctypes.cast(grids_quadrature_weights.data.ptr, ctypes.c_void_p),
         ctypes.cast(atm_coords.data.ptr, ctypes.c_void_p),
         a_factor_ptr,
+        ctypes.cast(inv_atom_distance.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_atm_idx.data.ptr, ctypes.c_void_p),
+        ctypes.cast(Ar_distance.data.ptr, ctypes.c_void_p),
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
         ctypes.cast(inv_sum_P_B.data.ptr, ctypes.c_void_p),
         ctypes.c_int(ngrids),

--- a/gpu4pyscf/lib/gdft/gen_grids.cu
+++ b/gpu4pyscf/lib/gdft/gen_grids.cu
@@ -195,10 +195,11 @@ __device__ double3& operator+=(double3& v1, const double3& v2) { v1.x += v2.x; v
 __device__ double3& operator-=(double3& v1, const double3& v2) { v1.x -= v2.x; v1.y -= v2.y; v1.z -= v2.z; return v1; }
 __device__ double3 operator*(const double k, const double3& v) { return { k * v.x, k * v.y, k * v.z }; }
 __device__ double norm(const double3& v) { return sqrt(v.x * v.x + v.y * v.y + v.z * v.z); }
-__device__ double inv(const double x)
+__device__ double inv(const double x) { return (fabs(x) > 1e-14) ? (1.0 / x) : 0.0; }
+__device__ double inv_norm(const double3& v)
 {
-    if (x > 1e-14) return 1.0 / x;
-    else return 0.0;
+    const double v_norm2 = v.x * v.x + v.y * v.y + v.z * v.z;
+    return (v_norm2 > 1e-28) ? rsqrt(v_norm2) : 0.0;
 }
 
 __device__ double becke_switch_function(const double mu, const double a_factor)
@@ -319,11 +320,13 @@ __device__ double switch_function_dsdmu_over_s(const double mu, const double a_f
 template <bool if_radii_adjust, GridPartitionScheme scheme>
 __global__
 void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* __restrict__ grid_coords, const double* __restrict__ grid_quadrature_weights,
-                                       const double* __restrict__ atm_coords, const double* __restrict__ a_factor, const int* __restrict__ atm_idx,
-                                       const double* __restrict__ PB, const double* __restrict__ invsumPB, const int ngrids, const int natm)
+                                       const double* __restrict__ atm_coords, const double* __restrict__ a_factor, const double* __restrict__ inv_atom_distance,
+                                       const int* __restrict__ atm_idx,
+                                       const double* __restrict__ Ar_distance, const double* __restrict__ PB, const double* __restrict__ invsumPB,
+                                       const int ngrids, const int natm)
 {
     const int i_grid = blockIdx.x * blockDim.x + threadIdx.x;
-    const int i_derivative_atom = blockIdx.y * blockDim.y + threadIdx.y;
+    const int i_derivative_atom = blockIdx.y;
     if (i_grid >= ngrids || i_derivative_atom >= natm)
         return;
     const int i_associated_atom = atm_idx[i_grid];
@@ -335,7 +338,7 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
     const double3 grid_r = { grid_coords[i_grid + 0 * ngrids], grid_coords[i_grid + 1 * ngrids], grid_coords[i_grid + 2 * ngrids] };
     const double3 atom_G = { atm_coords[i_derivative_atom + 0 * natm], atm_coords[i_derivative_atom + 1 * natm], atm_coords[i_derivative_atom + 2 * natm] };
     const double3 Gr = atom_G - grid_r;
-    const double norm_Gr = norm(Gr);
+    const double norm_Gr = Ar_distance[i_derivative_atom * ngrids + i_grid];
     const double norm_Gr_1 = inv(norm_Gr);
 
     double3 sum_dPB_dG = { 0.0, 0.0, 0.0 };
@@ -343,14 +346,13 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
 
     for (int j_atom = 0; j_atom < natm; j_atom++) {
         const double3 atom_B = { atm_coords[j_atom + 0 * natm], atm_coords[j_atom + 1 * natm], atm_coords[j_atom + 2 * natm] };
-        const double3 Br = atom_B - grid_r;
-        const double norm_Br = norm(Br);
+        const double norm_Br = Ar_distance[j_atom * ngrids + i_grid];
         const double P_B = PB[j_atom * ngrids + i_grid];
 
         const double3 BG = atom_B - atom_G;
-        const double norm_BG_1 = inv(norm(BG));
+        const double norm_BG_1 = inv_atom_distance[j_atom * natm + i_derivative_atom];
         const double mu_BG = (norm_Br - norm_Gr) * norm_BG_1;
-        const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + mu_BG * norm_BG_1 * BG);
+        const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + (mu_BG * norm_BG_1) * BG);
         double a_factor_BG = 0.0; if constexpr (if_radii_adjust) a_factor_BG = a_factor[j_atom * natm + i_derivative_atom];
         double inv_sBG = NAN;
         const double dsBG_dmuBG_over_sBG = switch_function_dsdmu_over_s<scheme>(mu_BG, a_factor_BG, &inv_sBG);
@@ -371,14 +373,13 @@ void GDFTgrid_weight_derivative_kernel(double* __restrict__ dwdG, const double* 
     sum_dPB_dG += P_G * dPG_dG;
 
     const double3 atom_A = { atm_coords[i_associated_atom + 0 * natm], atm_coords[i_associated_atom + 1 * natm], atm_coords[i_associated_atom + 2 * natm] };
-    const double3 Ar = atom_A - grid_r;
-    const double norm_Ar = norm(Ar);
+    const double norm_Ar = Ar_distance[i_associated_atom * ngrids + i_grid];
     const double P_A = PB[i_associated_atom * ngrids + i_grid];
 
     const double3 AG = atom_A - atom_G;
-    const double norm_AG_1 = inv(norm(AG));
+    const double norm_AG_1 = inv_atom_distance[i_associated_atom * natm + i_derivative_atom];
     const double mu_AG = (norm_Ar - norm_Gr) * norm_AG_1;
-    const double3 dmuAG_dG = norm_AG_1 * (-norm_Gr_1 * Gr + mu_AG * norm_AG_1 * AG);
+    const double3 dmuAG_dG = norm_AG_1 * (-norm_Gr_1 * Gr + (mu_AG * norm_AG_1) * AG);
     double a_factor_AG = 0.0; if constexpr (if_radii_adjust) a_factor_AG = a_factor[i_associated_atom * natm + i_derivative_atom];
     const double dsAG_dmuAG_over_sAG = switch_function_dsdmu_over_s<scheme>(mu_AG, a_factor_AG);
     const double3 dPA_dG = dsAG_dmuAG_over_sAG * P_A * dmuAG_dG;
@@ -522,9 +523,9 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
         // dPB_dG part
         const double3 BG = atom_B - atom_G;
-        const double norm_BG_1 = inv(norm(BG));
+        const double norm_BG_1 = inv_norm(BG);
         const double mu_BG = (norm_Br - norm_Gr) * norm_BG_1;
-        const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + mu_BG * norm_BG_1 * BG);
+        const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + (mu_BG * norm_BG_1) * BG);
         double a_factor_BG = 0.0; if constexpr (if_radii_adjust) a_factor_BG = a_factor[i_atom_B * natm + i_atom_G];
         double inv_sBG = NAN;
         const double dsBG_dmuBG_over_sBG = switch_function_dsdmu_over_s<scheme>(mu_BG, a_factor_BG, &inv_sBG);
@@ -542,7 +543,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
         // dPB_dH part
         const double3 BH = atom_B - atom_H;
-        const double norm_BH_1 = inv(norm(BH));
+        const double norm_BH_1 = inv_norm(BH);
         const double mu_BH = (norm_Br - norm_Hr) * norm_BH_1;
         double a_factor_BH = 0.0; if constexpr (if_radii_adjust) a_factor_BH = a_factor[i_atom_B * natm + i_atom_H];
         double inv_sBH = NAN;
@@ -567,7 +568,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
     sum_dPB_dH += P_H * dPH_dH;
 
     const double3 GH = atom_G - atom_H;
-    const double norm_GH_1 = inv(norm(GH));
+    const double norm_GH_1 = inv_norm(GH);
 
     const double mu_GH = (norm_Gr - norm_Hr) * norm_GH_1;
     const double3 dmuGH_dG = norm_GH_1 * ( norm_Gr_1 * Gr - mu_GH * norm_GH_1 * GH);
@@ -608,7 +609,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
     // dPA_dG part
     const double3 AG = atom_A - atom_G;
-    const double norm_AG_1 = inv(norm(AG));
+    const double norm_AG_1 = inv_norm(AG);
     const double mu_AG = (norm_Ar - norm_Gr) * norm_AG_1;
     const double3 dmuAG_dG = norm_AG_1 * (-norm_Gr_1 * Gr + mu_AG * norm_AG_1 * AG);
     double a_factor_AG = 0.0; if constexpr (if_radii_adjust) a_factor_AG = a_factor[i_atom_A * natm + i_atom_G];
@@ -617,7 +618,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
     // dPA_dH part
     const double3 AH = atom_A - atom_H;
-    const double norm_AH_1 = inv(norm(AH));
+    const double norm_AH_1 = inv_norm(AH);
     const double mu_AH = (norm_Ar - norm_Hr) * norm_AH_1;
     const double3 dmuAH_dH = norm_AH_1 * (-norm_Hr_1 * Hr + mu_AH * norm_AH_1 * AH);
     double a_factor_AH = 0.0; if constexpr (if_radii_adjust) a_factor_AH = a_factor[i_atom_A * natm + i_atom_H];
@@ -685,9 +686,9 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
 
         // dPB_dG part
         const double3 BG = atom_B - atom_G;
-        const double norm_BG_1 = inv(norm(BG));
+        const double norm_BG_1 = inv_norm(BG);
         const double mu_BG = (norm_Br - norm_Gr) * norm_BG_1;
-        const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + mu_BG * norm_BG_1 * BG);
+        const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + (mu_BG * norm_BG_1) * BG);
         double a_factor_BG = 0.0; if constexpr (if_radii_adjust) a_factor_BG = a_factor[i_atom_B * natm + i_atom_G];
         const double3 dsBG_dG = switch_function_dsdmu_over_s<scheme>(mu_BG, a_factor_BG) * dmuBG_dG;
         const double3 dPB_dG = P_B * dsBG_dG;
@@ -727,7 +728,7 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
 
     // dPA_dG part
     const double3 AG = atom_A - atom_G;
-    const double norm_AG_1 = inv(norm(AG));
+    const double norm_AG_1 = inv_norm(AG);
     const double mu_AG = (norm_Ar - norm_Gr) * norm_AG_1;
     const double3 dmuAG_dG = norm_AG_1 * (-norm_Gr_1 * Gr + mu_AG * norm_AG_1 * AG);
     double a_factor_AG = 0.0; if constexpr (if_radii_adjust) a_factor_AG = a_factor[i_atom_A * natm + i_atom_G];
@@ -766,8 +767,8 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
 
 template <bool if_radii_adjust, GridPartitionScheme scheme>
 __global__
-void GDFTgrid_becke_eval_PB_kernel(double* __restrict__ PB, const double* __restrict__ grid_coords,
-                                   const double* __restrict__ atm_coords, const double* __restrict__ a_factor,
+void GDFTgrid_becke_eval_PB_kernel(double* __restrict__ PB,
+                                   const double* __restrict__ a_factor, const double* __restrict__ inv_atom_distance, const double* __restrict__ Ar_distance,
                                    const int ngrids, const int natm)
 {
     const int i_grid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -775,19 +776,13 @@ void GDFTgrid_becke_eval_PB_kernel(double* __restrict__ PB, const double* __rest
     if (i_grid >= ngrids || i_atom_B >= natm)
         return;
 
-    const double3 grid_r = { grid_coords[i_grid + 0 * ngrids], grid_coords[i_grid + 1 * ngrids], grid_coords[i_grid + 2 * ngrids] };
-    const double3 atom_B = { atm_coords[i_atom_B + 0 * natm], atm_coords[i_atom_B + 1 * natm], atm_coords[i_atom_B + 2 * natm] };
-    const double3 Br = atom_B - grid_r;
-    const double norm_Br = norm(Br);
+    const double norm_Br = Ar_distance[i_atom_B * ngrids + i_grid];
 
     // P_B part
     double P_B = 1.0;
     for (int i_atom_C = 0; i_atom_C < natm; i_atom_C++) {
-        const double3 atom_C = { atm_coords[i_atom_C + 0 * natm], atm_coords[i_atom_C + 1 * natm], atm_coords[i_atom_C + 2 * natm] };
-        const double3 Cr = atom_C - grid_r;
-        const double3 BC = atom_B - atom_C;
-        const double norm_Cr = norm(Cr);
-        const double norm_BC_1 = inv(norm(BC));
+        const double norm_Cr = Ar_distance[i_atom_C * ngrids + i_grid];
+        const double norm_BC_1 = inv_atom_distance[i_atom_B * natm + i_atom_C];
 
         const double mu_BC = (norm_Br - norm_Cr) * norm_BC_1;
         double a_factor_BC = 0.0; if constexpr (if_radii_adjust) a_factor_BC = a_factor[i_atom_B * natm + i_atom_C];
@@ -877,12 +872,12 @@ int GDFTbecke_partition_weights(double *weights, const double *coords, const dou
 
 __host__
 int GDFTbecke_partition_weight_derivative(double *dwdG, const double *grid_coords, const double *grid_quadrature_weights,
-                                          const double *atm_coords, const double *a_factor, const int *atm_idx,
+                                          const double *atm_coords, const double *a_factor, const double *inv_atom_distance, const int *atm_idx, const double *Ar_distance,
                                           const double* PB, const double* invsumPB, const int ngrids, const int natm, const int scheme_id)
 {
-    const dim3 threads(TILE, TILE);
-    const dim3 blocks((ngrids + TILE - 1) / TILE,
-                      (natm + TILE - 1) / TILE);
+    const int n_thread_per_grid = 128;
+    const dim3 threads(n_thread_per_grid, 1);
+    const dim3 blocks((ngrids + n_thread_per_grid - 1) / n_thread_per_grid, natm);
 
     const bool if_radii_adjust = a_factor != NULL;
     const enum GridPartitionScheme scheme = get_grid_partition_sheme(scheme_id);
@@ -890,21 +885,21 @@ int GDFTbecke_partition_weight_derivative(double *dwdG, const double *grid_coord
     if (scheme == GridPartitionScheme::original_becke) {
         if (if_radii_adjust) {
             GDFTgrid_weight_derivative_kernel< true, GridPartitionScheme::original_becke> <<<blocks, threads>>>(
-                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
             );
         } else {
             GDFTgrid_weight_derivative_kernel<false, GridPartitionScheme::original_becke> <<<blocks, threads>>>(
-                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
             );
         }
     } else if (scheme == GridPartitionScheme::stratmann) {
         if (if_radii_adjust) {
             GDFTgrid_weight_derivative_kernel< true, GridPartitionScheme::stratmann> <<<blocks, threads>>>(
-                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
             );
         } else {
             GDFTgrid_weight_derivative_kernel<false, GridPartitionScheme::stratmann> <<<blocks, threads>>>(
-                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                dwdG, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
             );
         }
     } else {
@@ -1004,8 +999,8 @@ int GDFTbecke_partition_weight_second_derivative(double *d2w_dG1dG2, const doubl
 }
 
 __host__
-int GDFTbecke_eval_PB(double *PB, const double *grid_coords,
-                      const double *atm_coords, const double *a_factor,
+int GDFTbecke_eval_PB(double *PB,
+                      const double *a_factor, const double *inv_atom_distance, const double *Ar_distance,
                       const int ngrids, const int natm, const int scheme_id)
 {
     constexpr int n_grid_per_block = 64;
@@ -1019,15 +1014,15 @@ int GDFTbecke_eval_PB(double *PB, const double *grid_coords,
 
     if (scheme == GridPartitionScheme::original_becke) {
         if (if_radii_adjust) {
-            GDFTgrid_becke_eval_PB_kernel< true, GridPartitionScheme::original_becke> <<<blocks, threads>>>(PB, grid_coords, atm_coords, a_factor, ngrids, natm);
+            GDFTgrid_becke_eval_PB_kernel< true, GridPartitionScheme::original_becke> <<<blocks, threads>>>(PB, a_factor, inv_atom_distance, Ar_distance, ngrids, natm);
         } else {
-            GDFTgrid_becke_eval_PB_kernel<false, GridPartitionScheme::original_becke> <<<blocks, threads>>>(PB, grid_coords, atm_coords, a_factor, ngrids, natm);
+            GDFTgrid_becke_eval_PB_kernel<false, GridPartitionScheme::original_becke> <<<blocks, threads>>>(PB, a_factor, inv_atom_distance, Ar_distance, ngrids, natm);
         }
     } else if (scheme == GridPartitionScheme::stratmann) {
         if (if_radii_adjust) {
-            GDFTgrid_becke_eval_PB_kernel< true, GridPartitionScheme::stratmann> <<<blocks, threads>>>(PB, grid_coords, atm_coords, a_factor, ngrids, natm);
+            GDFTgrid_becke_eval_PB_kernel< true, GridPartitionScheme::stratmann> <<<blocks, threads>>>(PB, a_factor, inv_atom_distance, Ar_distance, ngrids, natm);
         } else {
-            GDFTgrid_becke_eval_PB_kernel<false, GridPartitionScheme::stratmann> <<<blocks, threads>>>(PB, grid_coords, atm_coords, a_factor, ngrids, natm);
+            GDFTgrid_becke_eval_PB_kernel<false, GridPartitionScheme::stratmann> <<<blocks, threads>>>(PB, a_factor, inv_atom_distance, Ar_distance, ngrids, natm);
         }
     } else {
         cudaMemset(PB, 0xFF, ngrids * natm * sizeof(double)); // Fill with NAN

--- a/gpu4pyscf/lib/gdft/gen_grids.cu
+++ b/gpu4pyscf/lib/gdft/gen_grids.cu
@@ -194,13 +194,8 @@ __device__ double3 operator-(const double3& v) { return { -v.x, -v.y, -v.z }; }
 __device__ double3& operator+=(double3& v1, const double3& v2) { v1.x += v2.x; v1.y += v2.y; v1.z += v2.z; return v1; }
 __device__ double3& operator-=(double3& v1, const double3& v2) { v1.x -= v2.x; v1.y -= v2.y; v1.z -= v2.z; return v1; }
 __device__ double3 operator*(const double k, const double3& v) { return { k * v.x, k * v.y, k * v.z }; }
-__device__ double norm(const double3& v) { return sqrt(v.x * v.x + v.y * v.y + v.z * v.z); }
+// __device__ double norm(const double3& v) { return sqrt(v.x * v.x + v.y * v.y + v.z * v.z); }
 __device__ double inv(const double x) { return (fabs(x) > 1e-14) ? (1.0 / x) : 0.0; }
-__device__ double inv_norm(const double3& v)
-{
-    const double v_norm2 = v.x * v.x + v.y * v.y + v.z * v.z;
-    return (v_norm2 > 1e-28) ? rsqrt(v_norm2) : 0.0;
-}
 
 __device__ double becke_switch_function(const double mu, const double a_factor)
 {
@@ -479,7 +474,8 @@ __device__ double switch_function_d2sdmu2_over_s(const double mu, const double a
 template <bool if_radii_adjust, GridPartitionScheme scheme>
 __global__
 void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d2w_dG1dG2, const double* __restrict__ grid_coords, const double* __restrict__ grid_quadrature_weights,
-                                                          const double* __restrict__ atm_coords, const double* __restrict__ a_factor, const int* __restrict__ atm_idx,
+                                                          const double* __restrict__ atm_coords, const double* __restrict__ a_factor, const double* __restrict__ inv_atom_distance,
+                                                          const int* __restrict__ atm_idx, const double* __restrict__ Ar_distance,
                                                           const double* __restrict__ PB, const double* __restrict__ invsumPB, const int ngrids, const int natm)
 {
     const int i_grid   = blockIdx.x * blockDim.x + threadIdx.x;
@@ -499,7 +495,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
     const double3 atom_G = { atm_coords[i_atom_G + 0 * natm], atm_coords[i_atom_G + 1 * natm], atm_coords[i_atom_G + 2 * natm] };
     const double3 Gr = atom_G - grid_r;
-    const double norm_Gr = norm(Gr);
+    const double norm_Gr = Ar_distance[i_atom_G * ngrids + i_grid];
     const double norm_Gr_1 = inv(norm_Gr);
     double3 sum_dPB_dG = { 0.0, 0.0, 0.0 };
     const double P_G = PB[i_atom_G * ngrids + i_grid];
@@ -507,7 +503,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
     const double3 atom_H = { atm_coords[i_atom_H + 0 * natm], atm_coords[i_atom_H + 1 * natm], atm_coords[i_atom_H + 2 * natm] };
     const double3 Hr = atom_H - grid_r;
-    const double norm_Hr = norm(Hr);
+    const double norm_Hr = Ar_distance[i_atom_H * ngrids + i_grid];
     const double norm_Hr_1 = inv(norm_Hr);
     double3 sum_dPB_dH = { 0.0, 0.0, 0.0 };
     const double P_H = PB[i_atom_H * ngrids + i_grid];
@@ -517,13 +513,12 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
     for (int i_atom_B = 0; i_atom_B < natm; i_atom_B++) {
         const double3 atom_B = { atm_coords[i_atom_B + 0 * natm], atm_coords[i_atom_B + 1 * natm], atm_coords[i_atom_B + 2 * natm] };
-        const double3 Br = atom_B - grid_r;
-        const double norm_Br = norm(Br);
+        const double norm_Br = Ar_distance[i_atom_B * ngrids + i_grid];
         const double P_B = PB[i_atom_B * ngrids + i_grid];
 
         // dPB_dG part
         const double3 BG = atom_B - atom_G;
-        const double norm_BG_1 = inv_norm(BG);
+        const double norm_BG_1 = inv_atom_distance[i_atom_B * natm + i_atom_G];
         const double mu_BG = (norm_Br - norm_Gr) * norm_BG_1;
         const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + (mu_BG * norm_BG_1) * BG);
         double a_factor_BG = 0.0; if constexpr (if_radii_adjust) a_factor_BG = a_factor[i_atom_B * natm + i_atom_G];
@@ -543,7 +538,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
         // dPB_dH part
         const double3 BH = atom_B - atom_H;
-        const double norm_BH_1 = inv_norm(BH);
+        const double norm_BH_1 = inv_atom_distance[i_atom_B * natm + i_atom_H];
         const double mu_BH = (norm_Br - norm_Hr) * norm_BH_1;
         double a_factor_BH = 0.0; if constexpr (if_radii_adjust) a_factor_BH = a_factor[i_atom_B * natm + i_atom_H];
         double inv_sBH = NAN;
@@ -568,7 +563,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
     sum_dPB_dH += P_H * dPH_dH;
 
     const double3 GH = atom_G - atom_H;
-    const double norm_GH_1 = inv_norm(GH);
+    const double norm_GH_1 = inv_atom_distance[i_atom_G * natm + i_atom_H];
 
     const double mu_GH = (norm_Gr - norm_Hr) * norm_GH_1;
     const double3 dmuGH_dG = norm_GH_1 * ( norm_Gr_1 * Gr - mu_GH * norm_GH_1 * GH);
@@ -603,13 +598,12 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
     sum_d2PB_dGdH += d2PH_dGdH;
 
     const double3 atom_A = { atm_coords[i_atom_A + 0 * natm], atm_coords[i_atom_A + 1 * natm], atm_coords[i_atom_A + 2 * natm] };
-    const double3 Ar = atom_A - grid_r;
-    const double norm_Ar = norm(Ar);
+    const double norm_Ar = Ar_distance[i_atom_A * ngrids + i_grid];
     const double P_A = PB[i_atom_A * ngrids + i_grid];
 
     // dPA_dG part
     const double3 AG = atom_A - atom_G;
-    const double norm_AG_1 = inv_norm(AG);
+    const double norm_AG_1 = inv_atom_distance[i_atom_A * natm + i_atom_G];
     const double mu_AG = (norm_Ar - norm_Gr) * norm_AG_1;
     const double3 dmuAG_dG = norm_AG_1 * (-norm_Gr_1 * Gr + mu_AG * norm_AG_1 * AG);
     double a_factor_AG = 0.0; if constexpr (if_radii_adjust) a_factor_AG = a_factor[i_atom_A * natm + i_atom_G];
@@ -618,7 +612,7 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 
     // dPA_dH part
     const double3 AH = atom_A - atom_H;
-    const double norm_AH_1 = inv_norm(AH);
+    const double norm_AH_1 = inv_atom_distance[i_atom_A * natm + i_atom_H];
     const double mu_AH = (norm_Ar - norm_Hr) * norm_AH_1;
     const double3 dmuAH_dH = norm_AH_1 * (-norm_Hr_1 * Hr + mu_AH * norm_AH_1 * AH);
     double a_factor_AH = 0.0; if constexpr (if_radii_adjust) a_factor_AH = a_factor[i_atom_A * natm + i_atom_H];
@@ -652,7 +646,8 @@ void GDFTgrid_weight_second_derivative_offdiagonal_kernel(double* __restrict__ d
 template <bool if_radii_adjust, GridPartitionScheme scheme>
 __global__
 void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_dG1dG2, const double* __restrict__ grid_coords, const double* __restrict__ grid_quadrature_weights,
-                                                       const double* __restrict__ atm_coords, const double* __restrict__ a_factor, const int* __restrict__ atm_idx,
+                                                       const double* __restrict__ atm_coords, const double* __restrict__ a_factor, const double* __restrict__ inv_atom_distance,
+                                                       const int* __restrict__ atm_idx, const double* __restrict__ Ar_distance,
                                                        const double* __restrict__ PB, const double* __restrict__ invsumPB, const int ngrids, const int natm)
 {
     const int i_grid = blockIdx.x * blockDim.x + threadIdx.x;
@@ -669,7 +664,7 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
 
     const double3 atom_G = { atm_coords[i_atom_G + 0 * natm], atm_coords[i_atom_G + 1 * natm], atm_coords[i_atom_G + 2 * natm] };
     const double3 Gr = atom_G - grid_r;
-    const double norm_Gr = norm(Gr);
+    const double norm_Gr = Ar_distance[i_atom_G * ngrids + i_grid];
     const double norm_Gr_1 = inv(norm_Gr);
     double3 sum_dPB_dG = { 0.0, 0.0, 0.0 };
     const double P_G = PB[i_atom_G * ngrids + i_grid];
@@ -680,13 +675,12 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
 
     for (int i_atom_B = 0; i_atom_B < natm; i_atom_B++) {
         const double3 atom_B = { atm_coords[i_atom_B + 0 * natm], atm_coords[i_atom_B + 1 * natm], atm_coords[i_atom_B + 2 * natm] };
-        const double3 Br = atom_B - grid_r;
-        const double norm_Br = norm(Br);
+        const double norm_Br = Ar_distance[i_atom_B * ngrids + i_grid];
         const double P_B = PB[i_atom_B * ngrids + i_grid];
 
         // dPB_dG part
         const double3 BG = atom_B - atom_G;
-        const double norm_BG_1 = inv_norm(BG);
+        const double norm_BG_1 = inv_atom_distance[i_atom_B * natm + i_atom_G];
         const double mu_BG = (norm_Br - norm_Gr) * norm_BG_1;
         const double3 dmuBG_dG = norm_BG_1 * (-norm_Gr_1 * Gr + (mu_BG * norm_BG_1) * BG);
         double a_factor_BG = 0.0; if constexpr (if_radii_adjust) a_factor_BG = a_factor[i_atom_B * natm + i_atom_G];
@@ -722,13 +716,12 @@ void GDFTgrid_weight_second_derivative_diagonal_kernel(double* __restrict__ d2w_
     sum_d2PB_dG2 += P_G * d2PG_dG2;
 
     const double3 atom_A = { atm_coords[i_atom_A + 0 * natm], atm_coords[i_atom_A + 1 * natm], atm_coords[i_atom_A + 2 * natm] };
-    const double3 Ar = atom_A - grid_r;
-    const double norm_Ar = norm(Ar);
+    const double norm_Ar = Ar_distance[i_atom_A * ngrids + i_grid];
     const double P_A = PB[i_atom_A * ngrids + i_grid];
 
     // dPA_dG part
     const double3 AG = atom_A - atom_G;
-    const double norm_AG_1 = inv_norm(AG);
+    const double norm_AG_1 = inv_atom_distance[i_atom_A * natm + i_atom_G];
     const double mu_AG = (norm_Ar - norm_Gr) * norm_AG_1;
     const double3 dmuAG_dG = norm_AG_1 * (-norm_Gr_1 * Gr + mu_AG * norm_AG_1 * AG);
     double a_factor_AG = 0.0; if constexpr (if_radii_adjust) a_factor_AG = a_factor[i_atom_A * natm + i_atom_G];
@@ -918,7 +911,7 @@ int GDFTbecke_partition_weight_derivative(double *dwdG, const double *grid_coord
 
 __host__
 int GDFTbecke_partition_weight_second_derivative(double *d2w_dG1dG2, const double *grid_coords, const double *grid_quadrature_weights,
-                                                 const double *atm_coords, const double *a_factor, const int *atm_idx,
+                                                 const double *atm_coords, const double *a_factor, const double *inv_atom_distance, const int *atm_idx, const double *Ar_distance,
                                                  const double *PB, const double *invsumPB, const int ngrids, const int natm, const int scheme_id)
 {
     const bool if_radii_adjust = a_factor != NULL;
@@ -934,21 +927,21 @@ int GDFTbecke_partition_weight_second_derivative(double *d2w_dG1dG2, const doubl
         if (scheme == GridPartitionScheme::original_becke) {
             if (if_radii_adjust) {
                 GDFTgrid_weight_second_derivative_offdiagonal_kernel< true, GridPartitionScheme::original_becke> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             } else {
                 GDFTgrid_weight_second_derivative_offdiagonal_kernel<false, GridPartitionScheme::original_becke> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             }
         } else if (scheme == GridPartitionScheme::stratmann) {
             if (if_radii_adjust) {
                 GDFTgrid_weight_second_derivative_offdiagonal_kernel< true, GridPartitionScheme::stratmann> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             } else {
                 GDFTgrid_weight_second_derivative_offdiagonal_kernel<false, GridPartitionScheme::stratmann> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             }
         } else {
@@ -966,21 +959,21 @@ int GDFTbecke_partition_weight_second_derivative(double *d2w_dG1dG2, const doubl
         if (scheme == GridPartitionScheme::original_becke) {
             if (if_radii_adjust) {
                 GDFTgrid_weight_second_derivative_diagonal_kernel< true, GridPartitionScheme::original_becke> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             } else {
                 GDFTgrid_weight_second_derivative_diagonal_kernel<false, GridPartitionScheme::original_becke> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             }
         } else if (scheme == GridPartitionScheme::stratmann) {
             if (if_radii_adjust) {
                 GDFTgrid_weight_second_derivative_diagonal_kernel< true, GridPartitionScheme::stratmann> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             } else {
                 GDFTgrid_weight_second_derivative_diagonal_kernel<false, GridPartitionScheme::stratmann> <<<blocks, threads>>>(
-                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, atm_idx, PB, invsumPB, ngrids, natm
+                    d2w_dG1dG2, grid_coords, grid_quadrature_weights, atm_coords, a_factor, inv_atom_distance, atm_idx, Ar_distance, PB, invsumPB, ngrids, natm
                 );
             }
         } else {

--- a/gpu4pyscf/pbc/dft/gen_grid.py
+++ b/gpu4pyscf/pbc/dft/gen_grid.py
@@ -168,12 +168,18 @@ def get_becke_weight_derivative(grids, natm):
     grids_supatm_coords = cp.asarray(grids.supatm_coords, order = "F")
     grids_supatm_to_atm_idx = cp.asarray(grids.supatm_to_atm_idx)
 
+    inv_atom_distance = 1 / cp.linalg.norm(grids_supatm_coords[:, None, :] - grids_supatm_coords[None, :, :], axis = 2)
+    cp.fill_diagonal(inv_atom_distance, 0)
+
+    Ar_distance = cp.linalg.norm(grids_supatm_coords[:, None, :] - grids_coords[None, :, :], axis = 2)
+    assert Ar_distance.shape == (sup_natm, ngrids)
+
     P_B = cp.zeros([sup_natm, ngrids], order = "C")
     libgdft.GDFTbecke_eval_PB(
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
-        ctypes.cast(grids_coords.data.ptr, ctypes.c_void_p),
-        ctypes.cast(grids_supatm_coords.data.ptr, ctypes.c_void_p),
         a_factor_ptr,
+        ctypes.cast(inv_atom_distance.data.ptr, ctypes.c_void_p),
+        ctypes.cast(Ar_distance.data.ptr, ctypes.c_void_p),
         ctypes.c_int(ngrids),
         ctypes.c_int(sup_natm),
         ctypes.c_int(scheme_id),
@@ -192,7 +198,9 @@ def get_becke_weight_derivative(grids, natm):
         ctypes.cast(grids_quadrature_weights.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_supatm_coords.data.ptr, ctypes.c_void_p),
         a_factor_ptr,
+        ctypes.cast(inv_atom_distance.data.ptr, ctypes.c_void_p),
         ctypes.cast(grids_supatm_idx.data.ptr, ctypes.c_void_p),
+        ctypes.cast(Ar_distance.data.ptr, ctypes.c_void_p),
         ctypes.cast(P_B.data.ptr, ctypes.c_void_p),
         ctypes.cast(inv_sum_P_B.data.ptr, ctypes.c_void_p),
         ctypes.c_int(ngrids),


### PR DESCRIPTION
This PR requires number of grids of each atom to be ceiled to multiple of 4096, when computing the grid response gradient. This can be a large increase of grid number and memory requirement.

Also the API of `gpu4pyscf.dft.gen_grid.Grids::build()` function is changed. A new argument is added.