### PR TITLE
GPU-accelerate get_pp_nl Fock-build path (#740 followup)

### DIFF
--- a/gpu4pyscf/pbc/df/aft.py
+++ b/gpu4pyscf/pbc/df/aft.py
@@ -25,6 +25,7 @@ from pyscf import lib
 from pyscf import gto
 from pyscf.pbc.df import aft as aft_cpu
 from pyscf.pbc.gto.pseudo import pp_int
+from gpu4pyscf.pbc.gto.pseudo.pp_int import get_pp_nl_gpu
 from pyscf.pbc.lib.kpts_helper import is_zero
 from pyscf.pbc.lib.kpts import KPoints
 from pyscf.pbc.df import ft_ao
@@ -99,7 +100,7 @@ def get_pp(mydf, kpts=None):
     vpp = _get_pp_loc_part1(mydf, kpts, with_pseudo=True)
     pp2builder = aft_cpu._IntPPBuilder(cell, kpts)
     vpp += cp.asarray(pp2builder.get_pp_loc_part2())
-    vpp += cp.asarray(pp_int.get_pp_nl(cell, kpts))
+    vpp += cp.asarray(get_pp_nl_gpu(cell, kpts))
     if is_single_kpt:
         vpp = vpp[0]
     return vpp

--- a/gpu4pyscf/pbc/df/rsdf_builder.py
+++ b/gpu4pyscf/pbc/df/rsdf_builder.py
@@ -922,13 +922,14 @@ def get_pp(cell, kpts=None):
     '''Get the periodic pseudopotential nuc-el ao matrix, with G=0 removed.
     '''
     from pyscf.pbc.gto import pseudo
+    from gpu4pyscf.pbc.gto.pseudo.pp_int import get_pp_nl_gpu
     log = logger.new_logger(cell)
     t0 = log.init_timer()
     is_single_kpt = kpts is not None and kpts.ndim == 1
     pp2builder = aft_cpu._IntPPBuilder(cell, kpts)
     vpp  = cp.asarray(pp2builder.get_pp_loc_part2())
     t1 = log.timer_debug1('get_pp_loc_part2', *t0)
-    vpp += cp.asarray(pseudo.pp_int.get_pp_nl(cell, kpts))
+    vpp += cp.asarray(get_pp_nl_gpu(cell, kpts))
     t1 = log.timer_debug1('get_pp_nl', *t1)
 
     vpp += get_pp_loc_part1(cell, kpts, with_pseudo=True, verbose=log)

--- a/gpu4pyscf/pbc/dft/multigrid.py
+++ b/gpu4pyscf/pbc/dft/multigrid.py
@@ -930,6 +930,7 @@ def get_pp(ni, kpts=None):
     '''
     from pyscf import gto
     from pyscf.pbc.gto.pseudo import pp_int
+    from gpu4pyscf.pbc.gto.pseudo.pp_int import get_pp_nl_gpu
     assert kpts is None or is_zero(kpts)
     if kpts is None or kpts.ndim == 1:
         is_single_kpt = True
@@ -945,7 +946,7 @@ def get_pp(ni, kpts=None):
     vpp = _get_j_pass2(ni, vpplocG[None,:], kpts=kpts)[0]
     t1 = log.timer_debug1('vpploc', *t0)
 
-    vppnl = pp_int.get_pp_nl(cell, kpts)
+    vppnl = get_pp_nl_gpu(cell, kpts)
     for k, kpt in enumerate(kpts):
         if is_zero(kpt):
             vpp[k] += cp.asarray(vppnl[k].real)

--- a/gpu4pyscf/pbc/dft/multigrid_v2.py
+++ b/gpu4pyscf/pbc/dft/multigrid_v2.py
@@ -27,6 +27,7 @@ from pyscf.pbc.dft.multigrid import multigrid
 
 from pyscf.pbc.df.df_jk import _format_kpts_band
 from pyscf.pbc.gto.pseudo import pp_int
+from gpu4pyscf.pbc.gto.pseudo.pp_int import get_pp_nl_gpu
 from pyscf.pbc.lib.kpts_helper import is_gamma_point
 from gpu4pyscf.dft import numint
 from gpu4pyscf.pbc.df.fft_jk import _format_dms, _format_jks
@@ -1150,7 +1151,7 @@ def get_pp(ni, kpts=None):
     vpp = convert_xc_on_g_mesh_to_fock(ni, vpplocG, hermi=1, kpts=kpts)[0]
     t1 = log.timer_debug1("vpploc", *t0)
 
-    vppnl = pp_int.get_pp_nl(cell, kpts)
+    vppnl = get_pp_nl_gpu(cell, kpts)
     for k, kpt in enumerate(kpts):
         if is_single_kpt:
             vpp[k] += cp.asarray(vppnl[k].real)

--- a/gpu4pyscf/pbc/gto/pseudo/pp_int.py
+++ b/gpu4pyscf/pbc/gto/pseudo/pp_int.py
@@ -14,8 +14,11 @@
 
 """GPU cross-basis integrals for GTH pseudopotentials via merged Cell + SortedGTO."""
 import numpy as np
+import cupy as cp
 from pyscf import gto, lib
 from pyscf.pbc.gto.cell import _estimate_rcut
+from pyscf.pbc.gto.pseudo.pp_int import fake_cell_vnl, _int_vnl
+from pyscf.pbc.lib.kpts_helper import gamma_point
 from gpu4pyscf.gto.mole import most_diffuse_pgto
 from gpu4pyscf.pbc.gto.int1e import _Int1eOpt
 
@@ -72,3 +75,83 @@ def _int_vnl_gpu(cell, fakecell, hl_blocks, kpts, intors=None, comp=1):
     return (int_ket(fakecell._bas[hl_dims > 0], intors[0]),
             int_ket(fakecell._bas[hl_dims > 1], intors[1]),
             int_ket(fakecell._bas[hl_dims > 2], intors[2]))
+
+
+def _contract_ppnl_gpu(cell, fakecell, hl_blocks, ppnl_half, comp=1, kpts=None):
+    '''GPU contraction of GTH non-local pseudopotential half-integrals.
+
+    Gamma-point only; the half-integrals are already image-summed so no
+    NeighborListOpt screening is needed. Returns NumPy.
+    '''
+    if kpts is None:
+        kpts_lst = np.zeros((1, 3))
+    else:
+        kpts_lst = np.reshape(kpts, (-1, 3))
+
+    nao = cell.nao_nr()
+
+    ppnl_half_gpu = [cp.asarray(a) if len(a) > 0 else a for a in ppnl_half]
+
+    ppnl = []
+    for k in range(len(kpts_lst)):
+        ppnl_k = cp.zeros((nao, nao), dtype=cp.float64)
+        offset = [0] * 3
+        for ib, hl in enumerate(hl_blocks):
+            l = fakecell.bas_angular(ib)
+            nd = 2 * l + 1
+            hl_dim = hl.shape[0]
+            hl_gpu = cp.asarray(hl)
+
+            ilp = cp.zeros((hl_dim, nd, nao), dtype=cp.float64)
+            for i in range(hl_dim):
+                p0 = offset[i]
+                if len(ppnl_half_gpu[i]) > 0:
+                    ilp[i] = ppnl_half_gpu[i][k, p0:p0+nd].real
+                offset[i] = p0 + nd
+
+            ppnl_k += cp.einsum('imp,ij,jmq->pq', ilp, hl_gpu, ilp)
+
+        ppnl.append(ppnl_k.get())
+
+    if kpts is None or np.shape(kpts) == (3,):
+        return ppnl[0]
+    return ppnl
+
+
+def get_pp_nl_gpu(cell, kpts=None):
+    if kpts is None:
+        kpts_lst = np.zeros((1, 3))
+    else:
+        kpts_lst = np.reshape(kpts, (-1, 3))
+    nkpts = len(kpts_lst)
+
+    fakecell, hl_blocks = fake_cell_vnl(cell)
+    nao = cell.nao_nr()
+
+    if gamma_point(kpts_lst):
+        ppnl_half = _int_vnl_gpu(cell, fakecell, hl_blocks, kpts_lst)
+        return _contract_ppnl_gpu(cell, fakecell, hl_blocks, ppnl_half, kpts=kpts)
+
+    ppnl_half = _int_vnl(cell, fakecell, hl_blocks, kpts_lst)
+
+    ppnl_half_gpu = [cp.asarray(a) if len(a) > 0 else a for a in ppnl_half]
+
+    ppnl = cp.zeros((nkpts, nao, nao), dtype=cp.complex128)
+    for k in range(nkpts):
+        offset = [0] * 3
+        for ib, hl in enumerate(hl_blocks):
+            l = fakecell.bas_angular(ib)
+            nd = 2 * l + 1
+            hl_dim = hl.shape[0]
+            hl_gpu = cp.asarray(hl, dtype=cp.complex128)
+
+            ilp = cp.zeros((hl_dim, nd, nao), dtype=cp.complex128)
+            for i in range(hl_dim):
+                p0 = offset[i]
+                if len(ppnl_half_gpu[i]) > 0:
+                    ilp[i] = ppnl_half_gpu[i][k, p0:p0+nd]
+                offset[i] = p0 + nd
+
+            ppnl[k] += cp.einsum('ilp,ij,jlq->pq', ilp.conj(), hl_gpu, ilp)
+
+    return ppnl.get()

--- a/gpu4pyscf/pbc/gto/pseudo/tests/test_pp_int.py
+++ b/gpu4pyscf/pbc/gto/pseudo/tests/test_pp_int.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# Copyright 2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for GPU-accelerated GTH non-local pseudopotential Fock contribution.
+
+Validates:
+1. _contract_ppnl_gpu against CPU _contract_ppnl, gamma point
+2. get_pp_nl_gpu against CPU get_pp_nl, gamma point
+3. get_pp_nl_gpu against CPU get_pp_nl, non-zero k-points (single kpt
+   and a k-mesh) — exercises the non-gamma branch of the GPU wrapper
+4. Multiple elements (C, Si, Fe) covering s/p/d/f projectors
+"""
+
+import unittest
+import numpy as np
+import pyscf
+from pyscf.pbc.gto.pseudo.pp_int import (
+    fake_cell_vnl, _int_vnl, _contract_ppnl, get_pp_nl)
+
+
+def setUpModule():
+    global cell_c, cell_si, cell_fe
+
+    cell_c = pyscf.M(
+        atom=[['C', [0.0, 0.0, 0.0]], ['C', [1.885, 1.685, 1.585]]],
+        a='''
+        0.000000000, 3.370137329, 3.370137329
+        3.370137329, 0.000000000, 3.370137329
+        3.370137329, 3.370137329, 0.000000000''',
+        basis='gth-szv',
+        pseudo='gth-pade',
+        unit='bohr',
+        verbose=0,
+    )
+
+    cell_si = pyscf.M(
+        atom=[['Si', [0.0, 0.0, 0.0]], ['Si', [2.5, 2.5, 0.0]]],
+        a=np.eye(3) * 8.0,
+        basis='gth-szv',
+        pseudo='gth-pade',
+        unit='bohr',
+        verbose=0,
+    )
+
+    cell_fe = pyscf.M(
+        atom=[['Fe', [0.0, 0.0, 0.0]], ['Fe', [2.71, 2.71, 2.71]]],
+        a=np.eye(3) * 5.42,
+        basis='gth-dzvp-molopt-sr',
+        pseudo='gth-pbe',
+        unit='bohr',
+        verbose=0,
+    )
+
+
+class TestContractPpnl(unittest.TestCase):
+    """Test GPU _contract_ppnl_gpu against CPU _contract_ppnl, gamma point."""
+
+    def _compare(self, cell, places=13):
+        from gpu4pyscf.pbc.gto.pseudo.pp_int import _contract_ppnl_gpu
+        kpts = np.zeros((1, 3))
+        fakecell, hl_blocks = fake_cell_vnl(cell)
+        ppnl_half = _int_vnl(cell, fakecell, hl_blocks, kpts)
+
+        cpu = _contract_ppnl(cell, fakecell, hl_blocks, ppnl_half, kpts=kpts)
+        gpu = _contract_ppnl_gpu(cell, fakecell, hl_blocks, ppnl_half, kpts=kpts)
+
+        err = np.max(np.abs(np.asarray(gpu) - np.asarray(cpu)))
+        self.assertAlmostEqual(err, 0, places, f"max|err|={err:.2e}")
+
+    def test_carbon(self):
+        self._compare(cell_c)
+
+    def test_silicon(self):
+        self._compare(cell_si)
+
+    def test_iron(self):
+        self._compare(cell_fe, places=12)
+
+
+class TestGetPpNlGamma(unittest.TestCase):
+    """Test get_pp_nl_gpu against CPU get_pp_nl, gamma point."""
+
+    def _compare(self, cell, places=12):
+        from gpu4pyscf.pbc.gto.pseudo.pp_int import get_pp_nl_gpu
+        cpu = get_pp_nl(cell)
+        gpu = get_pp_nl_gpu(cell)
+        err = np.max(np.abs(np.asarray(gpu) - np.asarray(cpu)))
+        self.assertAlmostEqual(err, 0, places, f"max|err|={err:.2e}")
+
+    def test_carbon(self):
+        self._compare(cell_c)
+
+    def test_silicon(self):
+        self._compare(cell_si)
+
+    def test_iron(self):
+        self._compare(cell_fe, places=10)
+
+
+class TestGetPpNlKpts(unittest.TestCase):
+    """Test get_pp_nl_gpu against CPU get_pp_nl with non-zero k-points."""
+
+    def _compare(self, cell, kpts, places=13):
+        from gpu4pyscf.pbc.gto.pseudo.pp_int import get_pp_nl_gpu
+        cpu = get_pp_nl(cell, kpts)
+        gpu = get_pp_nl_gpu(cell, kpts)
+        err = np.max(np.abs(np.asarray(gpu) - np.asarray(cpu)))
+        self.assertAlmostEqual(err, 0, places, f"max|err|={err:.2e}")
+
+    def test_silicon_single_kpt(self):
+        kpts = np.array([[0.1, 0.0, 0.0]])
+        self._compare(cell_si, kpts)
+
+    def test_silicon_kmesh(self):
+        kpts = cell_si.make_kpts([2, 2, 2])
+        self._compare(cell_si, kpts)
+
+    def test_iron_single_kpt(self):
+        kpts = np.array([[0.1, 0.0, 0.0]])
+        self._compare(cell_fe, kpts, places=12)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
 - Add _contract_ppnl_gpu and get_pp_nl_gpu in gpu4pyscf/pbc/gto/pseudo/pp_int.py
 - Use get_pp_nl_gpu in multigrid.get_pp, multigrid_v2.get_pp, rsdf_builder.get_pp, aft.get_pp
 - Add gpu4pyscf/pbc/gto/pseudo/tests/test_pp_int.py covering both branches on C, Si, Fe