### PR TITLE
Apply sparsity to XC Hessian

### DIFF
--- a/gpu4pyscf/dft/numint.py
+++ b/gpu4pyscf/dft/numint.py
@@ -2009,7 +2009,7 @@ def _sparse_index(mol, coords, l_ctr_offsets, ao_loc, opt=None):
     return pad, idx, non0shl_idx, ctr_offsets_slice, ao_loc_slice
 
 def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
-                non0tab=None, blksize=None, buf=None, extra=0, grid_range=None):
+                non0tab=None, blksize=None, buf=None, extra=0, grid_range=None, strict_grid_order=False):
     '''
     Generator loops over grids block-by-block.
     Kwargs:
@@ -2018,7 +2018,8 @@ def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
         non0tab: dummy argument for compatibility with PySCF
         blksize: if not given, it will be estimated with avail GPU memory.
         buf: dummy argument for compatibility with PySCF
-        grid_range: loop [grid_start, grid_end] in grids only. TODO: Henry 20251006 believes these parameters are not respected.
+        grid_range: loop [grid_start, grid_end] in grids only. Both values has to be multiple of MIN_BLK_SIZE.
+        strict_grid_order: if True, no grids will be skipped, even if ao dimension is zero.
     '''
     log = logger.new_logger(mol)
     if grids.coords is None:
@@ -2066,13 +2067,16 @@ def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
         pad, idx, non0shl_idx, ctr_offsets_slice, ao_loc_slice = non0ao_idx[block_id]
         nao_sub = len(idx)
 
-        if nao_sub == 0:
-            continue
-
         ip0 = block_id * MIN_BLK_SIZE
         ip1 = min(ip0 + MIN_BLK_SIZE, ngrids)
         coords = cupy.asarray(grids.coords[ip0:ip1])
         weight = cupy.asarray(grids.weights[ip0:ip1])
+
+        if nao_sub == 0:
+            if strict_grid_order:
+                zero_sized_ao = cupy.ndarray((comp,nao_sub,ip1-ip0), memptr=buf.data)
+                yield zero_sized_ao, idx, weight, coords
+            continue
 
         ao_mask = eval_ao(
             _sorted_mol, coords, deriv,

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -417,8 +417,10 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     '''Full response including the response of the grids'''
     log = logger.new_logger(mol, verbose)
     t0 = log.init_timer()
+    ni = numint.NumInt() # Don't mess up with the old numint object
     xctype = ni._xc_type(xc_code)
 
+    grids = grids.copy()
     grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
 
@@ -556,8 +558,10 @@ def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=
     log = logger.new_logger(mol, verbose)
     t0 = log.init_timer()
 
+    grids = grids.copy()
     grids.build(sort_grids = False)
 
+    ni = numint.NumInt() # Don't mess up with the old numint object
     ni.gdftopt = None
     ni.build(mol, grids.coords)
     opt = ni.gdftopt

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -452,10 +452,11 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     rho = cupy.empty([ncomp, ngrids])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv, strict_grid_order = True):
         g0, g1 = g1, g1 + weight.size
         dms_masked = take_last2d(dms, idx, out=dm_mask_buf)
         rho[:, g0:g1] = numint.eval_rho(_sorted_mol, ao, dms_masked, xctype = xctype, hermi = 1)
+    assert g1 == ngrids
 
     exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
     exc = exc[:,0]
@@ -488,7 +489,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     del exc
 
     g0 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1, strict_grid_order = True):
         g1 = g0 + weight.shape[0]
 
         ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -538,6 +539,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
             raise NotImplementedError(f"Unrecognized xctype = {xctype}")
 
         g0 = g1
+    assert g1 == ngrids
 
     excsum = de_grid_response_weight + de_grid_response_rho
     excsum = excsum.get()
@@ -583,10 +585,11 @@ def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=
     ngrids_full = grids.coords.shape[0]
     rho_drho = cupy.empty([4, ngrids_full])
     g1 = 0
-    for split_ao, ao_mask_index, split_weights, split_coords in ni.block_loop(_sorted_mol, grids, deriv = 1):
+    for split_ao, ao_mask_index, split_weights, split_coords in ni.block_loop(_sorted_mol, grids, deriv = 1, strict_grid_order = True):
         g0, g1 = g1, g1 + split_weights.size
         dms_masked = dms[ao_mask_index[:,None], ao_mask_index]
         rho_drho[:, g0:g1] = numint.eval_rho(_sorted_mol, split_ao, dms_masked, xctype = "NLC", hermi = 1)
+    assert g1 == ngrids_full
 
     rho_i = rho_drho[0,:]
 

--- a/gpu4pyscf/grad/uks.py
+++ b/gpu4pyscf/grad/uks.py
@@ -259,8 +259,10 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     '''Full response including the response of the grids'''
     log = logger.new_logger(mol, verbose)
     t0 = log.init_timer()
+    ni = numint.NumInt() # Don't mess up with the old ni
     xctype = ni._xc_type(xc_code)
 
+    grids = grids.copy()
     grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
 

--- a/gpu4pyscf/grad/uks.py
+++ b/gpu4pyscf/grad/uks.py
@@ -294,12 +294,13 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     rho = cupy.empty([2, ncomp, ngrids])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv, strict_grid_order = True):
         g0, g1 = g1, g1 + weight.size
         dma_masked = take_last2d(dms[0], idx, out=dm_mask_buf)
         rho[0, :, g0:g1] = numint.eval_rho(_sorted_mol, ao, dma_masked, xctype = xctype, hermi = 1)
         dmb_masked = take_last2d(dms[1], idx, out=dm_mask_buf)
         rho[1, :, g0:g1] = numint.eval_rho(_sorted_mol, ao, dmb_masked, xctype = xctype, hermi = 1)
+    assert g1 == ngrids
 
     exc, vxc = ni.eval_xc_eff(xc_code, rho, 1, xctype=xctype)[:2]
     exc = exc[:,0]
@@ -332,7 +333,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     del exc
 
     g0 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1, strict_grid_order = True):
         g1 = g0 + weight.shape[0]
 
         ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -397,6 +398,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
             raise NotImplementedError(f"Unrecognized xctype = {xctype}")
 
         g0 = g1
+    assert g1 == ngrids
 
     excsum = de_grid_response_weight + de_grid_response_rho
     excsum = excsum.get()

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -45,6 +45,9 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     log = logger.new_logger(hessobj, verbose)
     time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
+    import time
+    cupy.cuda.runtime.deviceSynchronize()
+    time_0 = time.time()
     mol = hessobj.mol
     mf = hessobj.base
     ni = mf._numint
@@ -103,6 +106,9 @@ def _get_exc_deriv2(hessobj, mo_coeff, mo_occ, dm0, max_memory, atmlst = None, l
     mol = hessobj.mol
     mf = hessobj.base
 
+    import time
+    cupy.cuda.runtime.deviceSynchronize()
+    time_0 = time.time()
     de2 = cupy.zeros([mol.natm, mol.natm, 3, 3])
 
     mem_now = lib.current_memory()[0]
@@ -123,6 +129,10 @@ def _get_exc_deriv2(hessobj, mo_coeff, mo_occ, dm0, max_memory, atmlst = None, l
 
         for j0 in range(i0):
             de2[j0,i0] = de2[i0,j0].T
+    cupy.cuda.runtime.deviceSynchronize()
+    time_1 = time.time()
+    print(f"d2e xc no response time = {time_1 - time_0}")
+    time_0 = time_1
     if hessobj.grid_response:
         log.info("Calculating grid response for DFT Hessian")
         de2 += _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
@@ -3093,6 +3103,91 @@ def get_drho_dA_full(dm0, xctype, natm, ngrids, aoslices = None, atom_to_grid_in
         return drho_dA_orbital_response, dnablarho_dA_orbital_response, dtau_dA_orbital_response, \
                drho_dA_grid_response, dnablarho_dA_grid_response, dtau_dA_grid_response
 
+def get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = None, i_atom_of_grids = None,
+                       mu = None, dmu_dr = None, d2mu_dr2 = None,
+                       with_orbital_response = True, with_grid_response = True):
+    if xctype == "LDA":
+        with_nablarho = False
+        with_tau = False
+        n_component = 1
+    elif xctype == "GGA":
+        with_nablarho = True
+        with_tau = False
+        n_component = 4
+    elif xctype == "MGGA":
+        with_nablarho = True
+        with_tau = True
+        n_component = 5
+    else:
+        raise NotImplementedError(f"Unrecognized xctype = {xctype}")
+
+    nao = dm0_masked.shape[-1]
+    assert mu is not None
+    ngrids = mu.shape[1]
+    assert mu.shape == (nao, ngrids)
+    assert dmu_dr is not None and dmu_dr.shape == (3, nao, ngrids)
+    if with_nablarho or with_tau:
+        assert d2mu_dr2 is not None and d2mu_dr2.shape == (3, 3, nao, ngrids)
+
+    if with_orbital_response:
+        assert masked_i_atom_of_aos is not None
+        masked_i_atom_of_aos = cupy.asarray(masked_i_atom_of_aos, dtype = numpy.int32)
+        assert masked_i_atom_of_aos.shape == (nao,)
+    if with_grid_response:
+        assert i_atom_of_grids is not None
+        i_atom_of_grids = int(i_atom_of_grids)
+        assert 0 <= i_atom_of_grids and i_atom_of_grids < natm
+
+    dm_dmT = dm0_masked + dm0_masked.T
+    dm_dot_mu_and_nu = dm_dmT @ mu
+    if with_nablarho:
+        dm_dot_dmu_and_dnu = contract('djg,ij->dig', dmu_dr, dm_dmT)
+
+    assert with_orbital_response or with_grid_response, "Why are you calling this function?"
+
+    drho_dA_orbital_response = None
+    if with_orbital_response:
+        drho_dA_orbital_response = cupy.zeros([natm, 3, n_component, ngrids])
+    drho_dA_grid_response = None
+    if with_grid_response:
+        drho_dA_grid_response = cupy.zeros([natm, 3, n_component, ngrids])
+
+    rho_response = dmu_dr * dm_dot_mu_and_nu[None, :, :]
+    if with_orbital_response:
+        cupy.add.at(drho_dA_orbital_response[:, :, 0, :], masked_i_atom_of_aos, rho_response.transpose(1,0,2))
+    if with_grid_response:
+        rho_response = cupy.einsum('dig->dg', rho_response)
+        drho_dA_grid_response[i_atom_of_grids, :, 0, :] = rho_response
+    del rho_response
+
+    if with_nablarho:
+        nablarho_response = d2mu_dr2 * dm_dot_mu_and_nu[None, None, :, :]
+        nablarho_response += contract('dig,Dig->dDig', dmu_dr, dm_dot_dmu_and_dnu)
+        if with_orbital_response:
+            cupy.add.at(drho_dA_orbital_response[:, :, 1:4, :], masked_i_atom_of_aos, nablarho_response.transpose(2,0,1,3))
+        if with_grid_response:
+            nablarho_response = cupy.einsum('dDig->dDg', nablarho_response)
+            drho_dA_grid_response[i_atom_of_grids, :, 1:4, :] = nablarho_response
+        del nablarho_response
+
+    if with_tau:
+        tau_reponse = 0.5 * contract('dDig,Dig->dig', d2mu_dr2, dm_dot_dmu_and_dnu)
+        if with_orbital_response:
+            cupy.add.at(drho_dA_orbital_response[:, :, 4, :], masked_i_atom_of_aos, tau_response.transpose(1,0,2))
+        if with_grid_response:
+            tau_reponse = cupy.einsum('dig->dg', tau_reponse)
+            drho_dA_grid_response[i_atom_of_grids, :, 4, :] = tau_reponse
+        del tau_reponse
+
+    drho_dA_orbital_response *= -1
+
+    if xctype == "LDA":
+        if drho_dA_orbital_response is not None:
+            drho_dA_orbital_response = drho_dA_orbital_response[:, :, 0, :]
+        if drho_dA_grid_response is not None:
+            drho_dA_grid_response = drho_dA_grid_response[:, :, 0, :]
+    return drho_dA_orbital_response, drho_dA_grid_response
+
 def get_d2rho_dAdB_full(dm0, xctype, natm, ngrids, aoslices = None, atom_to_grid_index_map = None,
                         mu = None, dmu_dr = None, d2mu_dr2 = None, d3mu_dr3 = None,
                         with_orbital_response = True, with_grid_response = True):
@@ -3502,6 +3597,176 @@ def contract_d2rho_dAdB_full(dm0, xctype, natm, ngrids, aoslices = None, atom_to
 
     return d2e
 
+def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = None, i_atom_of_grids = None,
+                               mu = None, dmu_dr = None, d2mu_dr2 = None, d3mu_dr3 = None,
+                               weight_depsilon_drho = None, weight_depsilon_dnablarho = None, weight_depsilon_dtau = None,
+                               with_orbital_response = True, with_grid_response = True):
+    if xctype == "LDA":
+        with_nablarho = False
+        with_tau = False
+    elif xctype == "GGA":
+        with_nablarho = True
+        with_tau = False
+    elif xctype == "MGGA":
+        with_nablarho = True
+        with_tau = True
+    else:
+        raise NotImplementedError(f"Unrecognized xctype = {xctype}")
+
+    nao = dm0_masked.shape[-1]
+    assert mu is not None
+    ngrids = mu.shape[1]
+    assert mu.shape == (nao, ngrids)
+    assert dmu_dr is not None and dmu_dr.shape == (3, nao, ngrids)
+    assert d2mu_dr2 is not None and d2mu_dr2.shape == (3, 3, nao, ngrids)
+    if with_nablarho or with_tau:
+        assert d3mu_dr3 is not None and d3mu_dr3.shape == (3, 3, 3, nao, ngrids)
+
+    assert weight_depsilon_drho is not None and weight_depsilon_drho.shape == (ngrids,)
+    if with_nablarho:
+        assert weight_depsilon_dnablarho is not None and weight_depsilon_dnablarho.shape == (3, ngrids)
+    if with_tau:
+        assert weight_depsilon_dtau is not None and weight_depsilon_dtau.shape == (ngrids,)
+
+    if with_orbital_response or with_grid_response: # There are cross terms in grid response
+        assert masked_i_atom_of_aos is not None
+        masked_i_atom_of_aos = cupy.asarray(masked_i_atom_of_aos, dtype = numpy.int32)
+        assert masked_i_atom_of_aos.shape == (nao,)
+    if with_grid_response:
+        assert i_atom_of_grids is not None
+        i_atom_of_grids = int(i_atom_of_grids)
+        assert 0 <= i_atom_of_grids and i_atom_of_grids < natm
+
+    # order = cp.argsort(X)
+    # sorted_vals = X[order]
+    # splits = cp.flatnonzero(cp.diff(sorted_vals)) + 1
+    # groups = cp.split(order, splits.get())
+
+    dm_dmT = dm0_masked + dm0_masked.T
+    dm_dot_mu = dm_dmT @ mu
+    dm_dot_dmudr = contract("ij,djg->dig", dm_dmT, dmu_dr)
+
+    d2e = cupy.zeros([natm, natm, 3, 3])
+
+    if with_orbital_response:
+        pass
+    #     for i_atom in range(natm):
+    #         pi0, pi1 = aoslices[i_atom][2:]
+    #         # d2mu/dr2 * nu, A orbital, B orbital
+    #         dm_dot_mu_i = dm_dot_mu[pi0:pi1, :]
+    #         d2mudAdA_nu = contract("dDig,ig->dDg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_mu_i)
+    #         d2e[i_atom, i_atom, :, :] += d2mudAdA_nu @ weight_depsilon_drho
+    #         d2mudAdA_nu = None
+
+    #         if with_nablarho:
+    #             # d3mu/(dr dA dB) * nu, A orbital, B orbital
+    #             d3mudAdAdr_nu = contract("dDxig,ig->dDxg", d3mu_dr3[:, :, :, pi0:pi1, :], dm_dot_mu_i)
+    #             d2e[i_atom, i_atom, :, :] += contract("dDxg,xg->dD", d3mudAdAdr_nu, weight_depsilon_dnablarho)
+    #             d3mudAdAdr_nu = None
+    #             # d2mu/(dA dB) * dnu/dr, A orbital, B orbital
+    #             dm_dot_dmudr_i = dm_dot_dmudr[:, pi0:pi1, :]
+    #             d2mudAdA_dnudr = contract("dDig,xig->dDxg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_dmudr_i)
+    #             d2e[i_atom, i_atom, :, :] += contract("dDxg,xg->dD", d2mudAdA_dnudr, weight_depsilon_dnablarho)
+    #             d2mudAdA_dnudr = None
+    #         dm_dot_mu_i = None
+
+    #         if with_tau:
+    #             # d3mu/(dA dB dr) * dnu/dr, A orbital, B orbital
+    #             d3mudAdAdr_dnudr = contract("dDxig,xig->dDg", d3mu_dr3[:, :, :, pi0:pi1, :], dm_dot_dmudr_i)
+    #             d2e[i_atom, i_atom, :, :] += 0.5 * d3mudAdAdr_dnudr @ weight_depsilon_dtau
+    #             d3mudAdAdr_dnudr = None
+    #         dm_dot_dmudr_i = None
+
+    #         for j_atom in range(natm):
+    #             pj0, pj1 = aoslices[j_atom][2:]
+    #             # dmu/dr * dnu/dr, A orbital, B orbital
+    #             dm_dot_dmudr_ij = contract("djg,ij->dig", dmu_dr[:, pj0:pj1, :], dm_dmT[pi0:pi1, pj0:pj1])
+    #             dmudA_dnudB = contract("dig,Dig->dDg", dmu_dr[:, pi0:pi1, :], dm_dot_dmudr_ij)
+    #             d2e[i_atom, j_atom, :, :] += dmudA_dnudB @ weight_depsilon_drho
+
+    #             if with_nablarho:
+    #                 # d2mu/(dr dA) * dnu/dB, A orbital, B orbital
+    #                 d2mudAdr_dnudB = contract("dxig,Dig->dDxg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_dmudr_ij)
+    #                 d2e_ij_AB = contract("dDxg,xg->dD", d2mudAdr_dnudB, weight_depsilon_dnablarho)
+    #                 d2mudAdr_dnudB = None
+    #                 d2e[i_atom, j_atom, :, :] += d2e_ij_AB
+    #                 d2e[j_atom, i_atom, :, :] += d2e_ij_AB.T
+    #                 d2e_ij_AB = None
+    #             dm_dot_dmudr_ij = None
+
+    #             if with_tau:
+    #                 pj0, pj1 = aoslices[j_atom][2:]
+    #                 # d2mu/(dA dr) * d2nu/(dB dr), A orbital, B orbital
+    #                 dm_dot_d2mudr2_ij = contract("dDjg,ij->dDig", d2mu_dr2[:, :, pj0:pj1, :], dm_dmT[pi0:pi1, pj0:pj1])
+    #                 d2mudAdr_d2nudBdr = contract("dxig,Dxig->dDg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_d2mudr2_ij)
+    #                 dm_dot_d2mudr2_ij = None
+    #                 d2e[i_atom, j_atom, :, :] += 0.5 * d2mudAdr_d2nudBdr @ weight_depsilon_dtau
+    #                 d2mudAdr_d2nudBdr = None
+
+    if with_grid_response:
+        # d2mu/dr2 * nu, A orbital, B grid
+        d2rhodAdG = contract("dDig,ig->dDi", d2mu_dr2, dm_dot_mu * weight_depsilon_drho)
+        # dmu/dr * dnu/dr, A orbital, B grid
+        d2rhodAdG += contract("dig,Dig->dDi", dmu_dr, dm_dot_dmudr * weight_depsilon_drho)
+        d2e_ji_AB_ao_uncontracted = d2rhodAdG
+        del d2rhodAdG
+
+        if with_nablarho:
+            # d3mu/(dr dA dB) * nu, A orbital, B grid
+            d3mudr3_wv = contract("dDxig,xg->dDig", d3mu_dr3, weight_depsilon_dnablarho)
+            d2nablarhodAdG = contract("dDig,ig->dDi", d3mudr3_wv, dm_dot_mu)
+            del d3mudr3_wv
+            # d2mu/(dA dB) * dnu/dr, A orbital, B grid
+            dm_dmudr_wv = contract("xig,xg->ig", dm_dot_dmudr, weight_depsilon_dnablarho)
+            d2nablarhodAdG += contract("dDig,ig->dDi", d2mu_dr2, dm_dmudr_wv)
+            del dm_dmudr_wv
+            # d2mu/(dr dA) * dnu/dB, A orbital, B grid
+            d2mudr2_wv = contract("dxig,xg->dig", d2mu_dr2, weight_depsilon_dnablarho)
+            d2nablarhodAdG += contract("dig,Dig->dDi", d2mudr2_wv, dm_dot_dmudr)
+            # del d2mudr2_wv
+            # d2mu/(dr dA) * dnu/dB, A grid, B orbital
+            # dm_d2mudr2_wv = contract("dxig,xg->dig", dm_dot_d2mudr2, weight_depsilon_dnablarho)
+            dm_d2mudr2_wv = contract("ij,djg->dig", dm_dmT, d2mudr2_wv)
+            d2nablarhodAdG += contract("dig,Dig->dDi", dmu_dr, dm_d2mudr2_wv)
+            del dm_d2mudr2_wv
+
+            d2e_ji_AB_ao_uncontracted += d2nablarhodAdG
+            del d2nablarhodAdG
+
+
+        # if with_tau:
+        #     d2taudGdG = cupy.ndarray([3, 3, ngrids_i], memptr = buf_27_nao_ngrids.data)
+        #     # d3mu/(dA dB dr) * dnu/dr, A grid, B grid
+        #     contract("dDxig,xig->dDg", d3mu_dr3_grid_i, dm_dot_dmudr_i, beta = 0.0, out = d2taudGdG)
+        #     # d2mu/(dA dr) * d2nu/(dB dr), A grid, B grid
+        #     contract("dxig,Dxig->dDg", d2mu_dr2_grid_i, dm_dot_d2mudr2_i, beta = 1.0, out = d2taudGdG)
+        #     d2e[i_atom, i_atom, :, :] += 0.5 * d2taudGdG @ weight_depsilon_dtau_grid_i
+        #     d2taudGdG = None
+
+
+        # if with_tau:
+        #     d2taudAdG = cupy.ndarray([3, 3, ngrids_i], memptr = buf_27_nao_ngrids.data)
+        #     # d3mu/(dA dB dr) * dnu/dr, A orbital, B grid
+        #     contract("dDxig,xig->dDg", d3mu_dr3_grid_i[:, :, :, pj0:pj1, :], dm_dot_dmudr_ji, beta = 0.0, out = d2taudAdG)
+        #     # d2mu/(dA dr) * d2nu/(dB dr), A orbital, B grid
+        #     contract("dxig,Dxig->dDg", d2mu_dr2_grid_i[:, :, pj0:pj1, :], dm_dot_d2mudr2_ij, beta = 1.0, out = d2taudAdG)
+        #     d2e_ji_AB_ao_uncontracted += 0.5 * d2taudAdG @ weight_depsilon_dtau_grid_i
+        #     d2taudAdG = None
+
+        d2e[i_atom_of_grids, i_atom_of_grids, :, :] += cupy.einsum("dDi->dD", d2e_ji_AB_ao_uncontracted)
+
+        d2e_ji_AB = cupy.zeros((natm, 3, 3))
+        d2e_ji_AB_ao_uncontracted = d2e_ji_AB_ao_uncontracted.transpose(2,0,1)
+        cupy.add.at(d2e_ji_AB, masked_i_atom_of_aos, d2e_ji_AB_ao_uncontracted)
+        del d2e_ji_AB_ao_uncontracted
+        # Why is there a transpose for this equation? Because we're using j index at where it supposes to be i.
+        d2e[i_atom_of_grids, :, :, :] -= d2e_ji_AB.transpose(0,2,1)
+        d2e[:, i_atom_of_grids, :, :] -= d2e_ji_AB
+        del d2e_ji_AB
+
+    return d2e
+
+import time
 def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     """
         xc energy 2nd derivative grid response contribution
@@ -3516,15 +3781,23 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         grids = hessobj.grids
     else:
         grids = mf.grids
-    if grids.coords is None:
-        grids.build()
+    grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
+
+    ni.gdftopt = None
+    ni.build(mol, grids.coords)
+    opt = ni.gdftopt
+
+    _sorted_mol = opt._sorted_mol
+    nao = _sorted_mol.nao
 
     natm = mol.natm
     aoslices = mol.aoslice_by_atom()
 
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
     assert dm0.ndim == 2
+    dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
+    dm_mask_buf = cupy.empty(nao * nao)
 
     d2e = cupy.zeros([mol.natm, mol.natm, 3, 3])
 
@@ -3629,7 +3902,12 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
         ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
 
+        time_eval_xc = 0
+        time_eval_d2w = 0
+        time_contract_d2w = 0
         for g0 in range(0, ngrids, ngrids_per_batch):
+            cupy.cuda.runtime.deviceSynchronize()
+            time_0 = time.time()
             g1 = min(g0 + ngrids_per_batch, ngrids)
             split_grids_coords = grids.coords[g0:g1, :]
             split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 1, gdftopt = None, transpose = False)
@@ -3644,10 +3922,26 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             rho = None
             exc = None
 
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_xc += time_1 - time_0
+            time_0 = time_1
             d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_d2w += time_1 - time_0
+            time_0 = time_1
             d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_contract_d2w += time_1 - time_0
+            time_0 = time_1
             d2w_dAdB = None
             epsilon = None
+
+        print(f"time_eval_xc = {time_eval_xc}")
+        print(f"time_eval_d2w = {time_eval_d2w}")
+        print(f"time_contract_d2w = {time_contract_d2w}")
 
         available_gpu_memory = get_avail_mem()
         available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
@@ -3660,7 +3954,17 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
         ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
 
+        d2e_d2rho = 0
+        time_eval_ao = 0
+        time_eval_xc = 0
+        time_eval_drho = 0
+        time_eval_dw = 0
+        time_contract_dw = 0
+        time_contract_drho_cross = 0
+        time_contract_d2rho = 0
         for g0 in range(0, ngrids, ngrids_per_batch):
+            cupy.cuda.runtime.deviceSynchronize()
+            time_0 = time.time()
             g1 = min(g0 + ngrids_per_batch, ngrids)
             split_grids_coords = grids.coords[g0:g1, :]
             split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 3, gdftopt = None, transpose = False)
@@ -3669,6 +3973,10 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             dmu_dr = split_ao[1:4]
             d2mu_dr2 = get_d2mu_dr2(split_ao)
             d3mu_dr3 = get_d3mu_dr3(split_ao)
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_ao += time_1 - time_0
+            time_0 = time_1
 
             rho_drho = numint.eval_rho2(mol, split_ao[:4], mo_coeff, mo_occ, xctype=xctype)
             vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 2, xctype=xctype)[1:3]
@@ -3680,6 +3988,11 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             # d2epsilon_drho_dnablarho = fxc[0,1:4]
             # d2epsilon_dnablarho2 = fxc[1:4,1:4]
 
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_xc += time_1 - time_0
+            time_0 = time_1
+
             grid_to_atom_index_map = grids.atm_idx[g0:g1]
             atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
             grid_to_atom_index_map = None
@@ -3690,7 +4003,18 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             drho_dA_full = drho_dA_orbital_response + drho_dA_grid_response
             dnablarho_dA_full = dnablarho_dA_orbital_response + dnablarho_dA_grid_response
 
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_drho += time_1 - time_0
+            time_0 = time_1
+
             dw_dA = get_dweight_dA(mol, grids, (g0,g1))
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_dw += time_1 - time_0
+            time_0 = time_1
+
             # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full)
             # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full)
             # d2e += cupy.einsum("Adg,xg,BDxg->ABdD", dw_dA, depsilon_dnablarho, dnablarho_dA_full)
@@ -3701,8 +4025,13 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             drho_dA_full = None
             depsilondnablarho_dnablarhodA = None
             dw_dA = None
-            d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
+            # d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
             d2e_dwdA_term = None
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_contract_dw += time_1 - time_0
+            time_0 = time_1
 
             weight = grids.weights[g0:g1]
             # # d2epsilon/drho2 * drho/dA * drho/dB
@@ -3738,13 +4067,167 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             d2e_drhodA_cross_term += contract("Adxg,BDxg->ABdD", combined_d_dA_grid_response, drhodA_grid_response_fwxc)
             combined_d_dA_grid_response = None
             drhodA_grid_response_fwxc = None
-            d2e += d2e_drhodA_cross_term
+            # d2e += d2e_drhodA_cross_term
             d2e_drhodA_cross_term = None
 
-            d2e += contract_d2rho_dAdB_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_contract_drho_cross += time_1 - time_0
+            time_0 = time_1
+
+            d2e_d2rho += contract_d2rho_dAdB_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
                                             mu, dmu_dr, d2mu_dr2, d3mu_dr3,
                                             depsilon_drho * weight, depsilon_dnablarho * weight,
                                             with_orbital_response = False)
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_contract_d2rho += time_1 - time_0
+            time_0 = time_1
+
+        print(f"time_eval_ao = {time_eval_ao}")
+        print(f"time_eval_xc = {time_eval_xc}")
+        print(f"time_eval_drho = {time_eval_drho}")
+        print(f"time_eval_dw = {time_eval_dw}")
+        print(f"time_contract_dw = {time_contract_dw}")
+        print(f"time_contract_drho_cross = {time_contract_drho_cross}")
+        print(f"time_contract_d2rho = {time_contract_d2rho}")
+
+        test_d2e_d2rho = 0
+        time_eval_ao = 0
+        time_eval_xc = 0
+        time_eval_drho = 0
+        time_eval_dw = 0
+        time_contract_dw = 0
+        time_contract_drho_cross = 0
+        time_contract_d2rho = 0
+
+        nonzero_weight_mask = cupy.abs(grids.weights) > 1e-20
+
+        ao_loc_sorted = _sorted_mol.ao_loc
+        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+        from pyscf.gto.mole import ATOM_OF
+        i_atom_of_aos = numpy.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+        i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, _sorted_mol.nao, deriv = 3):
+            g1 = g0 + weight.shape[0]
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_0 = time.time()
+
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_ao += time_1 - time_0
+            time_0 = time_1
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype = xctype)[1:3]
+            del rho
+
+            depsilon_drho = vxc[0]
+            depsilon_dnablarho = vxc[1:4]
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_xc += time_1 - time_0
+            time_0 = time_1
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_drho += time_1 - time_0
+            time_0 = time_1
+
+            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_eval_dw += time_1 - time_0
+            time_0 = time_1
+
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->ABdD", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->BADd", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            depsilondnablarho_dnablarhodA = contract("xg,Adxg->Adg", depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drho_dA_full_response[:,:,0,:] * depsilon_drho + depsilondnablarho_dnablarhodA)
+            del depsilondnablarho_dnablarhodA
+            del dw_dA
+            d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
+            del d2e_dwdA_term
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_contract_dw += time_1 - time_0
+            time_0 = time_1
+
+            weight = weight[nonzero_weight_mask[g0:g1]]
+            fwxc = fxc * weight
+            del fxc
+            drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, drho_dA_grid_response)
+            del fwxc
+            d2e_drhodA_cross_term = contract("Adxg,BDxg->ABdD", drho_dA_orbital_response, drhodA_grid_response_fwxc)
+            del drho_dA_orbital_response
+            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
+            d2e_drhodA_cross_term += contract("Adxg,BDxg->ABdD", drho_dA_grid_response, drhodA_grid_response_fwxc)
+            del drho_dA_grid_response
+            del drhodA_grid_response_fwxc
+            d2e += d2e_drhodA_cross_term
+            del d2e_drhodA_cross_term
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_contract_drho_cross += time_1 - time_0
+            time_0 = time_1
+
+            test_d2e_d2rho += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                                              mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                                              depsilon_drho * weight, depsilon_dnablarho * weight,
+                                              with_orbital_response = False)
+
+            cupy.cuda.runtime.deviceSynchronize()
+            time_1 = time.time()
+            time_contract_d2rho += time_1 - time_0
+            time_0 = time_1
+
+            g0 = g1
+        assert g1 == ngrids
+
+        print(f"revised time_eval_ao = {time_eval_ao}")
+        print(f"revised time_eval_xc = {time_eval_xc}")
+        print(f"revised time_eval_drho = {time_eval_drho}")
+        print(f"revised time_eval_dw = {time_eval_dw}")
+        print(f"revised time_contract_dw = {time_contract_dw}")
+        print(f"revised time_contract_drho_cross = {time_contract_drho_cross}")
+        print(f"revised time_contract_d2rho = {time_contract_d2rho}")
+
+        print(cupy.max(cupy.abs(test_d2e_d2rho - d2e_d2rho)))
+
+        d2e += test_d2e_d2rho
 
     elif xctype == 'MGGA':
         available_gpu_memory = get_avail_mem()

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -1862,7 +1862,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             dmu_dr = ao[1:4]
 
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
-            mo_coeff_masked = mo_coeff_sorted[idx, :]
+            # mo_coeff_masked = mo_coeff_sorted[idx, :]
             mocc_masked = mocc_sorted[idx, :]
 
             rho = numint.eval_rho(_sorted_mol, ao[0], dm0_masked, xctype = xctype, hermi = 1)
@@ -1937,6 +1937,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             d2mu_dr2 = get_d2mu_dr2(ao)
 
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            # mo_coeff_masked = mo_coeff_sorted[idx, :]
             mocc_masked = mocc_sorted[idx, :]
 
             rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
@@ -2008,12 +2009,18 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
             dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += dmudA_nu_ao
 
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
             dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,2,1)
             del dmudA_nu_ao
             dFock_sparse_ao_occ[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
@@ -2041,6 +2048,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             d2mu_dr2 = get_d2mu_dr2(ao)
 
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            # mo_coeff_masked = mo_coeff_sorted[idx, :]
             mocc_masked = mocc_sorted[idx, :]
 
             rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
@@ -2106,10 +2114,14 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             weight_depsilon_dtau = wv[4]
             del wv
 
-            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
-            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dxpg,qg->dpq", depsilon_dnablarho * weight, d2mu_dr2, mu)
-            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dpg,xqg->dpq", depsilon_dnablarho * weight, dmu_dr, dmu_dr)
-            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += 0.5 * cupy.einsum("g,dxpg,xqg->dpq", depsilon_dtau * weight, d2mu_dr2, dmu_dr)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum(
+            #     "g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum(
+            #     "xg,dxpg,qg->dpq", depsilon_dnablarho * weight, d2mu_dr2, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum(
+            #     "xg,dpg,xqg->dpq", depsilon_dnablarho * weight, dmu_dr, dmu_dr)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += 0.5 * cupy.einsum(
+            #     "g,dxpg,xqg->dpq", depsilon_dtau * weight, d2mu_dr2, dmu_dr)
             dmudr_weight_depsilondnablarho = contract("xg,xpg->pg", weight_depsilon_dnablarho, dmu_dr)
             dmudA_nu_ao = contract("dpg,qg->dpq", dmu_dr, mu * weight_depsilon_drho + dmudr_weight_depsilondnablarho)
             del dmudr_weight_depsilondnablarho
@@ -2119,14 +2131,22 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
             dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += dmudA_nu_ao
 
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum("pi,g,dxpg,xqg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
-            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum("pi,g,dxqg,xpg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum(
+            #     "pi,g,dxpg,xqg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum(
+            #     "pi,g,dxqg,xpg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
             dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,2,1)
             del dmudA_nu_ao
             dFock_sparse_ao_occ[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
@@ -2148,8 +2168,14 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     for i_atom in range(0, natm):
         ao_of_atom_i = cupy.where(i_atom_of_aos == i_atom)[0]
         if ao_of_atom_i.size > 0:
-            dFock_mo_occ[i_atom, :, :, :] -= cupy.einsum("pi,dpq,qj->dij", mo_coeff_sorted[ao_of_atom_i], dFock_orbital_response_dmudA_nu_term[:, ao_of_atom_i, :], mocc_sorted)
-            dFock_mo_occ[i_atom, :, :, :] -= cupy.einsum("pi,dpq,qj->dij", mo_coeff_sorted, dFock_orbital_response_dmudA_nu_term[:, ao_of_atom_i, :].transpose(0,2,1), mocc_sorted[ao_of_atom_i])
+            dFock_ao_of_atom_i = dFock_orbital_response_dmudA_nu_term[:, ao_of_atom_i, :]
+
+            dFock_ao_of_atom_i_mocc = dFock_ao_of_atom_i @ mocc_sorted
+            dFock_mo_occ[i_atom, :, :, :] -= cupy.einsum("pi,dpj->dij", mo_coeff_sorted[ao_of_atom_i], dFock_ao_of_atom_i_mocc)
+            dFock_ao_of_atom_i_mocc = dFock_ao_of_atom_i.transpose(0,2,1) @ mocc_sorted[ao_of_atom_i]
+            dFock_mo_occ[i_atom, :, :, :] -= cupy.einsum("pi,dpj->dij", mo_coeff_sorted, dFock_ao_of_atom_i_mocc)
+            del dFock_ao_of_atom_i_mocc, dFock_ao_of_atom_i
+    del dFock_orbital_response_dmudA_nu_term
 
     return dFock_mo_occ
 

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -1746,454 +1746,6 @@ def _get_vxc_deriv1_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
         else:
             raise NotImplementedError(f"xctype = {xctype} not supported")
 
-        if hessobj.grid_response:
-            t2 = log.init_timer()
-
-            if xctype == 'LDA':
-                # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
-                available_gpu_memory = get_avail_mem()
-                available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-                ao_nbytes_per_grid = ((4 + 3 + 2 + 3*2 + 1) * mol.nao + (3*2) * mol.natm + 16 + 4) * 8
-                ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-                if ngrids_per_batch < 16:
-                    raise MemoryError(f"Out of GPU memory for LDA Fock first derivative, available gpu memory = {get_avail_mem()}"
-                                      f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}, device_id = {device_id}")
-                ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-                ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-                for g0 in range(grid_start, grid_end, ngrids_per_batch):
-                    g1 = min(g0 + ngrids_per_batch, grid_end)
-                    split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
-                    split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 1, gdftopt = None, transpose = False)
-
-                    mu = split_ao[0]
-                    dmu_dr = split_ao[1:4]
-
-                    rho = numint.eval_rho2(mol, mu, mo_coeff, mo_occ, xctype=xctype)
-                    vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
-                    rho = None
-
-                    depsilon_drho = vxc[0] # Just of shape (ngrids,)
-                    d2epsilon_drho2 = fxc[0,0] # Just of shape (ngrids,)
-
-                    dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-                    # # Negative here to cancel the overall negative sign before return
-                    # vmat -= cupy.einsum("Adg,g,pg,qg,qj->Adpj", dw_dA, depsilon_drho, mu, mu, mocc)
-                    dwdA_depsilondrho = dw_dA * depsilon_drho
-                    dw_dA = None
-                    mu_occ = mu.T @ mocc
-                    for i_atom in range(natm):
-                        dwdA_depsilondrho_mu = contract("dg,pg->dpg", dwdA_depsilondrho[i_atom, :, :], mu)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu, mu_occ)
-                        dwdA_depsilondrho_mu = None
-                    dwdA_depsilondrho = None
-
-                    grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
-                    atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-                    grid_to_atom_index_map = None
-
-                    _, drho_dA_grid_response = \
-                        get_drho_dA_full(dm0, xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, with_orbital_response = False)
-
-                    weight = cupy.asarray(grids.weights)[g0:g1]
-                    # # Negative here to cancel the overall negative sign before return
-                    # vmat -= cupy.einsum("g,g,Adg,pg,qg,qj->Adpj", weight, d2epsilon_drho2, drho_dA_grid_response, mu, mu, mocc)
-                    weight_d2epsilondrho2_drhodA_grid_response = drho_dA_grid_response * (weight * d2epsilon_drho2)
-                    drho_dA_grid_response = None
-                    for i_atom in range(natm):
-                        weight_d2epsilondrho2_drhodA_grid_response_mu = contract("dg,pg->dpg", weight_d2epsilondrho2_drhodA_grid_response[i_atom, :, :], mu)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_d2epsilondrho2_drhodA_grid_response_mu, mu_occ)
-                        weight_d2epsilondrho2_drhodA_grid_response_mu = None
-                    mu_occ = None
-
-                    for i_atom in range(natm):
-                        associated_grid_index = atom_to_grid_index_map[i_atom]
-                        if len(associated_grid_index) == 0:
-                            continue
-
-                        # # Negative here to cancel the overall negative sign before return
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dpg,qg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dqg,pg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        mu_grid_i = mu[:, associated_grid_index]
-                        weight_depsilondrho_dmudr_grid_i = dmu_dr[:, :, associated_grid_index] * \
-                                                           (weight[associated_grid_index] * depsilon_drho[associated_grid_index])
-                        mu_occ_grid_i = mu_grid_i.T @ mocc
-                        vmat[i_atom, :, :, :] -= weight_depsilondrho_dmudr_grid_i @ mu_occ_grid_i
-                        mu_occ_grid_i = None
-                        weight_depsilondrho_dmudr_occ_grid_i = contract("dqg,qj->djg", weight_depsilondrho_dmudr_grid_i, mocc)
-                        weight_depsilondrho_dmudr_grid_i = None
-                        vmat[i_atom, :, :, :] -= contract("pg,djg->dpj", mu_grid_i, weight_depsilondrho_dmudr_occ_grid_i)
-                        weight_depsilondrho_dmudr_occ_grid_i = None
-                        mu_grid_i = None
-
-            elif xctype == 'GGA':
-                # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
-                available_gpu_memory = get_avail_mem()
-                available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-                ao_nbytes_per_grid = ((10 + 9 + 2 + 3*2 + 2 + 3*2 + 3*3 + 9 + 4*3) * mol.nao + (3 + 3 + 9 + 3*4*2) * mol.natm + 4*2 + 16*2 + 2 + 2) * 8
-                ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-                if ngrids_per_batch < 16:
-                    raise MemoryError(f"Out of GPU memory for GGA Fock first derivative, available gpu memory = {get_avail_mem()}"
-                                      f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}, device_id = {device_id}")
-                ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-                ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-                for g0 in range(grid_start, grid_end, ngrids_per_batch):
-                    g1 = min(g0 + ngrids_per_batch, grid_end)
-                    split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
-                    split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
-
-                    mu = split_ao[0]
-                    dmu_dr = split_ao[1:4]
-                    d2mu_dr2 = get_d2mu_dr2(split_ao)
-
-                    rho_drho = numint.eval_rho2(mol, split_ao[:4], mo_coeff, mo_occ, xctype=xctype)
-                    vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 2, xctype=xctype)[1:3]
-
-                    # rho = rho_drho[0]
-                    # drho_dr = rho_drho[1:4]
-                    rho_drho = None
-
-                    depsilon_drho = vxc[0]
-                    depsilon_dnablarho = vxc[1:4]
-                    # d2epsilon_drho2 = fxc[0,0]
-                    # d2epsilon_drho_dnablarho = fxc[0,1:4]
-                    # d2epsilon_dnablarho2 = fxc[1:4,1:4]
-
-                    dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-                    # # Negative here to cancel the overall negative sign before return
-                    # vmat -= cupy.einsum("Adg,g,pg,qg,qj->Adpj", dw_dA, depsilon_drho, mu, mu, mocc)
-                    # vmat -= cupy.einsum("Adg,xg,xpg,qg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
-                    # vmat -= cupy.einsum("Adg,xg,xqg,pg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
-                    depsilondnablarho_dmudr = contract("xg,xpg->pg", depsilon_dnablarho, dmu_dr)
-                    depsilondrho_mu = mu * depsilon_drho
-                    mu_occ = mu.T @ mocc
-                    for i_atom in range(natm):
-                        dwdA_depsilondrho_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], depsilondrho_mu + depsilondnablarho_dmudr)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu, mu_occ)
-                        dwdA_depsilondrho_mu = None
-                    depsilondrho_mu = None
-                    mu_occ = None
-                    depsilondnablarho_dmudr_occ = depsilondnablarho_dmudr.T @ mocc
-                    depsilondnablarho_dmudr = None
-                    for i_atom in range(natm):
-                        dwdA_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], mu)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ)
-                        dwdA_mu = None
-                    depsilondnablarho_dmudr_occ = None
-                    dw_dA = None
-
-                    grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
-                    atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-                    grid_to_atom_index_map = None
-
-                    _, _, drho_dA_grid_response, dnablarho_dA_grid_response = \
-                        get_drho_dA_full(dm0, xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, with_orbital_response = False)
-
-                    weight = cupy.asarray(grids.weights)[g0:g1]
-                    # # Negative here to cancel the overall negative sign before return
-                    # # d2epsilon/drho2 * drho/dR * mu * nu
-                    # vmat -= cupy.einsum("g,g,Adg,pg,qg,qj->Adpj", weight, d2epsilon_drho2, drho_dA_grid_response, mu, mu, mocc)
-                    # # d2epsilon/(drho d_nabla_rho) * d_nabla_rho/dR * mu * nu
-                    # vmat -= cupy.einsum("g,xg,Adxg,pg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, dnablarho_dA_grid_response, mu, mu, mocc)
-                    # # d2epsilon/(d_nabla_rho drho) * drho/dR * nabla(mu * nu)
-                    # vmat -= cupy.einsum("g,xg,Adg,xpg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
-                    # vmat -= cupy.einsum("g,xg,Adg,xqg,pg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
-                    # # d2epsilon/(d_nabla_rho d_nabla_rho) * d_nabla_rho/dR * nabla(mu * nu)
-                    # vmat -= cupy.einsum("g,xyg,Adxg,ypg,qg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
-                    # vmat -= cupy.einsum("g,xyg,Adxg,yqg,pg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
-                    combined_d_dA_grid_response = cupy.concatenate((drho_dA_grid_response[:, :, None, :], dnablarho_dA_grid_response), axis = 2)
-                    drho_dA_grid_response = None
-                    dnablarho_dA_grid_response = None
-
-                    fwxc = fxc * weight
-                    fxc = None
-                    drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, combined_d_dA_grid_response)
-                    combined_d_dA_grid_response = None
-                    fwxc = None
-
-                    mu_occ = mu.T @ mocc
-                    dmudr_occ = contract("dqg,qj->dgj", dmu_dr, mocc)
-                    for i_atom in range(natm):
-                        drhodA_grid_response_fwxc_rho_term_mu = contract("dg,pg->dpg", drhodA_grid_response_fwxc[i_atom, :, 0, :], mu)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu, mu_occ)
-                        drhodA_grid_response_fwxc_rho_term_mu = None
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmudr_occ)
-                        vmat[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = None
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr = contract("dxg,xpg->dpg", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmu_dr)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr, mu_occ)
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr = None
-                    drhodA_grid_response_fwxc = None
-                    mu_occ = None
-                    dmudr_occ = None
-
-                    for i_atom in range(natm):
-                        associated_grid_index = atom_to_grid_index_map[i_atom]
-                        if len(associated_grid_index) == 0:
-                            continue
-                        # # Negative here to cancel the overall negative sign before return
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dpg,qg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dqg,pg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDpg,qg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDqg,pg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dpg,Dqg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dqg,Dpg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-                        mu_grid_i = mu[:, associated_grid_index]
-                        dmu_dr_grid_i = dmu_dr[:, :, associated_grid_index]
-
-                        mu_occ_grid_i = mu_grid_i.T @ mocc
-                        dmudr_occ_grid_i = contract("dqg,qj->dgj", dmu_dr_grid_i, mocc)
-
-                        weight_depsilondrho_grid_i = weight[associated_grid_index] * depsilon_drho[associated_grid_index]
-                        vmat[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i) @ mu_occ_grid_i
-                        vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i, dmudr_occ_grid_i)
-                        weight_depsilondrho_grid_i = None
-
-                        d2mu_dr2_grid_i = d2mu_dr2[:, :, :, associated_grid_index]
-
-                        weight_depsilondnablarho_grid_i = weight[associated_grid_index] * depsilon_dnablarho[:, associated_grid_index]
-                        weight_depsilondnablarho_d2mudr2 = contract("Dg,dDpg->dpg", weight_depsilondnablarho_grid_i, d2mu_dr2_grid_i)
-                        d2mu_dr2_grid_i = None
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2, mu_occ_grid_i)
-                        mu_occ_grid_i = None
-                        weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2, mocc)
-                        weight_depsilondnablarho_d2mudr2 = None
-                        vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
-                        mu_grid_i = None
-                        weight_depsilondnablarho_d2mudr2_occ = None
-                        weight_depsilondnablarho_dmudr = contract("Dg,Dpg->pg", weight_depsilondnablarho_grid_i, dmu_dr_grid_i)
-                        vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr, dmudr_occ_grid_i)
-                        dmudr_occ_grid_i = None
-                        weight_depsilondnablarho_dmudr_occ = weight_depsilondnablarho_dmudr.T @ mocc
-                        weight_depsilondnablarho_dmudr = None
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ)
-                        weight_depsilondnablarho_dmudr_occ = None
-                        dmu_dr_grid_i = None
-                        weight_depsilondnablarho_grid_i = None
-
-            elif xctype == 'MGGA':
-                # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
-                available_gpu_memory = get_avail_mem()
-                available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-                ao_nbytes_per_grid = ((10 + 9 + 24 + 4*2 + 24 + 3 + 24) * mol.nao + (3 + 15*3) * mol.natm + 5*2 + 25*2 + 2 + 2) * 8
-                ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-                if ngrids_per_batch < 16:
-                    raise MemoryError(f"Out of GPU memory for mGGA Fock first derivative, available gpu memory = {get_avail_mem()}"
-                                      f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}, device_id = {device_id}")
-                ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-                ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-                for g0 in range(grid_start, grid_end, ngrids_per_batch):
-                    g1 = min(g0 + ngrids_per_batch, grid_end)
-                    split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
-                    split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
-
-                    mu = split_ao[0]
-                    dmu_dr = split_ao[1:4]
-                    d2mu_dr2 = get_d2mu_dr2(split_ao)
-
-                    rho_drho_tau = numint.eval_rho2(mol, split_ao[:4], mo_coeff, mo_occ, xctype=xctype)
-                    vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho_tau, deriv = 2, xctype=xctype)[1:3]
-
-                    # rho = rho_drho_tau[0]
-                    # drho_dr = rho_drho_tau[1:4]
-                    # tau = rho_drho_tau[4]
-                    rho_drho_tau = None
-
-                    depsilon_drho = vxc[0]
-                    depsilon_dnablarho = vxc[1:4]
-                    depsilon_dtau = vxc[4]
-                    # d2epsilon_drho2 = fxc[0,0]
-                    # d2epsilon_drho_dnablarho = fxc[0,1:4]
-                    # d2epsilon_drho_dtau = fxc[0,4]
-                    # d2epsilon_dnablarho2 = fxc[1:4,1:4]
-                    # d2epsilon_dnablarho_dtau = fxc[1:4,4]
-                    # d2epsilon_dtau2 = fxc[4,4]
-
-                    dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-                    # # Negative here to cancel the overall negative sign before return
-                    # vmat -= cupy.einsum("Adg,g,pg,qg,qj->Adpj", dw_dA, depsilon_drho, mu, mu, mocc)
-                    # vmat -= cupy.einsum("Adg,xg,xpg,qg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
-                    # vmat -= cupy.einsum("Adg,xg,xqg,pg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
-                    # vmat -= 0.5 * cupy.einsum("Adg,g,xpg,xqg,qj->Adpj", dw_dA, depsilon_dtau, dmu_dr, dmu_dr, mocc)
-                    depsilondnablarho_dmudr = contract("xg,xpg->pg", depsilon_dnablarho, dmu_dr)
-                    depsilondrho_mu = mu * depsilon_drho
-                    mu_occ = mu.T @ mocc
-                    for i_atom in range(natm):
-                        dwdA_depsilondrho_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], depsilondrho_mu + depsilondnablarho_dmudr)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu, mu_occ)
-                        dwdA_depsilondrho_mu = None
-                    depsilondrho_mu = None
-                    mu_occ = None
-                    depsilondnablarho_dmudr_occ = depsilondnablarho_dmudr.T @ mocc
-                    depsilondnablarho_dmudr = None
-                    for i_atom in range(natm):
-                        dwdA_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], mu)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ)
-                        dwdA_mu = None
-                    depsilondnablarho_dmudr_occ = None
-                    depsilondtau_dmudr_occ = contract("dqg,qj->dgj", dmu_dr * depsilon_dtau, mocc)
-                    for i_atom in range(natm):
-                        dwdA_dmudr = contract("dg,xpg->dpxg", dw_dA[i_atom, :, :], dmu_dr)
-                        vmat[i_atom, :, :, :] -= 0.5 * contract("dpxg,xgj->dpj", dwdA_dmudr, depsilondtau_dmudr_occ)
-                        dwdA_dmudr = None
-                    depsilondtau_dmudr_occ = None
-                    dw_dA = None
-
-                    grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
-                    atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-                    grid_to_atom_index_map = None
-
-                    _, _, _, drho_dA_grid_response, dnablarho_dA_grid_response, dtau_dA_grid_response = \
-                        get_drho_dA_full(dm0, xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, with_orbital_response = False)
-
-                    weight = cupy.asarray(grids.weights)[g0:g1]
-                    # # d2epsilon/drho2 * drho/dR * mu * nu
-                    # vmat -= cupy.einsum("g,g,Adg,pg,qg,qj->Adpj", weight, d2epsilon_drho2, drho_dA_grid_response, mu, mu, mocc)
-                    # # d2epsilon/(drho d_nabla_rho) * d_nabla_rho/dR * mu * nu
-                    # vmat -= cupy.einsum("g,xg,Adxg,pg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, dnablarho_dA_grid_response, mu, mu, mocc)
-                    # # d2epsilon/(d_nabla_rho drho) * drho/dR * nabla(mu * nu)
-                    # vmat -= cupy.einsum("g,xg,Adg,xpg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
-                    # vmat -= cupy.einsum("g,xg,Adg,xqg,pg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
-                    # # d2epsilon/(d_nabla_rho d_nabla_rho) * d_nabla_rho/dR * nabla(mu * nu)
-                    # vmat -= cupy.einsum("g,xyg,Adxg,ypg,qg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
-                    # vmat -= cupy.einsum("g,xyg,Adxg,yqg,pg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
-                    # # d2epsilon/(drho dtau) * dtau/dR * mu * nu
-                    # vmat -= cupy.einsum("g,g,Adg,pg,qg,qj->Adpj", weight, d2epsilon_drho_dtau, dtau_dA_grid_response, mu, mu, mocc)
-                    # # d2epsilon/(d_nabla_rho dtau) * dtau/dR * nabla(mu * nu)
-                    # vmat -= cupy.einsum("g,xg,Adg,xpg,qg,qj->Adpj", weight, d2epsilon_dnablarho_dtau, dtau_dA_grid_response, dmu_dr, mu, mocc)
-                    # vmat -= cupy.einsum("g,xg,Adg,xqg,pg,qj->Adpj", weight, d2epsilon_dnablarho_dtau, dtau_dA_grid_response, dmu_dr, mu, mocc)
-                    # # d2epsilon/(dtau drho) * drho/dR * nabla_mu * nabla_nu
-                    # vmat -= 0.5 * cupy.einsum("g,g,Adg,xpg,xqg,qj->Adpj", weight, d2epsilon_drho_dtau, drho_dA_grid_response, dmu_dr, dmu_dr, mocc)
-                    # # d2epsilon/(dtau d_nabla_rho) * d_nabla_rho/dR * nabla_mu * nabla_nu
-                    # vmat -= 0.5 * cupy.einsum("g,xg,Adxg,ypg,yqg,qj->Adpj",
-                    #     weight, d2epsilon_dnablarho_dtau, dnablarho_dA_grid_response, dmu_dr, dmu_dr, mocc)
-                    # # d2epsilon/dtau2 * dtau/dR * nabla_mu * nabla_nu
-                    # vmat -= 0.5 * cupy.einsum("g,g,Adg,xpg,xqg,qj->Adpj", weight, d2epsilon_dtau2, dtau_dA_grid_response, dmu_dr, dmu_dr, mocc)
-                    combined_d_dA_grid_response = cupy.concatenate(
-                        (drho_dA_grid_response[:, :, None, :], dnablarho_dA_grid_response, dtau_dA_grid_response[:, :, None, :]),
-                        axis = 2
-                    )
-                    drho_dA_grid_response = None
-                    dnablarho_dA_grid_response = None
-                    dtau_dA_grid_response = None
-
-                    fwxc = fxc * weight
-                    fxc = None
-                    drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, combined_d_dA_grid_response)
-                    combined_d_dA_grid_response = None
-                    fwxc = None
-
-                    mu_occ = mu.T @ mocc
-                    dmudr_occ = contract("dqg,qj->dgj", dmu_dr, mocc)
-                    for i_atom in range(natm):
-                        drhodA_grid_response_fwxc_rho_term_mu = contract("dg,pg->dpg", drhodA_grid_response_fwxc[i_atom, :, 0, :], mu)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu, mu_occ)
-                        drhodA_grid_response_fwxc_rho_term_mu = None
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmudr_occ)
-                        vmat[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = None
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr = contract("dxg,xpg->dpg", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmu_dr)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr, mu_occ)
-                        drhodA_grid_response_fwxc_nablarho_term_dmudr = None
-                        drhodA_grid_response_fwxc_tau_term_dmudr = contract("dg,xpg->dpxg", drhodA_grid_response_fwxc[i_atom, :, 4, :], dmu_dr)
-                        vmat[i_atom, :, :, :] -= 0.5 * contract("dpxg,xgj->dpj", drhodA_grid_response_fwxc_tau_term_dmudr, dmudr_occ)
-                        drhodA_grid_response_fwxc_tau_term_dmudr = None
-                    drhodA_grid_response_fwxc = None
-                    mu_occ = None
-                    dmudr_occ = None
-
-                    for i_atom in range(natm):
-                        associated_grid_index = atom_to_grid_index_map[i_atom]
-                        if len(associated_grid_index) == 0:
-                            continue
-                        # # Negative here to cancel the overall negative sign before return
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dpg,qg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dqg,pg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDpg,qg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDqg,pg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dpg,Dqg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dqg,Dpg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-                        #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= 0.5 * cupy.einsum("g,g,dDpg,Dqg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dtau[associated_grid_index],
-                        #     d2mu_dr2[:, :, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-                        # vmat[i_atom, :, :, :] -= 0.5 * cupy.einsum("g,g,dDqg,Dpg,qj->dpj",
-                        #     weight[associated_grid_index], depsilon_dtau[associated_grid_index],
-                        #     d2mu_dr2[:, :, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-                        mu_grid_i = mu[:, associated_grid_index]
-                        dmu_dr_grid_i = dmu_dr[:, :, associated_grid_index]
-
-                        mu_occ_grid_i = mu_grid_i.T @ mocc
-                        dmudr_occ_grid_i = contract("dqg,qj->dgj", dmu_dr_grid_i, mocc)
-
-                        weight_depsilondrho_grid_i = weight[associated_grid_index] * depsilon_drho[associated_grid_index]
-                        vmat[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i) @ mu_occ_grid_i
-                        vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i, dmudr_occ_grid_i)
-                        weight_depsilondrho_grid_i = None
-
-                        d2mu_dr2_grid_i = d2mu_dr2[:, :, :, associated_grid_index]
-
-                        weight_depsilondnablarho_grid_i = weight[associated_grid_index] * depsilon_dnablarho[:, associated_grid_index]
-                        weight_depsilondnablarho_d2mudr2 = contract("Dg,dDpg->dpg", weight_depsilondnablarho_grid_i, d2mu_dr2_grid_i)
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2, mu_occ_grid_i)
-                        mu_occ_grid_i = None
-                        weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2, mocc)
-                        weight_depsilondnablarho_d2mudr2 = None
-                        vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
-                        mu_grid_i = None
-                        weight_depsilondnablarho_d2mudr2_occ = None
-                        weight_depsilondnablarho_dmudr = contract("Dg,Dpg->pg", weight_depsilondnablarho_grid_i, dmu_dr_grid_i)
-                        vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr, dmudr_occ_grid_i)
-                        weight_depsilondnablarho_dmudr_occ = weight_depsilondnablarho_dmudr.T @ mocc
-                        weight_depsilondnablarho_dmudr = None
-                        vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ)
-                        weight_depsilondnablarho_dmudr_occ = None
-                        weight_depsilondnablarho_grid_i = None
-
-                        weight_depsilondrho_grid_i = weight[associated_grid_index] * depsilon_dtau[associated_grid_index]
-                        vmat[i_atom, :, :, :] -= 0.5 * cupy.einsum("dDpg,Dgj->dpj", d2mu_dr2_grid_i * weight_depsilondrho_grid_i, dmudr_occ_grid_i)
-                        dmudr_occ_grid_i = None
-                        d2mudr2_occ_grid_i = contract("dDqg,qj->dDgj", d2mu_dr2_grid_i, mocc)
-                        d2mu_dr2_grid_i = None
-                        vmat[i_atom, :, :, :] -= 0.5 * contract("Dpg,dDgj->dpj", dmu_dr_grid_i * weight_depsilondrho_grid_i, d2mudr2_occ_grid_i)
-                        dmu_dr_grid_i = None
-                        d2mudr2_occ_grid_i = None
-
-            elif xctype == 'HF':
-                pass
-            else:
-                raise NotImplementedError(f"xctype = {xctype} not supported")
-            t2 = log.timer_debug2('grid response', *t2)
-
         t0 = log.timer_debug1(f'vxc_deriv1 on Device {device_id}', *t0)
 
         # Inplace transform the AO to MO.
@@ -2213,6 +1765,10 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     '''
     Derivatives of Vxc matrix in MO bases
     '''
+
+    if hessobj.grid_response:
+        return _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
+
     mol = hessobj.mol
     mf = hessobj.base
     if hessobj.grids is not None:
@@ -2241,6 +1797,414 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     vmat_dist = [future.result() for future in futures]
     vmat = reduce_to_device(vmat_dist, inplace=True)
     return vmat
+
+def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
+    mol = hessobj.mol
+    mf = hessobj.base
+    ni = mf._numint
+    xctype = ni._xc_type(mf.xc)
+
+    if hessobj.grids is not None:
+        grids = hessobj.grids
+    else:
+        grids = mf.grids
+    grids.build(sort_grids_of_each_atom = True)
+    ngrids = grids.coords.shape[0]
+
+    ni.gdftopt = None
+    ni.build(mol, grids.coords)
+    opt = ni.gdftopt
+
+    _sorted_mol = opt._sorted_mol
+    nao = _sorted_mol.nao
+    natm = mol.natm
+    mol = None
+
+    mo_occ = cupy.asarray(mo_occ)
+    mo_coeff = cupy.asarray(mo_coeff)
+    assert mo_coeff.ndim == 2
+    mo_coeff_sorted = opt.sort_orbitals(mo_coeff, axis=[0])
+    mocc_sorted = mo_coeff_sorted[:, mo_occ > 0]
+    nao = _sorted_mol.nao
+    nmo = mo_coeff_sorted.shape[1]
+    nocc = mocc_sorted.shape[1]
+
+    dm0 = mf.make_rdm1(mo_coeff, mo_occ)
+    assert dm0.ndim == 2
+    dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
+    dm_mask_buf = cupy.empty(nao * nao)
+    dm0 = None
+    mo_coeff = None
+
+    nonzero_weight_mask = cupy.abs(grids.weights) > 1e-20 # There are d2rho/dAdB terms with very low weight but very big contribution
+
+    ao_loc_sorted = _sorted_mol.ao_loc
+    ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+    from pyscf.gto.mole import ATOM_OF
+    i_atom_of_aos = numpy.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+    i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
+
+    dFock_orbital_response_dmudA_nu_term = cupy.zeros((3, nao, nao))
+    dFock_mo_occ = cupy.zeros((natm, 3, nmo, nocc))
+
+    if xctype == 'LDA':
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            mo_coeff_masked = mo_coeff_sorted[idx, :]
+            mocc_masked = mocc_sorted[idx, :]
+
+            rho = numint.eval_rho(_sorted_mol, ao[0], dm0_masked, xctype = xctype, hermi = 1)
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
+            del rho
+
+            depsilon_drho = vxc[0] # Just of shape (ngrids,)
+            d2epsilon_drho2 = fxc[0,0] # Just of shape (ngrids,)
+            del vxc, fxc
+
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,g,pg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_drho, mu, mu, mocc_masked)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
+
+            weight = weight[nonzero_weight_mask[g0:g1]]
+
+            # dFock_mo_occ += cupy.einsum("pi,g,Adg,pg,qg,qj->Adij", mo_coeff_masked, d2epsilon_drho2 * weight, drho_dA_full_response, mu, mu, mocc_masked)
+            mu_nu_term_prefactor = drho_dA_full_response * (d2epsilon_drho2 * weight) + dw_dA * depsilon_drho
+            del drho_dA_full_response, d2epsilon_drho2, dw_dA
+            mu_mocc = mu.T @ mocc_masked
+            dFock_ao_occ = cupy.zeros((natm, 3, mu.shape[0], nocc))
+            for i_atom in range(natm):
+                prefactor_with_nu_mocc = contract("dg,gj->dgj", mu_nu_term_prefactor[i_atom, :, :], mu_mocc)
+                dFock_ao_occ[i_atom, :, :, :] = contract("pg,dgj->dpj", mu, prefactor_with_nu_mocc)
+                del prefactor_with_nu_mocc
+            dFock_mo_occ += contract("pi,Adpj->Adij", mo_coeff_masked, dFock_ao_occ)
+            del dFock_ao_occ
+            del mu_mocc
+            del mu_nu_term_prefactor
+
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
+            dmudA_nu_ao = contract("dpg,qg->dpq", dmu_dr, mu * (depsilon_drho * weight))
+            dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += dmudA_nu_ao
+
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,2,1)
+            del dmudA_nu_ao
+            dmudA_nu_ao_occ = contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
+            del dmudA_nu_ao_ao
+            dFock_mo_occ[i_atom_of_grids, :, :, :] += contract("pi,dpj->dij", mo_coeff_masked, dmudA_nu_ao_occ)
+            del dmudA_nu_ao_occ
+
+            g0 = g1
+        assert g1 == ngrids
+
+    elif xctype == 'GGA':
+        raise
+            #     # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
+            #     available_gpu_memory = get_avail_mem()
+            #     available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
+            #     ao_nbytes_per_grid = ((10 + 9 + 2 + 3*2 + 2 + 3*2 + 3*3 + 9 + 4*3) * mol.nao + (3 + 3 + 9 + 3*4*2) * mol.natm + 4*2 + 16*2 + 2 + 2) * 8
+            #     ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
+            #     if ngrids_per_batch < 16:
+            #         raise MemoryError(f"Out of GPU memory for GGA Fock first derivative, available gpu memory = {get_avail_mem()}"
+            #                           f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}, device_id = {device_id}")
+            #     ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
+            #     ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+
+            #     for g0 in range(grid_start, grid_end, ngrids_per_batch):
+            #         g1 = min(g0 + ngrids_per_batch, grid_end)
+            #         split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
+            #         split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
+
+            #         mu = split_ao[0]
+            #         dmu_dr = split_ao[1:4]
+            #         d2mu_dr2 = get_d2mu_dr2(split_ao)
+
+            #         rho_drho = numint.eval_rho2(mol, split_ao[:4], mo_coeff, mo_occ, xctype=xctype)
+            #         vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 2, xctype=xctype)[1:3]
+
+            #         # rho = rho_drho[0]
+            #         # drho_dr = rho_drho[1:4]
+            #         rho_drho = None
+
+            #         depsilon_drho = vxc[0]
+            #         depsilon_dnablarho = vxc[1:4]
+            #         # d2epsilon_drho2 = fxc[0,0]
+            #         # d2epsilon_drho_dnablarho = fxc[0,1:4]
+            #         # d2epsilon_dnablarho2 = fxc[1:4,1:4]
+
+            #         dw_dA = get_dweight_dA(mol, grids, (g0,g1))
+            #         # # Negative here to cancel the overall negative sign before return
+            #         # vmat -= cupy.einsum("Adg,g,pg,qg,qj->Adpj", dw_dA, depsilon_drho, mu, mu, mocc)
+            #         # vmat -= cupy.einsum("Adg,xg,xpg,qg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
+            #         # vmat -= cupy.einsum("Adg,xg,xqg,pg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
+            #         depsilondnablarho_dmudr = contract("xg,xpg->pg", depsilon_dnablarho, dmu_dr)
+            #         depsilondrho_mu = mu * depsilon_drho
+            #         mu_occ = mu.T @ mocc
+            #         for i_atom in range(natm):
+            #             dwdA_depsilondrho_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], depsilondrho_mu + depsilondnablarho_dmudr)
+            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu, mu_occ)
+            #             dwdA_depsilondrho_mu = None
+            #         depsilondrho_mu = None
+            #         mu_occ = None
+            #         depsilondnablarho_dmudr_occ = depsilondnablarho_dmudr.T @ mocc
+            #         depsilondnablarho_dmudr = None
+            #         for i_atom in range(natm):
+            #             dwdA_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], mu)
+            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ)
+            #             dwdA_mu = None
+            #         depsilondnablarho_dmudr_occ = None
+            #         dw_dA = None
+
+            #         grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
+            #         atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
+            #         grid_to_atom_index_map = None
+
+            #         _, _, drho_dA_grid_response, dnablarho_dA_grid_response = \
+            #             get_drho_dA_full(dm0, xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, with_orbital_response = False)
+
+            #         weight = cupy.asarray(grids.weights)[g0:g1]
+            #         # # Negative here to cancel the overall negative sign before return
+            #         # # d2epsilon/drho2 * drho/dR * mu * nu
+            #         # vmat -= cupy.einsum("g,g,Adg,pg,qg,qj->Adpj", weight, d2epsilon_drho2, drho_dA_grid_response, mu, mu, mocc)
+            #         # # d2epsilon/(drho d_nabla_rho) * d_nabla_rho/dR * mu * nu
+            #         # vmat -= cupy.einsum("g,xg,Adxg,pg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, dnablarho_dA_grid_response, mu, mu, mocc)
+            #         # # d2epsilon/(d_nabla_rho drho) * drho/dR * nabla(mu * nu)
+            #         # vmat -= cupy.einsum("g,xg,Adg,xpg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
+            #         # vmat -= cupy.einsum("g,xg,Adg,xqg,pg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
+            #         # # d2epsilon/(d_nabla_rho d_nabla_rho) * d_nabla_rho/dR * nabla(mu * nu)
+            #         # vmat -= cupy.einsum("g,xyg,Adxg,ypg,qg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
+            #         # vmat -= cupy.einsum("g,xyg,Adxg,yqg,pg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
+            #         combined_d_dA_grid_response = cupy.concatenate((drho_dA_grid_response[:, :, None, :], dnablarho_dA_grid_response), axis = 2)
+            #         drho_dA_grid_response = None
+            #         dnablarho_dA_grid_response = None
+
+            #         fwxc = fxc * weight
+            #         fxc = None
+            #         drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, combined_d_dA_grid_response)
+            #         combined_d_dA_grid_response = None
+            #         fwxc = None
+
+            #         mu_occ = mu.T @ mocc
+            #         dmudr_occ = contract("dqg,qj->dgj", dmu_dr, mocc)
+            #         for i_atom in range(natm):
+            #             drhodA_grid_response_fwxc_rho_term_mu = contract("dg,pg->dpg", drhodA_grid_response_fwxc[i_atom, :, 0, :], mu)
+            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu, mu_occ)
+            #             drhodA_grid_response_fwxc_rho_term_mu = None
+            #             drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmudr_occ)
+            #             vmat[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
+            #             drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = None
+            #             drhodA_grid_response_fwxc_nablarho_term_dmudr = contract("dxg,xpg->dpg", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmu_dr)
+            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr, mu_occ)
+            #             drhodA_grid_response_fwxc_nablarho_term_dmudr = None
+            #         drhodA_grid_response_fwxc = None
+            #         mu_occ = None
+            #         dmudr_occ = None
+
+            #         for i_atom in range(natm):
+            #             associated_grid_index = atom_to_grid_index_map[i_atom]
+            #             if len(associated_grid_index) == 0:
+            #                 continue
+            #             # # Negative here to cancel the overall negative sign before return
+            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dpg,qg,qj->dpj",
+            #             #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
+            #             #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
+            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dqg,pg,qj->dpj",
+            #             #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
+            #             #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
+            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDpg,qg,qj->dpj",
+            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
+            #             #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
+            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDqg,pg,qj->dpj",
+            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
+            #             #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
+            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dpg,Dqg,qj->dpj",
+            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
+            #             #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
+            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dqg,Dpg,qj->dpj",
+            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
+            #             #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
+            #             mu_grid_i = mu[:, associated_grid_index]
+            #             dmu_dr_grid_i = dmu_dr[:, :, associated_grid_index]
+
+            #             mu_occ_grid_i = mu_grid_i.T @ mocc
+            #             dmudr_occ_grid_i = contract("dqg,qj->dgj", dmu_dr_grid_i, mocc)
+
+            #             weight_depsilondrho_grid_i = weight[associated_grid_index] * depsilon_drho[associated_grid_index]
+            #             vmat[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i) @ mu_occ_grid_i
+            #             vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i, dmudr_occ_grid_i)
+            #             weight_depsilondrho_grid_i = None
+
+            #             d2mu_dr2_grid_i = d2mu_dr2[:, :, :, associated_grid_index]
+
+            #             weight_depsilondnablarho_grid_i = weight[associated_grid_index] * depsilon_dnablarho[:, associated_grid_index]
+            #             weight_depsilondnablarho_d2mudr2 = contract("Dg,dDpg->dpg", weight_depsilondnablarho_grid_i, d2mu_dr2_grid_i)
+            #             d2mu_dr2_grid_i = None
+            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2, mu_occ_grid_i)
+            #             mu_occ_grid_i = None
+            #             weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2, mocc)
+            #             weight_depsilondnablarho_d2mudr2 = None
+            #             vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
+            #             mu_grid_i = None
+            #             weight_depsilondnablarho_d2mudr2_occ = None
+            #             weight_depsilondnablarho_dmudr = contract("Dg,Dpg->pg", weight_depsilondnablarho_grid_i, dmu_dr_grid_i)
+            #             vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr, dmudr_occ_grid_i)
+            #             dmudr_occ_grid_i = None
+            #             weight_depsilondnablarho_dmudr_occ = weight_depsilondnablarho_dmudr.T @ mocc
+            #             weight_depsilondnablarho_dmudr = None
+            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ)
+            #             weight_depsilondnablarho_dmudr_occ = None
+            #             dmu_dr_grid_i = None
+            #             weight_depsilondnablarho_grid_i = None
+
+    elif xctype == 'MGGA':
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            mo_coeff_masked = mo_coeff_sorted[idx, :]
+            mocc_masked = mocc_sorted[idx, :]
+
+            rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
+            del rho
+
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,g,pg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_drho, mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xpg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xqg,pg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += 0.5 * cupy.einsum("pi,Adg,g,xpg,xqg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dtau, dmu_dr, dmu_dr, mocc_masked)
+            dwdA_vxc = contract("Adg,xg->Adxg", dw_dA, vxc)
+            del dw_dA
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
+
+            weight = weight[nonzero_weight_mask[g0:g1]]
+
+            fwxc = fxc * weight
+            del fxc
+            drhodA_fwxc = contract("xyg,Adyg->Adxg", fwxc, drho_dA_full_response)
+            del drho_dA_full_response
+            del fwxc
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,pg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 0, :], mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xpg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xqg,pg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += 0.5 * cupy.einsum("pi,Adg,xpg,xqg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 4, :], dmu_dr, dmu_dr, mocc_masked)
+            mu_nu_term_prefactor = drhodA_fwxc + dwdA_vxc
+            del drhodA_fwxc, dwdA_vxc
+
+            mu_mocc = mu.T @ mocc_masked
+            dmudr_mocc = contract("dqg,qj->djg", dmu_dr, mocc_masked)
+            dFock_ao_occ = cupy.zeros((natm, 3, mu.shape[0], nocc))
+            for i_atom in range(natm): # Henry 20260519: This is the most performance critical loop
+                mu_on_right_term = contract("xpg,dxg->dpg", ao[0:4], mu_nu_term_prefactor[i_atom, :, 0:4, :])
+                dFock_ao_occ[i_atom, :, :, :] = contract("dpg,gj->dpj", mu_on_right_term, mu_mocc)
+                del mu_on_right_term
+                nablarho_dmudr_on_right_term = contract("dxg,xjg->djg", mu_nu_term_prefactor[i_atom, :, 1:4, :], dmudr_mocc)
+                dFock_ao_occ[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
+                del nablarho_dmudr_on_right_term
+                tau_term = contract("dg,xjg->dxjg", mu_nu_term_prefactor[i_atom, :, 4, :], dmudr_mocc)
+                dFock_ao_occ[i_atom, :, :, :] += 0.5 * contract("xpg,dxjg->dpj", dmu_dr, tau_term)
+                del tau_term
+            dFock_mo_occ += contract("pi,Adpj->Adij", mo_coeff_masked, dFock_ao_occ)
+            del dFock_ao_occ
+            del mu_mocc, dmudr_mocc
+            del mu_nu_term_prefactor
+
+            wv = vxc * weight
+            del vxc
+            weight_depsilon_drho = wv[0]
+            weight_depsilon_dnablarho = wv[1:4]
+            weight_depsilon_dtau = wv[4]
+            del wv
+
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dxpg,qg->dpq", depsilon_dnablarho * weight, d2mu_dr2, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dpg,xqg->dpq", depsilon_dnablarho * weight, dmu_dr, dmu_dr)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += 0.5 * cupy.einsum("g,dxpg,xqg->dpq", depsilon_dtau * weight, d2mu_dr2, dmu_dr)
+            dmudr_weight_depsilondnablarho = contract("xg,xpg->pg", weight_depsilon_dnablarho, dmu_dr)
+            dmudA_nu_ao = contract("dpg,qg->dpq", dmu_dr, mu * weight_depsilon_drho + dmudr_weight_depsilondnablarho)
+            del dmudr_weight_depsilondnablarho
+            mu_weight_depsilondnablarho = contract("xg,qg->xqg", weight_depsilon_dnablarho, mu)
+            dmudA_nu_ao += contract("dxpg,xqg->dpq", d2mu_dr2, 0.5 * dmu_dr * weight_depsilon_dtau + mu_weight_depsilondnablarho)
+            del mu_weight_depsilondnablarho
+
+            dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += dmudA_nu_ao
+
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum("pi,g,dxpg,xqg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum("pi,g,dxqg,xpg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
+            dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,2,1)
+            del dmudA_nu_ao
+            dmudA_nu_ao_occ = contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
+            del dmudA_nu_ao_ao
+            dFock_mo_occ[i_atom_of_grids, :, :, :] += contract("pi,dpj->dij", mo_coeff_masked, dmudA_nu_ao_occ)
+            del dmudA_nu_ao_occ
+
+            g0 = g1
+        assert g1 == ngrids
+
+    elif xctype == 'HF':
+        pass
+    else:
+        raise NotImplementedError(f"xctype = {xctype} not supported")
+
+    for i_atom in range(0, natm):
+        ao_of_atom_i = cupy.where(i_atom_of_aos == i_atom)[0]
+        if ao_of_atom_i.size > 0:
+            dFock_mo_occ[i_atom, :, :, :] -= cupy.einsum("pi,dpq,qj->dij", mo_coeff_sorted[ao_of_atom_i], dFock_orbital_response_dmudA_nu_term[:, ao_of_atom_i, :], mocc_sorted)
+            dFock_mo_occ[i_atom, :, :, :] -= cupy.einsum("pi,dpq,qj->dij", mo_coeff_sorted, dFock_orbital_response_dmudA_nu_term[:, ao_of_atom_i, :].transpose(0,2,1), mocc_sorted[ao_of_atom_i])
+
+    return dFock_mo_occ
 
 def get_dweight_dA(mol, grids, grid_range = None):
     ngrids = grids.coords.shape[0]
@@ -3603,16 +3567,16 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
                 dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, d3mu_dr3,
             )
 
-        ref_d2E_dAdB_orbital_response += d2rho_dAdB_orbital_response @ weight_depsilon_drho[g0:g1]
-        ref_d2E_dAdB_orbital_response += cp.einsum("ABdDxg,xg->ABdD", d2nablarho_dAdB_orbital_response, weight_depsilon_dnablarho[:, g0:g1])
-        ref_d2E_dAdB_orbital_response += d2tau_dAdB_orbital_response @ weight_depsilon_dtau[g0:g1]
+        d2E_dAdB_orbital_response += d2rho_dAdB_orbital_response @ weight_depsilon_drho[g0:g1]
+        d2E_dAdB_orbital_response += cp.einsum("ABdDxg,xg->ABdD", d2nablarho_dAdB_orbital_response, weight_depsilon_dnablarho[:, g0:g1])
+        d2E_dAdB_orbital_response += d2tau_dAdB_orbital_response @ weight_depsilon_dtau[g0:g1]
 
-        If you think the logic in this function is nonsense, I agree. Refer get_d2rho_dAdB_full() for a readable code.
+        If you think the logic in this function is nonsense, I agree. Refer to get_d2rho_dAdB_full() for a readable code.
         This function has went through the following optimizations:
-        1. Split the chain contraction into binary contractions, and reorder the contraction
+        1. Split the chain contraction into binary contractions, and reorder the contractions
         2. Allow a sparse AO, and guarantees a block of grids belongs to the same atom
         3. Merge grid response diagonal terms into off-digonal term
-        4. Share the intermediate variables among orbital and grid response
+        4. Share the intermediate variables among orbital and grid responses
     """
     if xctype == "LDA":
         with_nablarho = False
@@ -3778,6 +3742,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     assert dm0.ndim == 2
     dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
     dm_mask_buf = cupy.empty(nao * nao)
+    dm0 = None
 
     nonzero_weight_mask = cupy.abs(grids.weights) > 1e-20 # There are d2rho/dAdB terms with very low weight but very big contribution
 

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -1765,7 +1765,6 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     '''
     Derivatives of Vxc matrix in MO bases
     '''
-
     if hessobj.grid_response:
         return _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
 

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -3377,6 +3377,7 @@ def get_d2rho_dAdB_full(dm0, xctype, natm, ngrids, aoslices = None, atom_to_grid
         return d2rho_dAdB_orbital_response, d2nablarho_dAdB_orbital_response, d2tau_dAdB_orbital_response, \
                d2rho_dAdB_grid_response, d2nablarho_dAdB_grid_response, d2tau_dAdB_grid_response
 
+# TODO: remove this function
 def contract_d2rho_dAdB_full(dm0, xctype, natm, ngrids, aoslices = None, atom_to_grid_index_map = None,
                              mu = None, dmu_dr = None, d2mu_dr2 = None, d3mu_dr3 = None,
                              weight_depsilon_drho = None, weight_depsilon_dnablarho = None, weight_depsilon_dtau = None,
@@ -3790,8 +3791,12 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     if xctype == 'LDA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
 
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
             rho = numint.eval_rho(_sorted_mol, ao, dm0_masked, xctype = xctype, hermi = 1)
@@ -3807,7 +3812,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -3863,8 +3868,12 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'GGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
 
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
             rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
@@ -3880,7 +3889,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -3944,8 +3953,12 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'MGGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
 
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
             rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
@@ -3961,7 +3974,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -1826,7 +1826,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     mo_coeff_sorted = opt.sort_orbitals(mo_coeff, axis=[0])
     mocc_sorted = mo_coeff_sorted[:, mo_occ > 0]
     nao = _sorted_mol.nao
-    nmo = mo_coeff_sorted.shape[1]
+    # nmo = mo_coeff_sorted.shape[1]
     nocc = mocc_sorted.shape[1]
 
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
@@ -1845,7 +1845,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
 
     dFock_orbital_response_dmudA_nu_term = cupy.zeros((3, nao, nao))
-    dFock_mo_occ = cupy.zeros((natm, 3, nmo, nocc))
+    dFock_ao_occ = cupy.zeros((natm, 3, nao, nocc))
 
     if xctype == 'LDA':
         g0 = 0
@@ -1893,14 +1893,14 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             # dFock_mo_occ += cupy.einsum("pi,g,Adg,pg,qg,qj->Adij", mo_coeff_masked, d2epsilon_drho2 * weight, drho_dA_full_response, mu, mu, mocc_masked)
             mu_nu_term_prefactor = drho_dA_full_response * (d2epsilon_drho2 * weight) + dw_dA * depsilon_drho
             del drho_dA_full_response, d2epsilon_drho2, dw_dA
+
+            dFock_sparse_ao_occ = cupy.zeros((natm, 3, mu.shape[0], nocc))
+
             mu_mocc = mu.T @ mocc_masked
-            dFock_ao_occ = cupy.zeros((natm, 3, mu.shape[0], nocc))
             for i_atom in range(natm):
                 prefactor_with_nu_mocc = contract("dg,gj->dgj", mu_nu_term_prefactor[i_atom, :, :], mu_mocc)
-                dFock_ao_occ[i_atom, :, :, :] = contract("pg,dgj->dpj", mu, prefactor_with_nu_mocc)
+                dFock_sparse_ao_occ[i_atom, :, :, :] += contract("pg,dgj->dpj", mu, prefactor_with_nu_mocc)
                 del prefactor_with_nu_mocc
-            dFock_mo_occ += contract("pi,Adpj->Adij", mo_coeff_masked, dFock_ao_occ)
-            del dFock_ao_occ
             del mu_mocc
             del mu_nu_term_prefactor
 
@@ -1912,172 +1912,118 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
             dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,2,1)
             del dmudA_nu_ao
-            dmudA_nu_ao_occ = contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
+            dFock_sparse_ao_occ[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
             del dmudA_nu_ao_ao
-            dFock_mo_occ[i_atom_of_grids, :, :, :] += contract("pi,dpj->dij", mo_coeff_masked, dmudA_nu_ao_occ)
-            del dmudA_nu_ao_occ
+
+            dFock_ao_occ[:, :, idx, :] += dFock_sparse_ao_occ
+            del dFock_sparse_ao_occ
 
             g0 = g1
         assert g1 == ngrids
 
     elif xctype == 'GGA':
-        raise
-            #     # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
-            #     available_gpu_memory = get_avail_mem()
-            #     available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-            #     ao_nbytes_per_grid = ((10 + 9 + 2 + 3*2 + 2 + 3*2 + 3*3 + 9 + 4*3) * mol.nao + (3 + 3 + 9 + 3*4*2) * mol.natm + 4*2 + 16*2 + 2 + 2) * 8
-            #     ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-            #     if ngrids_per_batch < 16:
-            #         raise MemoryError(f"Out of GPU memory for GGA Fock first derivative, available gpu memory = {get_avail_mem()}"
-            #                           f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}, device_id = {device_id}")
-            #     ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-            #     ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
 
-            #     for g0 in range(grid_start, grid_end, ngrids_per_batch):
-            #         g1 = min(g0 + ngrids_per_batch, grid_end)
-            #         split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
-            #         split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
 
-            #         mu = split_ao[0]
-            #         dmu_dr = split_ao[1:4]
-            #         d2mu_dr2 = get_d2mu_dr2(split_ao)
+            if ao.size == 0:
+                g0 = g1
+                continue
 
-            #         rho_drho = numint.eval_rho2(mol, split_ao[:4], mo_coeff, mo_occ, xctype=xctype)
-            #         vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 2, xctype=xctype)[1:3]
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
 
-            #         # rho = rho_drho[0]
-            #         # drho_dr = rho_drho[1:4]
-            #         rho_drho = None
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            mocc_masked = mocc_sorted[idx, :]
 
-            #         depsilon_drho = vxc[0]
-            #         depsilon_dnablarho = vxc[1:4]
-            #         # d2epsilon_drho2 = fxc[0,0]
-            #         # d2epsilon_drho_dnablarho = fxc[0,1:4]
-            #         # d2epsilon_dnablarho2 = fxc[1:4,1:4]
+            rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
+            del rho
 
-            #         dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-            #         # # Negative here to cancel the overall negative sign before return
-            #         # vmat -= cupy.einsum("Adg,g,pg,qg,qj->Adpj", dw_dA, depsilon_drho, mu, mu, mocc)
-            #         # vmat -= cupy.einsum("Adg,xg,xpg,qg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
-            #         # vmat -= cupy.einsum("Adg,xg,xqg,pg,qj->Adpj", dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc)
-            #         depsilondnablarho_dmudr = contract("xg,xpg->pg", depsilon_dnablarho, dmu_dr)
-            #         depsilondrho_mu = mu * depsilon_drho
-            #         mu_occ = mu.T @ mocc
-            #         for i_atom in range(natm):
-            #             dwdA_depsilondrho_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], depsilondrho_mu + depsilondnablarho_dmudr)
-            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu, mu_occ)
-            #             dwdA_depsilondrho_mu = None
-            #         depsilondrho_mu = None
-            #         mu_occ = None
-            #         depsilondnablarho_dmudr_occ = depsilondnablarho_dmudr.T @ mocc
-            #         depsilondnablarho_dmudr = None
-            #         for i_atom in range(natm):
-            #             dwdA_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], mu)
-            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ)
-            #             dwdA_mu = None
-            #         depsilondnablarho_dmudr_occ = None
-            #         dw_dA = None
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
 
-            #         grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
-            #         atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-            #         grid_to_atom_index_map = None
+            # dFock_mo_occ += cupy.einsum("pi,Adg,g,pg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_drho, mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xpg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xqg,pg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            dwdA_vxc = contract("Adg,xg->Adxg", dw_dA, vxc)
+            del dw_dA
 
-            #         _, _, drho_dA_grid_response, dnablarho_dA_grid_response = \
-            #             get_drho_dA_full(dm0, xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, with_orbital_response = False)
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
 
-            #         weight = cupy.asarray(grids.weights)[g0:g1]
-            #         # # Negative here to cancel the overall negative sign before return
-            #         # # d2epsilon/drho2 * drho/dR * mu * nu
-            #         # vmat -= cupy.einsum("g,g,Adg,pg,qg,qj->Adpj", weight, d2epsilon_drho2, drho_dA_grid_response, mu, mu, mocc)
-            #         # # d2epsilon/(drho d_nabla_rho) * d_nabla_rho/dR * mu * nu
-            #         # vmat -= cupy.einsum("g,xg,Adxg,pg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, dnablarho_dA_grid_response, mu, mu, mocc)
-            #         # # d2epsilon/(d_nabla_rho drho) * drho/dR * nabla(mu * nu)
-            #         # vmat -= cupy.einsum("g,xg,Adg,xpg,qg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
-            #         # vmat -= cupy.einsum("g,xg,Adg,xqg,pg,qj->Adpj", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dmu_dr, mu, mocc)
-            #         # # d2epsilon/(d_nabla_rho d_nabla_rho) * d_nabla_rho/dR * nabla(mu * nu)
-            #         # vmat -= cupy.einsum("g,xyg,Adxg,ypg,qg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
-            #         # vmat -= cupy.einsum("g,xyg,Adxg,yqg,pg,qj->Adpj", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dmu_dr, mu, mocc)
-            #         combined_d_dA_grid_response = cupy.concatenate((drho_dA_grid_response[:, :, None, :], dnablarho_dA_grid_response), axis = 2)
-            #         drho_dA_grid_response = None
-            #         dnablarho_dA_grid_response = None
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
 
-            #         fwxc = fxc * weight
-            #         fxc = None
-            #         drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, combined_d_dA_grid_response)
-            #         combined_d_dA_grid_response = None
-            #         fwxc = None
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
 
-            #         mu_occ = mu.T @ mocc
-            #         dmudr_occ = contract("dqg,qj->dgj", dmu_dr, mocc)
-            #         for i_atom in range(natm):
-            #             drhodA_grid_response_fwxc_rho_term_mu = contract("dg,pg->dpg", drhodA_grid_response_fwxc[i_atom, :, 0, :], mu)
-            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu, mu_occ)
-            #             drhodA_grid_response_fwxc_rho_term_mu = None
-            #             drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmudr_occ)
-            #             vmat[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
-            #             drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = None
-            #             drhodA_grid_response_fwxc_nablarho_term_dmudr = contract("dxg,xpg->dpg", drhodA_grid_response_fwxc[i_atom, :, 1:4, :], dmu_dr)
-            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr, mu_occ)
-            #             drhodA_grid_response_fwxc_nablarho_term_dmudr = None
-            #         drhodA_grid_response_fwxc = None
-            #         mu_occ = None
-            #         dmudr_occ = None
+            weight = weight[nonzero_weight_mask[g0:g1]]
 
-            #         for i_atom in range(natm):
-            #             associated_grid_index = atom_to_grid_index_map[i_atom]
-            #             if len(associated_grid_index) == 0:
-            #                 continue
-            #             # # Negative here to cancel the overall negative sign before return
-            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dpg,qg,qj->dpj",
-            #             #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-            #             #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,g,dqg,pg,qj->dpj",
-            #             #     weight[associated_grid_index], depsilon_drho[associated_grid_index],
-            #             #     dmu_dr[:, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDpg,qg,qj->dpj",
-            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-            #             #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dDqg,pg,qj->dpj",
-            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-            #             #     d2mu_dr2[:, :, :, associated_grid_index], mu[:, associated_grid_index], mocc)
-            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dpg,Dqg,qj->dpj",
-            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-            #             #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-            #             # vmat[i_atom, :, :, :] -= cupy.einsum("g,Dg,dqg,Dpg,qj->dpj",
-            #             #     weight[associated_grid_index], depsilon_dnablarho[:, associated_grid_index],
-            #             #     dmu_dr[:, :, associated_grid_index], dmu_dr[:, :, associated_grid_index], mocc)
-            #             mu_grid_i = mu[:, associated_grid_index]
-            #             dmu_dr_grid_i = dmu_dr[:, :, associated_grid_index]
+            fwxc = fxc * weight
+            del fxc
+            drhodA_fwxc = contract("xyg,Adyg->Adxg", fwxc, drho_dA_full_response)
+            del drho_dA_full_response
+            del fwxc
 
-            #             mu_occ_grid_i = mu_grid_i.T @ mocc
-            #             dmudr_occ_grid_i = contract("dqg,qj->dgj", dmu_dr_grid_i, mocc)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,pg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 0, :], mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xpg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xqg,pg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            mu_nu_term_prefactor = drhodA_fwxc + dwdA_vxc
+            del drhodA_fwxc, dwdA_vxc
 
-            #             weight_depsilondrho_grid_i = weight[associated_grid_index] * depsilon_drho[associated_grid_index]
-            #             vmat[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i) @ mu_occ_grid_i
-            #             vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i, dmudr_occ_grid_i)
-            #             weight_depsilondrho_grid_i = None
+            dFock_sparse_ao_occ = cupy.zeros((natm, 3, mu.shape[0], nocc))
 
-            #             d2mu_dr2_grid_i = d2mu_dr2[:, :, :, associated_grid_index]
+            mu_mocc = mu.T @ mocc_masked
+            dmudr_mocc = contract("dqg,qj->djg", dmu_dr, mocc_masked)
+            for i_atom in range(natm):
+                mu_on_right_term = contract("xpg,dxg->dpg", ao[0:4], mu_nu_term_prefactor[i_atom, :, 0:4, :])
+                dFock_sparse_ao_occ[i_atom, :, :, :] += contract("dpg,gj->dpj", mu_on_right_term, mu_mocc)
+                del mu_on_right_term
+                nablarho_dmudr_on_right_term = contract("dxg,xjg->djg", mu_nu_term_prefactor[i_atom, :, 1:4, :], dmudr_mocc)
+                dFock_sparse_ao_occ[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
+                del nablarho_dmudr_on_right_term
+            del mu_mocc, dmudr_mocc
+            del mu_nu_term_prefactor
 
-            #             weight_depsilondnablarho_grid_i = weight[associated_grid_index] * depsilon_dnablarho[:, associated_grid_index]
-            #             weight_depsilondnablarho_d2mudr2 = contract("Dg,dDpg->dpg", weight_depsilondnablarho_grid_i, d2mu_dr2_grid_i)
-            #             d2mu_dr2_grid_i = None
-            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2, mu_occ_grid_i)
-            #             mu_occ_grid_i = None
-            #             weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2, mocc)
-            #             weight_depsilondnablarho_d2mudr2 = None
-            #             vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
-            #             mu_grid_i = None
-            #             weight_depsilondnablarho_d2mudr2_occ = None
-            #             weight_depsilondnablarho_dmudr = contract("Dg,Dpg->pg", weight_depsilondnablarho_grid_i, dmu_dr_grid_i)
-            #             vmat[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr, dmudr_occ_grid_i)
-            #             dmudr_occ_grid_i = None
-            #             weight_depsilondnablarho_dmudr_occ = weight_depsilondnablarho_dmudr.T @ mocc
-            #             weight_depsilondnablarho_dmudr = None
-            #             vmat[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ)
-            #             weight_depsilondnablarho_dmudr_occ = None
-            #             dmu_dr_grid_i = None
-            #             weight_depsilondnablarho_grid_i = None
+            wv = vxc * weight
+            del vxc
+            weight_depsilon_drho = wv[0]
+            weight_depsilon_dnablarho = wv[1:4]
+            del wv
+
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dxpg,qg->dpq", depsilon_dnablarho * weight, d2mu_dr2, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dpg,xqg->dpq", depsilon_dnablarho * weight, dmu_dr, dmu_dr)
+            dmudr_weight_depsilondnablarho = contract("xg,xpg->pg", weight_depsilon_dnablarho, dmu_dr)
+            dmudA_nu_ao = contract("dpg,qg->dpq", dmu_dr, mu * weight_depsilon_drho + dmudr_weight_depsilondnablarho)
+            del dmudr_weight_depsilondnablarho
+            d2mudr2_weight_depsilondnablarho = contract("dxpg,xg->dpg", d2mu_dr2, weight_depsilon_dnablarho)
+            dmudA_nu_ao += contract("dpg,qg->dpq", d2mudr2_weight_depsilondnablarho, mu)
+            del d2mudr2_weight_depsilondnablarho
+
+            dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += dmudA_nu_ao
+
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,2,1)
+            del dmudA_nu_ao
+            dFock_sparse_ao_occ[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
+            del dmudA_nu_ao_ao
+
+            dFock_ao_occ[:, :, idx, :] += dFock_sparse_ao_occ
+            del dFock_sparse_ao_occ
+
+            g0 = g1
+        assert g1 == ngrids
 
     elif xctype == 'MGGA':
         g0 = 0
@@ -2095,7 +2041,6 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             d2mu_dr2 = get_d2mu_dr2(ao)
 
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
-            mo_coeff_masked = mo_coeff_sorted[idx, :]
             mocc_masked = mocc_sorted[idx, :]
 
             rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
@@ -2137,21 +2082,20 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             mu_nu_term_prefactor = drhodA_fwxc + dwdA_vxc
             del drhodA_fwxc, dwdA_vxc
 
+            dFock_sparse_ao_occ = cupy.zeros((natm, 3, mu.shape[0], nocc))
+
             mu_mocc = mu.T @ mocc_masked
             dmudr_mocc = contract("dqg,qj->djg", dmu_dr, mocc_masked)
-            dFock_ao_occ = cupy.zeros((natm, 3, mu.shape[0], nocc))
             for i_atom in range(natm): # Henry 20260519: This is the most performance critical loop
                 mu_on_right_term = contract("xpg,dxg->dpg", ao[0:4], mu_nu_term_prefactor[i_atom, :, 0:4, :])
-                dFock_ao_occ[i_atom, :, :, :] = contract("dpg,gj->dpj", mu_on_right_term, mu_mocc)
+                dFock_sparse_ao_occ[i_atom, :, :, :] += contract("dpg,gj->dpj", mu_on_right_term, mu_mocc)
                 del mu_on_right_term
                 nablarho_dmudr_on_right_term = contract("dxg,xjg->djg", mu_nu_term_prefactor[i_atom, :, 1:4, :], dmudr_mocc)
-                dFock_ao_occ[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
+                dFock_sparse_ao_occ[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
                 del nablarho_dmudr_on_right_term
                 tau_term = contract("dg,xjg->dxjg", mu_nu_term_prefactor[i_atom, :, 4, :], dmudr_mocc)
-                dFock_ao_occ[i_atom, :, :, :] += 0.5 * contract("xpg,dxjg->dpj", dmu_dr, tau_term)
+                dFock_sparse_ao_occ[i_atom, :, :, :] += 0.5 * contract("xpg,dxjg->dpj", dmu_dr, tau_term)
                 del tau_term
-            dFock_mo_occ += contract("pi,Adpj->Adij", mo_coeff_masked, dFock_ao_occ)
-            del dFock_ao_occ
             del mu_mocc, dmudr_mocc
             del mu_nu_term_prefactor
 
@@ -2185,10 +2129,11 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum("pi,g,dxqg,xpg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
             dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,2,1)
             del dmudA_nu_ao
-            dmudA_nu_ao_occ = contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
+            dFock_sparse_ao_occ[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao, mocc_masked)
             del dmudA_nu_ao_ao
-            dFock_mo_occ[i_atom_of_grids, :, :, :] += contract("pi,dpj->dij", mo_coeff_masked, dmudA_nu_ao_occ)
-            del dmudA_nu_ao_occ
+
+            dFock_ao_occ[:, :, idx, :] += dFock_sparse_ao_occ
+            del dFock_sparse_ao_occ
 
             g0 = g1
         assert g1 == ngrids
@@ -2198,6 +2143,8 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     else:
         raise NotImplementedError(f"xctype = {xctype} not supported")
 
+    dFock_mo_occ = contract("Adpj,pi->Adij", dFock_ao_occ, mo_coeff_sorted)
+    del dFock_ao_occ
     for i_atom in range(0, natm):
         ao_of_atom_i = cupy.where(i_atom_of_aos == i_atom)[0]
         if ao_of_atom_i.size > 0:

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -3163,13 +3163,13 @@ def get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = None, i_
         del nablarho_response
 
     if with_tau:
-        tau_reponse = 0.5 * contract('dDig,Dig->dig', d2mu_dr2, dm_dot_dmu_and_dnu)
+        tau_response = 0.5 * contract('dDig,Dig->dig', d2mu_dr2, dm_dot_dmu_and_dnu)
         if with_orbital_response:
             cupy.add.at(drho_dA_orbital_response[:, :, 4, :], masked_i_atom_of_aos, tau_response.transpose(1,0,2))
         if with_grid_response:
-            tau_reponse = cupy.einsum('dig->dg', tau_reponse)
-            drho_dA_grid_response[i_atom_of_grids, :, 4, :] = tau_reponse
-        del tau_reponse
+            tau_response = cupy.einsum('dig->dg', tau_response)
+            drho_dA_grid_response[i_atom_of_grids, :, 4, :] = tau_response
+        del tau_response
 
     drho_dA_orbital_response *= -1
 
@@ -3593,6 +3593,26 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
                                mu = None, dmu_dr = None, d2mu_dr2 = None, d3mu_dr3 = None,
                                weight_depsilon_drho = None, weight_depsilon_dnablarho = None, weight_depsilon_dtau = None,
                                with_orbital_response = True, with_grid_response = True):
+    r"""
+        This function does the following in an optimized way:
+
+        d2rho_dAdB_orbital_response, d2nablarho_dAdB_orbital_response, d2tau_dAdB_orbital_response, \
+            d2rho_dAdB_grid_response, d2nablarho_dAdB_grid_response, d2tau_dAdB_grid_response = \
+            get_d2rho_dAdB_full(
+                dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+            )
+
+        ref_d2E_dAdB_orbital_response += d2rho_dAdB_orbital_response @ weight_depsilon_drho[g0:g1]
+        ref_d2E_dAdB_orbital_response += cp.einsum("ABdDxg,xg->ABdD", d2nablarho_dAdB_orbital_response, weight_depsilon_dnablarho[:, g0:g1])
+        ref_d2E_dAdB_orbital_response += d2tau_dAdB_orbital_response @ weight_depsilon_dtau[g0:g1]
+
+        If you think the logic in this function is nonsense, I agree. Refer get_d2rho_dAdB_full() for a readable code.
+        This function has went through the following optimizations:
+        1. Split the chain contraction into binary contractions, and reorder the contraction
+        2. Allow a sparse AO, and guarantees a block of grids belongs to the same atom
+        3. Merge grid response diagonal terms into off-digonal term
+        4. Share the intermediate variables among orbital and grid response
+    """
     if xctype == "LDA":
         with_nablarho = False
         with_tau = False
@@ -3632,25 +3652,6 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
     dm_dmT = dm0_masked + dm0_masked.T
     dm_dot_mu = dm_dmT @ mu
     dm_dot_dmudr = contract("ij,djg->dig", dm_dmT, dmu_dr)
-
-    d2e = cupy.zeros([natm, natm, 3, 3])
-
-    # if with_orbital_response:
-    #     for i_atom in range(natm):
-    #         if with_tau:
-    #             # d3mu/(dA dB dr) * dnu/dr, A orbital, B orbital
-    #             d3mudAdAdr_dnudr = contract("dDxig,xig->dDg", d3mu_dr3[:, :, :, pi0:pi1, :], dm_dot_dmudr_i)
-    #             d2e[i_atom, i_atom, :, :] += 0.5 * d3mudAdAdr_dnudr @ weight_depsilon_dtau
-    #             d3mudAdAdr_dnudr = None
-    #         dm_dot_dmudr_i = None
-    #             if with_tau:
-    #                 pj0, pj1 = aoslices[j_atom][2:]
-    #                 # d2mu/(dA dr) * d2nu/(dB dr), A orbital, B orbital
-    #                 dm_dot_d2mudr2_ij = contract("dDjg,ij->dDig", d2mu_dr2[:, :, pj0:pj1, :], dm_dmT[pi0:pi1, pj0:pj1])
-    #                 d2mudAdr_d2nudBdr = contract("dxig,Dxig->dDg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_d2mudr2_ij)
-    #                 dm_dot_d2mudr2_ij = None
-    #                 d2e[i_atom, j_atom, :, :] += 0.5 * d2mudAdr_d2nudBdr @ weight_depsilon_dtau
-    #                 d2mudAdr_d2nudBdr = None
 
     d2e_ii_AA_ao_uncontracted = 0
     d2V = 0
@@ -3703,24 +3704,21 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
         del d2mudr2_wv
         del d2nablarhodAdG
 
-        # if with_tau:
-        #     d2taudGdG = cupy.ndarray([3, 3, ngrids_i], memptr = buf_27_nao_ngrids.data)
-        #     # d3mu/(dA dB dr) * dnu/dr, A grid, B grid
-        #     contract("dDxig,xig->dDg", d3mu_dr3_grid_i, dm_dot_dmudr_i, beta = 0.0, out = d2taudGdG)
-        #     # d2mu/(dA dr) * d2nu/(dB dr), A grid, B grid
-        #     contract("dxig,Dxig->dDg", d2mu_dr2_grid_i, dm_dot_d2mudr2_i, beta = 1.0, out = d2taudGdG)
-        #     d2e[i_atom, i_atom, :, :] += 0.5 * d2taudGdG @ weight_depsilon_dtau_grid_i
-        #     d2taudGdG = None
+    if with_tau:
+        # d3mu/(dA dB dr) * dnu/dr
+        d2taudAdG = 0.5 * contract("dDxig,xig->dDi", d3mu_dr3, dm_dot_dmudr * weight_depsilon_dtau)
+        # d2mu/(dA dr) * d2nu/(dB dr)
+        d2mudAdr_d2nudBdr_wv = 0.5 * contract("dxig,Dxjg->dDij", d2mu_dr2, d2mu_dr2 * weight_depsilon_dtau)
+        if with_orbital_response:
+            d2e_ii_AA_ao_uncontracted += d2taudAdG
+            d2V += d2mudAdr_d2nudBdr_wv
+        if with_grid_response:
+            d2taudAdG += contract("dDij,ij->dDi", d2mudAdr_d2nudBdr_wv, dm_dmT)
+            d2e_ji_AB_ao_uncontracted += d2taudAdG
+        del d2mudAdr_d2nudBdr_wv
+        del d2taudAdG
 
-
-        # if with_tau:
-        #     d2taudAdG = cupy.ndarray([3, 3, ngrids_i], memptr = buf_27_nao_ngrids.data)
-        #     # d3mu/(dA dB dr) * dnu/dr, A orbital, B grid
-        #     contract("dDxig,xig->dDg", d3mu_dr3_grid_i[:, :, :, pj0:pj1, :], dm_dot_dmudr_ji, beta = 0.0, out = d2taudAdG)
-        #     # d2mu/(dA dr) * d2nu/(dB dr), A orbital, B grid
-        #     contract("dxig,Dxig->dDg", d2mu_dr2_grid_i[:, :, pj0:pj1, :], dm_dot_d2mudr2_ij, beta = 1.0, out = d2taudAdG)
-        #     d2e_ji_AB_ao_uncontracted += 0.5 * d2taudAdG @ weight_depsilon_dtau_grid_i
-        #     d2taudAdG = None
+    d2e = cupy.zeros([natm, natm, 3, 3])
 
     if with_orbital_response:
         d2e_ii_AA = cupy.zeros((natm, 3, 3))
@@ -3772,9 +3770,8 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     _sorted_mol = opt._sorted_mol
     nao = _sorted_mol.nao
-
     natm = mol.natm
-    aoslices = mol.aoslice_by_atom()
+    mol = None
 
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
     assert dm0.ndim == 2
@@ -3789,7 +3786,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     i_atom_of_aos = numpy.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
     i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
 
-    d2e = cupy.zeros([mol.natm, mol.natm, 3, 3])
+    d2e = cupy.zeros([natm, natm, 3, 3])
 
     if xctype == 'LDA':
         g0 = 0
@@ -3803,7 +3800,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             epsilon = exc[:, 0] * rho
             del rho, exc
 
-            d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
+            d2w_dAdB = get_d2weight_dAdB(_sorted_mol, grids, (g0,g1))
             d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
             del d2w_dAdB, epsilon
             g0 = g1
@@ -3916,7 +3913,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
             del drho_dA_orbital_response, drho_dA_grid_response
 
-            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
             dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
 
             # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
@@ -3946,169 +3943,88 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
     elif xctype == 'MGGA':
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((4) * mol.nao + (9) * mol.natm * mol.natm + 5 + 1*2) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for mGGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                                f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 1, gdftopt = None, transpose = False)
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
+            exc = ni.eval_xc_eff(mf.xc, rho, deriv = 0, xctype=xctype)[0]
 
-            rho_drho_tau = numint.eval_rho2(mol, split_ao, mo_coeff, mo_occ, xctype=xctype)
-            exc = ni.eval_xc_eff(mf.xc, rho_drho_tau, deriv = 0, xctype=xctype)[0]
+            epsilon = exc[:, 0] * rho[0, :]
+            del rho, exc
 
-            rho = rho_drho_tau[0]
-            rho_drho_tau = None
-
-            epsilon = exc[:, 0] * rho
-            rho = None
-            exc = None
-
-            d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
+            d2w_dAdB = get_d2weight_dAdB(_sorted_mol, grids, (g0,g1))
             d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
-            d2w_dAdB = None
-            epsilon = None
+            del d2w_dAdB, epsilon
+            g0 = g1
+        assert g1 == ngrids
 
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((20 + 9 + 27 + 2 + 3*2 + 4*4 + 12*4 + 9*4) * mol.nao
-                              + (3*3 + 9*3 + 3*3 + 3 + 3*3 + 5*2*3) * mol.natm + 5*2 + 25*2 + 18*4 + 27*2*4 + 18*4) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for mGGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                                f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 3, gdftopt = None, transpose = False)
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
 
-            mu = split_ao[0]
-            dmu_dr = split_ao[1:4]
-            d2mu_dr2 = get_d2mu_dr2(split_ao)
-            d3mu_dr3 = get_d3mu_dr3(split_ao)
+            if ao.size == 0:
+                g0 = g1
+                continue
 
-            rho_drho_tau = numint.eval_rho2(mol, split_ao[:4], mo_coeff, mo_occ, xctype=xctype)
-            vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho_tau, deriv = 2, xctype=xctype)[1:3]
-            rho_drho_tau = None
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype = xctype)[1:3]
+            del rho
 
             depsilon_drho = vxc[0]
             depsilon_dnablarho = vxc[1:4]
             depsilon_dtau = vxc[4]
-            # d2epsilon_drho2 = fxc[0,0]
-            # d2epsilon_drho_dnablarho = fxc[0,1:4]
-            # d2epsilon_drho_dtau = fxc[0,4]
-            # d2epsilon_dnablarho2 = fxc[1:4,1:4]
-            # d2epsilon_dnablarho_dtau = fxc[1:4,4]
-            # d2epsilon_dtau2 = fxc[4,4]
 
-            grid_to_atom_index_map = grids.atm_idx[g0:g1]
-            atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-            grid_to_atom_index_map = None
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
 
-            drho_dA_orbital_response, dnablarho_dA_orbital_response, dtau_dA_orbital_response, \
-                drho_dA_grid_response, dnablarho_dA_grid_response, dtau_dA_grid_response = \
-                    get_drho_dA_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2)
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
 
-            drho_dA_full = drho_dA_orbital_response + drho_dA_grid_response
-            dnablarho_dA_full = dnablarho_dA_orbital_response + dnablarho_dA_grid_response
-            dtau_dA_full = dtau_dA_orbital_response + dtau_dA_grid_response
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
 
-            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full)
-            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full)
-            # d2e += cupy.einsum("Adg,xg,BDxg->ABdD", dw_dA, depsilon_dnablarho, dnablarho_dA_full)
-            # d2e += cupy.einsum("Adg,xg,BDxg->BADd", dw_dA, depsilon_dnablarho, dnablarho_dA_full)
-            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_dtau, dtau_dA_full)
-            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_dtau, dtau_dA_full)
-            depsilondnablarho_dnablarhodA = contract("xg,Adxg->Adg", depsilon_dnablarho, dnablarho_dA_full)
-            dnablarho_dA_full = None
-            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drho_dA_full * depsilon_drho + depsilondnablarho_dnablarhodA + dtau_dA_full * depsilon_dtau)
-            drho_dA_full = None
-            dtau_dA_full = None
-            depsilondnablarho_dnablarhodA = None
-            dw_dA = None
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->ABdD", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->BADd", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_dtau, drho_dA_full_response[:,:,4,:])
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_dtau, drho_dA_full_response[:,:,4,:])
+            depsilondnablarho_dnablarhodA = contract("xg,Adxg->Adg", depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drho_dA_full_response[:,:,0,:] * depsilon_drho + depsilondnablarho_dnablarhodA + drho_dA_full_response[:,:,4,:] * depsilon_dtau)
+            del depsilondnablarho_dnablarhodA
+            del dw_dA
             d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
-            d2e_dwdA_term = None
+            del d2e_dwdA_term
 
-            weight = grids.weights[g0:g1]
-            # # d2epsilon/drho2 * drho/dA * drho/dB
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_orbital_response, drho_dA_grid_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_grid_response, drho_dA_orbital_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_grid_response, drho_dA_grid_response)
-            # # d2epsilon/(drho d_nabla_rho) * d_nabla_rho/dA * drho/dB
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->ABdD", weight, d2epsilon_drho_dnablarho, drho_dA_orbital_response, dnablarho_dA_grid_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->ABdD", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_orbital_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->ABdD", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_grid_response)
-            # # d2epsilon/(drho d_nabla_rho) * drho/dA * d_nabla_rho/dB
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->BADd", weight, d2epsilon_drho_dnablarho, drho_dA_orbital_response, dnablarho_dA_grid_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->BADd", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_orbital_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->BADd", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_grid_response)
-            # # d2epsilon/(d_nabla_rho d_nabla_rho) * d_nabla_rho/dA * d_nabla_rho/dB
-            # d2e += cupy.einsum("g,xyg,Adxg,BDyg->ABdD", weight, d2epsilon_dnablarho2, dnablarho_dA_orbital_response, dnablarho_dA_grid_response)
-            # d2e += cupy.einsum("g,xyg,Adxg,BDyg->ABdD", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dnablarho_dA_orbital_response)
-            # d2e += cupy.einsum("g,xyg,Adxg,BDyg->ABdD", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dnablarho_dA_grid_response)
-            # # d2epsilon/(drho dtau) * dtau/dA * drho/dB
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho_dtau, drho_dA_orbital_response, dtau_dA_grid_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho_dtau, drho_dA_grid_response, dtau_dA_orbital_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho_dtau, drho_dA_grid_response, dtau_dA_grid_response)
-            # # d2epsilon/(drho dtau) * drho/dA * dtau/dB
-            # d2e += cupy.einsum("g,g,Adg,BDg->BADd", weight, d2epsilon_drho_dtau, drho_dA_orbital_response, dtau_dA_grid_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->BADd", weight, d2epsilon_drho_dtau, drho_dA_grid_response, dtau_dA_orbital_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->BADd", weight, d2epsilon_drho_dtau, drho_dA_grid_response, dtau_dA_grid_response)
-            # # d2epsilon/(d_nabla_rho dtau) * dtau/dA * d_nabla_rho/dB
-            # d2e += cupy.einsum("g,xg,Adxg,BDg->ABdD", weight, d2epsilon_dnablarho_dtau, dnablarho_dA_orbital_response, dtau_dA_grid_response)
-            # d2e += cupy.einsum("g,xg,Adxg,BDg->ABdD", weight, d2epsilon_dnablarho_dtau, dnablarho_dA_grid_response, dtau_dA_orbital_response)
-            # d2e += cupy.einsum("g,xg,Adxg,BDg->ABdD", weight, d2epsilon_dnablarho_dtau, dnablarho_dA_grid_response, dtau_dA_grid_response)
-            # # d2epsilon/(d_nabla_rho dtau) * d_nabla_rho/dA * dtau/dB
-            # d2e += cupy.einsum("g,xg,Adxg,BDg->BADd", weight, d2epsilon_dnablarho_dtau, dnablarho_dA_orbital_response, dtau_dA_grid_response)
-            # d2e += cupy.einsum("g,xg,Adxg,BDg->BADd", weight, d2epsilon_dnablarho_dtau, dnablarho_dA_grid_response, dtau_dA_orbital_response)
-            # d2e += cupy.einsum("g,xg,Adxg,BDg->BADd", weight, d2epsilon_dnablarho_dtau, dnablarho_dA_grid_response, dtau_dA_grid_response)
-            # # d2epsilon/dtau2 * dtau/dA * dtau/dB
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_dtau2, dtau_dA_orbital_response, dtau_dA_grid_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_dtau2, dtau_dA_grid_response, dtau_dA_orbital_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_dtau2, dtau_dA_grid_response, dtau_dA_grid_response)
-            combined_d_dA_orbital_response = cupy.concatenate(
-                (drho_dA_orbital_response[:, :, None, :], dnablarho_dA_orbital_response, dtau_dA_orbital_response[:, :, None, :]),
-                axis = 2
-            )
-            combined_d_dA_grid_response    = cupy.concatenate(
-                (   drho_dA_grid_response[:, :, None, :],    dnablarho_dA_grid_response,    dtau_dA_grid_response[:, :, None, :]),
-                axis = 2
-            )
-            drho_dA_orbital_response = None
-            dnablarho_dA_orbital_response = None
-            dtau_dA_orbital_response = None
-            drho_dA_grid_response = None
-            dnablarho_dA_grid_response = None
-            dtau_dA_grid_response = None
+            weight = weight[nonzero_weight_mask[g0:g1]]
             fwxc = fxc * weight
-            fxc = None
+            del fxc
+            drhodA_fwxc = contract("xyg,Adyg->Adxg", fwxc, drho_dA_full_response)
+            del fwxc
+            d2e += contract("Adxg,BDxg->ABdD", drho_dA_full_response, drhodA_fwxc)
+            del drhodA_fwxc, drho_dA_full_response
 
-            drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, combined_d_dA_grid_response)
-            fwxc = None
-            d2e_drhodA_cross_term = contract("Adxg,BDxg->ABdD", combined_d_dA_orbital_response, drhodA_grid_response_fwxc)
-            combined_d_dA_orbital_response = None
-            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
-            d2e_drhodA_cross_term += contract("Adxg,BDxg->ABdD", combined_d_dA_grid_response, drhodA_grid_response_fwxc)
-            combined_d_dA_grid_response = None
-            drhodA_grid_response_fwxc = None
-            d2e += d2e_drhodA_cross_term
-            d2e_drhodA_cross_term = None
+            d2e += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                                              mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                                              depsilon_drho * weight, depsilon_dnablarho * weight, depsilon_dtau * weight)
 
-            d2e += contract_d2rho_dAdB_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
-                                            mu, dmu_dr, d2mu_dr2, d3mu_dr3,
-                                            depsilon_drho * weight, depsilon_dnablarho * weight, depsilon_dtau * weight,
-                                            with_orbital_response = False)
+            g0 = g1
+        assert g1 == ngrids
 
     elif xctype == 'HF':
         pass

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -45,9 +45,6 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     log = logger.new_logger(hessobj, verbose)
     time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
-    import time
-    cupy.cuda.runtime.deviceSynchronize()
-    time_0 = time.time()
     mol = hessobj.mol
     mf = hessobj.base
     ni = mf._numint
@@ -103,12 +100,14 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
 def _get_exc_deriv2(hessobj, mo_coeff, mo_occ, dm0, max_memory, atmlst = None, log = None):
     if log is None:
         log = logger.new_logger(hessobj)
+
+    if hessobj.grid_response:
+        log.info("Calculating grid response for DFT Hessian")
+        return _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
+
     mol = hessobj.mol
     mf = hessobj.base
 
-    import time
-    cupy.cuda.runtime.deviceSynchronize()
-    time_0 = time.time()
     de2 = cupy.zeros([mol.natm, mol.natm, 3, 3])
 
     mem_now = lib.current_memory()[0]
@@ -129,13 +128,6 @@ def _get_exc_deriv2(hessobj, mo_coeff, mo_occ, dm0, max_memory, atmlst = None, l
 
         for j0 in range(i0):
             de2[j0,i0] = de2[i0,j0].T
-    cupy.cuda.runtime.deviceSynchronize()
-    time_1 = time.time()
-    print(f"d2e xc no response time = {time_1 - time_0}")
-    time_0 = time_1
-    if hessobj.grid_response:
-        log.info("Calculating grid response for DFT Hessian")
-        de2 += _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
 
     return de2
 
@@ -3637,63 +3629,20 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
         i_atom_of_grids = int(i_atom_of_grids)
         assert 0 <= i_atom_of_grids and i_atom_of_grids < natm
 
-    # order = cp.argsort(X)
-    # sorted_vals = X[order]
-    # splits = cp.flatnonzero(cp.diff(sorted_vals)) + 1
-    # groups = cp.split(order, splits.get())
-
     dm_dmT = dm0_masked + dm0_masked.T
     dm_dot_mu = dm_dmT @ mu
     dm_dot_dmudr = contract("ij,djg->dig", dm_dmT, dmu_dr)
 
     d2e = cupy.zeros([natm, natm, 3, 3])
 
-    if with_orbital_response:
-        pass
+    # if with_orbital_response:
     #     for i_atom in range(natm):
-    #         pi0, pi1 = aoslices[i_atom][2:]
-    #         # d2mu/dr2 * nu, A orbital, B orbital
-    #         dm_dot_mu_i = dm_dot_mu[pi0:pi1, :]
-    #         d2mudAdA_nu = contract("dDig,ig->dDg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_mu_i)
-    #         d2e[i_atom, i_atom, :, :] += d2mudAdA_nu @ weight_depsilon_drho
-    #         d2mudAdA_nu = None
-
-    #         if with_nablarho:
-    #             # d3mu/(dr dA dB) * nu, A orbital, B orbital
-    #             d3mudAdAdr_nu = contract("dDxig,ig->dDxg", d3mu_dr3[:, :, :, pi0:pi1, :], dm_dot_mu_i)
-    #             d2e[i_atom, i_atom, :, :] += contract("dDxg,xg->dD", d3mudAdAdr_nu, weight_depsilon_dnablarho)
-    #             d3mudAdAdr_nu = None
-    #             # d2mu/(dA dB) * dnu/dr, A orbital, B orbital
-    #             dm_dot_dmudr_i = dm_dot_dmudr[:, pi0:pi1, :]
-    #             d2mudAdA_dnudr = contract("dDig,xig->dDxg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_dmudr_i)
-    #             d2e[i_atom, i_atom, :, :] += contract("dDxg,xg->dD", d2mudAdA_dnudr, weight_depsilon_dnablarho)
-    #             d2mudAdA_dnudr = None
-    #         dm_dot_mu_i = None
-
     #         if with_tau:
     #             # d3mu/(dA dB dr) * dnu/dr, A orbital, B orbital
     #             d3mudAdAdr_dnudr = contract("dDxig,xig->dDg", d3mu_dr3[:, :, :, pi0:pi1, :], dm_dot_dmudr_i)
     #             d2e[i_atom, i_atom, :, :] += 0.5 * d3mudAdAdr_dnudr @ weight_depsilon_dtau
     #             d3mudAdAdr_dnudr = None
     #         dm_dot_dmudr_i = None
-
-    #         for j_atom in range(natm):
-    #             pj0, pj1 = aoslices[j_atom][2:]
-    #             # dmu/dr * dnu/dr, A orbital, B orbital
-    #             dm_dot_dmudr_ij = contract("djg,ij->dig", dmu_dr[:, pj0:pj1, :], dm_dmT[pi0:pi1, pj0:pj1])
-    #             dmudA_dnudB = contract("dig,Dig->dDg", dmu_dr[:, pi0:pi1, :], dm_dot_dmudr_ij)
-    #             d2e[i_atom, j_atom, :, :] += dmudA_dnudB @ weight_depsilon_drho
-
-    #             if with_nablarho:
-    #                 # d2mu/(dr dA) * dnu/dB, A orbital, B orbital
-    #                 d2mudAdr_dnudB = contract("dxig,Dig->dDxg", d2mu_dr2[:, :, pi0:pi1, :], dm_dot_dmudr_ij)
-    #                 d2e_ij_AB = contract("dDxg,xg->dD", d2mudAdr_dnudB, weight_depsilon_dnablarho)
-    #                 d2mudAdr_dnudB = None
-    #                 d2e[i_atom, j_atom, :, :] += d2e_ij_AB
-    #                 d2e[j_atom, i_atom, :, :] += d2e_ij_AB.T
-    #                 d2e_ij_AB = None
-    #             dm_dot_dmudr_ij = None
-
     #             if with_tau:
     #                 pj0, pj1 = aoslices[j_atom][2:]
     #                 # d2mu/(dA dr) * d2nu/(dB dr), A orbital, B orbital
@@ -3703,36 +3652,56 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
     #                 d2e[i_atom, j_atom, :, :] += 0.5 * d2mudAdr_d2nudBdr @ weight_depsilon_dtau
     #                 d2mudAdr_d2nudBdr = None
 
-    if with_grid_response:
-        # d2mu/dr2 * nu, A orbital, B grid
-        d2rhodAdG = contract("dDig,ig->dDi", d2mu_dr2, dm_dot_mu * weight_depsilon_drho)
-        # dmu/dr * dnu/dr, A orbital, B grid
-        d2rhodAdG += contract("dig,Dig->dDi", dmu_dr, dm_dot_dmudr * weight_depsilon_drho)
-        d2e_ji_AB_ao_uncontracted = d2rhodAdG
-        del d2rhodAdG
+    d2e_ii_AA_ao_uncontracted = 0
+    d2V = 0
+    d2e_ji_AB_ao_uncontracted = 0
 
-        if with_nablarho:
-            # d3mu/(dr dA dB) * nu, A orbital, B grid
-            d3mudr3_wv = contract("dDxig,xg->dDig", d3mu_dr3, weight_depsilon_dnablarho)
-            d2nablarhodAdG = contract("dDig,ig->dDi", d3mudr3_wv, dm_dot_mu)
-            del d3mudr3_wv
-            # d2mu/(dA dB) * dnu/dr, A orbital, B grid
-            dm_dmudr_wv = contract("xig,xg->ig", dm_dot_dmudr, weight_depsilon_dnablarho)
-            d2nablarhodAdG += contract("dDig,ig->dDi", d2mu_dr2, dm_dmudr_wv)
-            del dm_dmudr_wv
+    # d2mu/dAdB * nu
+    d2rhodAdG = contract("dDig,ig->dDi", d2mu_dr2, dm_dot_mu * weight_depsilon_drho)
+    if with_orbital_response:
+        d2e_ii_AA_ao_uncontracted += d2rhodAdG
+    if with_grid_response:
+        d2e_ji_AB_ao_uncontracted += d2rhodAdG
+    del d2rhodAdG
+
+    # dmu/dA * dnu/dB
+    dmudr_wv = dmu_dr * weight_depsilon_drho
+    if with_orbital_response:
+        d2rhodAdB = contract("dig,Djg->dDij", dmu_dr, dmudr_wv)
+        d2V += d2rhodAdB
+        del d2rhodAdB
+    if with_grid_response:
+        d2rhodAdG = contract("dig,Dig->dDi", dmudr_wv, dm_dot_dmudr)
+        d2e_ji_AB_ao_uncontracted += d2rhodAdG
+        del d2rhodAdG
+    del dmudr_wv
+
+    if with_nablarho:
+        # d3mu/(dr dA dB) * nu
+        d3mudr3_wv = contract("dDxig,xg->dDig", d3mu_dr3, weight_depsilon_dnablarho)
+        d2nablarhodAdG = contract("dDig,ig->dDi", d3mudr3_wv, dm_dot_mu)
+        del d3mudr3_wv
+        # d2mu/(dA dB) * dnu/dr
+        dm_dmudr_wv = contract("xig,xg->ig", dm_dot_dmudr, weight_depsilon_dnablarho)
+        d2nablarhodAdG += contract("dDig,ig->dDi", d2mu_dr2, dm_dmudr_wv)
+        del dm_dmudr_wv
+        d2mudr2_wv = contract("dxig,xg->dig", d2mu_dr2, weight_depsilon_dnablarho)
+        if with_orbital_response:
+            d2e_ii_AA_ao_uncontracted += d2nablarhodAdG
+            # d2mu/(dr dA) * dnu/dB, A orbital, B orbital
+            d2mudr2_dnudr_wv = contract("dig,Djg->dDij", d2mudr2_wv, dmu_dr)
+            d2V += d2mudr2_dnudr_wv + d2mudr2_dnudr_wv.transpose(1,0,3,2)
+            del d2mudr2_dnudr_wv
+        if with_grid_response:
             # d2mu/(dr dA) * dnu/dB, A orbital, B grid
-            d2mudr2_wv = contract("dxig,xg->dig", d2mu_dr2, weight_depsilon_dnablarho)
             d2nablarhodAdG += contract("dig,Dig->dDi", d2mudr2_wv, dm_dot_dmudr)
-            # del d2mudr2_wv
             # d2mu/(dr dA) * dnu/dB, A grid, B orbital
-            # dm_d2mudr2_wv = contract("dxig,xg->dig", dm_dot_d2mudr2, weight_depsilon_dnablarho)
             dm_d2mudr2_wv = contract("ij,djg->dig", dm_dmT, d2mudr2_wv)
             d2nablarhodAdG += contract("dig,Dig->dDi", dmu_dr, dm_d2mudr2_wv)
             del dm_d2mudr2_wv
-
             d2e_ji_AB_ao_uncontracted += d2nablarhodAdG
-            del d2nablarhodAdG
-
+        del d2mudr2_wv
+        del d2nablarhodAdG
 
         # if with_tau:
         #     d2taudGdG = cupy.ndarray([3, 3, ngrids_i], memptr = buf_27_nao_ngrids.data)
@@ -3753,6 +3722,20 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
         #     d2e_ji_AB_ao_uncontracted += 0.5 * d2taudAdG @ weight_depsilon_dtau_grid_i
         #     d2taudAdG = None
 
+    if with_orbital_response:
+        d2e_ii_AA = cupy.zeros((natm, 3, 3))
+        d2e_ii_AA_ao_uncontracted = d2e_ii_AA_ao_uncontracted.transpose(2,0,1)
+        cupy.add.at(d2e_ii_AA, masked_i_atom_of_aos, d2e_ii_AA_ao_uncontracted)
+        del d2e_ii_AA_ao_uncontracted
+        for i_atom in range(natm):
+            d2e[i_atom, i_atom, :, :] += d2e_ii_AA[i_atom, :, :]
+        del d2e_ii_AA
+
+        d2V = d2V * dm_dmT[None, None, :, :]
+        d2V = d2V.transpose(2,3,0,1)
+        cupy.add.at(d2e, (masked_i_atom_of_aos[:, None], masked_i_atom_of_aos[None, :], slice(None), slice(None)), d2V)
+
+    if with_grid_response:
         d2e[i_atom_of_grids, i_atom_of_grids, :, :] += cupy.einsum("dDi->dD", d2e_ji_AB_ao_uncontracted)
 
         d2e_ji_AB = cupy.zeros((natm, 3, 3))
@@ -3766,7 +3749,6 @@ def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = 
 
     return d2e
 
-import time
 def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     """
         xc energy 2nd derivative grid response contribution
@@ -3799,323 +3781,110 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
     dm_mask_buf = cupy.empty(nao * nao)
 
+    nonzero_weight_mask = cupy.abs(grids.weights) > 1e-20 # There are d2rho/dAdB terms with very low weight but very big contribution
+
+    ao_loc_sorted = _sorted_mol.ao_loc
+    ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+    from pyscf.gto.mole import ATOM_OF
+    i_atom_of_aos = numpy.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+    i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
+
     d2e = cupy.zeros([mol.natm, mol.natm, 3, 3])
 
     if xctype == 'LDA':
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((1) * mol.nao + (9) * mol.natm * mol.natm + 2) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for LDA energy second derivative, available gpu memory = {get_avail_mem()}"
-                              f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 0, gdftopt = None, transpose = False)
-            rho = numint.eval_rho2(mol, split_ao, mo_coeff, mo_occ, xctype=xctype)
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            rho = numint.eval_rho(_sorted_mol, ao, dm0_masked, xctype = xctype, hermi = 1)
             exc = ni.eval_xc_eff(mf.xc, rho, deriv = 0, xctype=xctype)[0]
 
             epsilon = exc[:, 0] * rho
-            rho = None
-            exc = None
+            del rho, exc
 
             d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
             d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
-            d2w_dAdB = None
-            epsilon = None
-
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((10 + 9 + 2 + 4*4) * mol.nao + (3*3 + 3) * mol.natm + 3 + 1 + 18*4) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for LDA energy second derivative, available gpu memory = {get_avail_mem()}"
-                                f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
-
-            mu = split_ao[0]
-            dmu_dr = split_ao[1:4]
-            d2mu_dr2 = get_d2mu_dr2(split_ao)
-
-            rho = numint.eval_rho2(mol, mu, mo_coeff, mo_occ, xctype=xctype)
-            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
-            rho = None
-
-            depsilon_drho = vxc[0] # Just of shape (ngrids,)
-            d2epsilon_drho2 = fxc[0,0] # Just of shape (ngrids,)
-
-            grid_to_atom_index_map = grids.atm_idx[g0:g1]
-            atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-            grid_to_atom_index_map = None
-
-            drho_dA_orbital_response, drho_dA_grid_response = \
-                get_drho_dA_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr)
-
-            drho_dA_full = drho_dA_orbital_response + drho_dA_grid_response
-
-            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full)
-            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full)
-            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drho_dA_full * depsilon_drho)
-            dw_dA = None
-            drho_dA_full = None
-            d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
-            d2e_dwdA_term = None
-
-            weight = grids.weights[g0:g1]
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_orbital_response, drho_dA_grid_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_grid_response, drho_dA_orbital_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_grid_response, drho_dA_grid_response)
-            drhodA_grid_response_weight_d2epsilondrho2 = drho_dA_grid_response * (weight * d2epsilon_drho2)
-            d2e_drhodA_cross_term = contract("Adg,BDg->ABdD", drho_dA_orbital_response, drhodA_grid_response_weight_d2epsilondrho2)
-            drho_dA_orbital_response = None
-            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
-            d2e_drhodA_cross_term += contract("Adg,BDg->ABdD", drho_dA_grid_response, drhodA_grid_response_weight_d2epsilondrho2)
-            drho_dA_grid_response = None
-            drhodA_grid_response_weight_d2epsilondrho2 = None
-            d2e += d2e_drhodA_cross_term
-            d2e_drhodA_cross_term = None
-
-            d2e += contract_d2rho_dAdB_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
-                                            mu, dmu_dr, d2mu_dr2, None,
-                                            depsilon_drho * weight,
-                                            with_orbital_response = False)
-
-    elif xctype == 'GGA':
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((4) * mol.nao + (9) * mol.natm * mol.natm + 4 + 1*2) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for GGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                                f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-        time_eval_xc = 0
-        time_eval_d2w = 0
-        time_contract_d2w = 0
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            cupy.cuda.runtime.deviceSynchronize()
-            time_0 = time.time()
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 1, gdftopt = None, transpose = False)
-
-            rho_drho = numint.eval_rho2(mol, split_ao, mo_coeff, mo_occ, xctype=xctype)
-            exc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 0, xctype=xctype)[0]
-
-            rho = rho_drho[0]
-            rho_drho = None
-
-            epsilon = exc[:, 0] * rho
-            rho = None
-            exc = None
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_xc += time_1 - time_0
-            time_0 = time_1
-            d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_d2w += time_1 - time_0
-            time_0 = time_1
-            d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_contract_d2w += time_1 - time_0
-            time_0 = time_1
-            d2w_dAdB = None
-            epsilon = None
-
-        print(f"time_eval_xc = {time_eval_xc}")
-        print(f"time_eval_d2w = {time_eval_d2w}")
-        print(f"time_contract_d2w = {time_contract_d2w}")
-
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((20 + 9 + 27 + 2 + 3*2 + 4*4 + 12*4) * mol.nao
-                              + (3*3 + 9*3 + 3 + 2*3 + 4*2*3) * mol.natm + 4*2 + 16*2 + 18*4 + 27*2*4) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for GGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                                f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-        d2e_d2rho = 0
-        time_eval_ao = 0
-        time_eval_xc = 0
-        time_eval_drho = 0
-        time_eval_dw = 0
-        time_contract_dw = 0
-        time_contract_drho_cross = 0
-        time_contract_d2rho = 0
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            cupy.cuda.runtime.deviceSynchronize()
-            time_0 = time.time()
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 3, gdftopt = None, transpose = False)
-
-            mu = split_ao[0]
-            dmu_dr = split_ao[1:4]
-            d2mu_dr2 = get_d2mu_dr2(split_ao)
-            d3mu_dr3 = get_d3mu_dr3(split_ao)
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_ao += time_1 - time_0
-            time_0 = time_1
-
-            rho_drho = numint.eval_rho2(mol, split_ao[:4], mo_coeff, mo_occ, xctype=xctype)
-            vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 2, xctype=xctype)[1:3]
-            rho_drho = None
-
-            depsilon_drho = vxc[0]
-            depsilon_dnablarho = vxc[1:4]
-            # d2epsilon_drho2 = fxc[0,0]
-            # d2epsilon_drho_dnablarho = fxc[0,1:4]
-            # d2epsilon_dnablarho2 = fxc[1:4,1:4]
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_xc += time_1 - time_0
-            time_0 = time_1
-
-            grid_to_atom_index_map = grids.atm_idx[g0:g1]
-            atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-            grid_to_atom_index_map = None
-
-            drho_dA_orbital_response, dnablarho_dA_orbital_response, drho_dA_grid_response, dnablarho_dA_grid_response = \
-                get_drho_dA_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2)
-
-            drho_dA_full = drho_dA_orbital_response + drho_dA_grid_response
-            dnablarho_dA_full = dnablarho_dA_orbital_response + dnablarho_dA_grid_response
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_drho += time_1 - time_0
-            time_0 = time_1
-
-            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_dw += time_1 - time_0
-            time_0 = time_1
-
-            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full)
-            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full)
-            # d2e += cupy.einsum("Adg,xg,BDxg->ABdD", dw_dA, depsilon_dnablarho, dnablarho_dA_full)
-            # d2e += cupy.einsum("Adg,xg,BDxg->BADd", dw_dA, depsilon_dnablarho, dnablarho_dA_full)
-            depsilondnablarho_dnablarhodA = contract("xg,Adxg->Adg", depsilon_dnablarho, dnablarho_dA_full)
-            dnablarho_dA_full = None
-            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drho_dA_full * depsilon_drho + depsilondnablarho_dnablarhodA)
-            drho_dA_full = None
-            depsilondnablarho_dnablarhodA = None
-            dw_dA = None
-            # d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
-            d2e_dwdA_term = None
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_contract_dw += time_1 - time_0
-            time_0 = time_1
-
-            weight = grids.weights[g0:g1]
-            # # d2epsilon/drho2 * drho/dA * drho/dB
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_orbital_response, drho_dA_grid_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_grid_response, drho_dA_orbital_response)
-            # d2e += cupy.einsum("g,g,Adg,BDg->ABdD", weight, d2epsilon_drho2, drho_dA_grid_response, drho_dA_grid_response)
-            # # d2epsilon/(drho d_nabla_rho) * d_nabla_rho/dA * drho/dB
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->ABdD", weight, d2epsilon_drho_dnablarho, drho_dA_orbital_response, dnablarho_dA_grid_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->ABdD", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_orbital_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->ABdD", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_grid_response)
-            # # d2epsilon/(drho d_nabla_rho) * drho/dA * d_nabla_rho/dB
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->BADd", weight, d2epsilon_drho_dnablarho, drho_dA_orbital_response, dnablarho_dA_grid_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->BADd", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_orbital_response)
-            # d2e += cupy.einsum("g,xg,Adg,BDxg->BADd", weight, d2epsilon_drho_dnablarho, drho_dA_grid_response, dnablarho_dA_grid_response)
-            # # d2epsilon/(d_nabla_rho d_nabla_rho) * d_nabla_rho/dA * d_nabla_rho/dB
-            # d2e += cupy.einsum("g,xyg,Adxg,BDyg->ABdD", weight, d2epsilon_dnablarho2, dnablarho_dA_orbital_response, dnablarho_dA_grid_response)
-            # d2e += cupy.einsum("g,xyg,Adxg,BDyg->ABdD", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dnablarho_dA_orbital_response)
-            # d2e += cupy.einsum("g,xyg,Adxg,BDyg->ABdD", weight, d2epsilon_dnablarho2, dnablarho_dA_grid_response, dnablarho_dA_grid_response)
-            combined_d_dA_orbital_response = cupy.concatenate((drho_dA_orbital_response[:, :, None, :], dnablarho_dA_orbital_response), axis = 2)
-            combined_d_dA_grid_response    = cupy.concatenate((   drho_dA_grid_response[:, :, None, :],    dnablarho_dA_grid_response), axis = 2)
-            drho_dA_orbital_response = None
-            dnablarho_dA_orbital_response = None
-            drho_dA_grid_response = None
-            dnablarho_dA_grid_response = None
-            fwxc = fxc * weight
-            fxc = None
-
-            drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, combined_d_dA_grid_response)
-            fwxc = None
-            d2e_drhodA_cross_term = contract("Adxg,BDxg->ABdD", combined_d_dA_orbital_response, drhodA_grid_response_fwxc)
-            combined_d_dA_orbital_response = None
-            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
-            d2e_drhodA_cross_term += contract("Adxg,BDxg->ABdD", combined_d_dA_grid_response, drhodA_grid_response_fwxc)
-            combined_d_dA_grid_response = None
-            drhodA_grid_response_fwxc = None
-            # d2e += d2e_drhodA_cross_term
-            d2e_drhodA_cross_term = None
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_contract_drho_cross += time_1 - time_0
-            time_0 = time_1
-
-            d2e_d2rho += contract_d2rho_dAdB_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
-                                            mu, dmu_dr, d2mu_dr2, d3mu_dr3,
-                                            depsilon_drho * weight, depsilon_dnablarho * weight,
-                                            with_orbital_response = False)
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_contract_d2rho += time_1 - time_0
-            time_0 = time_1
-
-        print(f"time_eval_ao = {time_eval_ao}")
-        print(f"time_eval_xc = {time_eval_xc}")
-        print(f"time_eval_drho = {time_eval_drho}")
-        print(f"time_eval_dw = {time_eval_dw}")
-        print(f"time_contract_dw = {time_contract_dw}")
-        print(f"time_contract_drho_cross = {time_contract_drho_cross}")
-        print(f"time_contract_d2rho = {time_contract_d2rho}")
-
-        test_d2e_d2rho = 0
-        time_eval_ao = 0
-        time_eval_xc = 0
-        time_eval_drho = 0
-        time_eval_dw = 0
-        time_contract_dw = 0
-        time_contract_drho_cross = 0
-        time_contract_d2rho = 0
-
-        nonzero_weight_mask = cupy.abs(grids.weights) > 1e-20
-
-        ao_loc_sorted = _sorted_mol.ao_loc
-        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
-        from pyscf.gto.mole import ATOM_OF
-        i_atom_of_aos = numpy.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
-        i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
+            del d2w_dAdB, epsilon
+            g0 = g1
+        assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, _sorted_mol.nao, deriv = 3):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
-            cupy.cuda.runtime.deviceSynchronize()
-            time_0 = time.time()
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            rho = numint.eval_rho(_sorted_mol, ao[0], dm0_masked, xctype = xctype, hermi = 1)
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype = xctype)[1:3]
+            del rho
+
+            depsilon_drho = vxc[0]
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
+
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response)
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full_response)
+            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drho_dA_full_response * depsilon_drho)
+            del dw_dA
+            d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
+            del d2e_dwdA_term
+
+            weight = weight[nonzero_weight_mask[g0:g1]]
+            fwxc = fxc[0,0] * weight
+            del fxc
+            d2e += contract("Adg,BDg->ABdD", drho_dA_full_response, drho_dA_full_response * fwxc)
+            del fwxc, drho_dA_full_response
+
+            d2e += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                                              mu, dmu_dr, d2mu_dr2, None,
+                                              depsilon_drho * weight)
+
+            g0 = g1
+        assert g1 == ngrids
+
+    elif xctype == 'GGA':
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
+            g1 = g0 + weight.shape[0]
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
+            exc = ni.eval_xc_eff(mf.xc, rho, deriv = 0, xctype=xctype)[0]
+
+            epsilon = exc[:, 0] * rho[0, :]
+            del rho, exc
+
+            d2w_dAdB = get_d2weight_dAdB(_sorted_mol, grids, (g0,g1))
+            d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
+            del d2w_dAdB, epsilon
+            g0 = g1
+        assert g1 == ngrids
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+            g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
 
@@ -4128,11 +3897,6 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             d2mu_dr2 = get_d2mu_dr2(ao)
             d3mu_dr3 = get_d3mu_dr3(ao)
 
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_ao += time_1 - time_0
-            time_0 = time_1
-
             dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
 
             rho = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked, xctype = xctype, hermi = 1)
@@ -4142,11 +3906,6 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             depsilon_drho = vxc[0]
             depsilon_dnablarho = vxc[1:4]
 
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_xc += time_1 - time_0
-            time_0 = time_1
-
             i_atom_of_grids = int(grids.atm_idx[g0])
             assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
 
@@ -4155,19 +3914,10 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             drho_dA_orbital_response, drho_dA_grid_response = \
                 get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
             drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_drho += time_1 - time_0
-            time_0 = time_1
+            del drho_dA_orbital_response, drho_dA_grid_response
 
             dw_dA = get_dweight_dA(mol, grids, (g0,g1))
             dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_eval_dw += time_1 - time_0
-            time_0 = time_1
 
             # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
             # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
@@ -4180,54 +3930,20 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
             del d2e_dwdA_term
 
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_contract_dw += time_1 - time_0
-            time_0 = time_1
-
             weight = weight[nonzero_weight_mask[g0:g1]]
             fwxc = fxc * weight
             del fxc
-            drhodA_grid_response_fwxc = contract("xyg,Adyg->Adxg", fwxc, drho_dA_grid_response)
+            drhodA_fwxc = contract("xyg,Adyg->Adxg", fwxc, drho_dA_full_response)
             del fwxc
-            d2e_drhodA_cross_term = contract("Adxg,BDxg->ABdD", drho_dA_orbital_response, drhodA_grid_response_fwxc)
-            del drho_dA_orbital_response
-            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
-            d2e_drhodA_cross_term += contract("Adxg,BDxg->ABdD", drho_dA_grid_response, drhodA_grid_response_fwxc)
-            del drho_dA_grid_response
-            del drhodA_grid_response_fwxc
-            d2e += d2e_drhodA_cross_term
-            del d2e_drhodA_cross_term
+            d2e += contract("Adxg,BDxg->ABdD", drho_dA_full_response, drhodA_fwxc)
+            del drhodA_fwxc, drho_dA_full_response
 
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_contract_drho_cross += time_1 - time_0
-            time_0 = time_1
-
-            test_d2e_d2rho += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+            d2e += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
                                               mu, dmu_dr, d2mu_dr2, d3mu_dr3,
-                                              depsilon_drho * weight, depsilon_dnablarho * weight,
-                                              with_orbital_response = False)
-
-            cupy.cuda.runtime.deviceSynchronize()
-            time_1 = time.time()
-            time_contract_d2rho += time_1 - time_0
-            time_0 = time_1
+                                              depsilon_drho * weight, depsilon_dnablarho * weight)
 
             g0 = g1
         assert g1 == ngrids
-
-        print(f"revised time_eval_ao = {time_eval_ao}")
-        print(f"revised time_eval_xc = {time_eval_xc}")
-        print(f"revised time_eval_drho = {time_eval_drho}")
-        print(f"revised time_eval_dw = {time_eval_dw}")
-        print(f"revised time_contract_dw = {time_contract_dw}")
-        print(f"revised time_contract_drho_cross = {time_contract_drho_cross}")
-        print(f"revised time_contract_d2rho = {time_contract_d2rho}")
-
-        print(cupy.max(cupy.abs(test_d2e_d2rho - d2e_d2rho)))
-
-        d2e += test_d2e_d2rho
 
     elif xctype == 'MGGA':
         available_gpu_memory = get_avail_mem()

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -1800,13 +1800,14 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
 def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     mol = hessobj.mol
     mf = hessobj.base
-    ni = mf._numint
+    ni = numint.NumInt()
     xctype = ni._xc_type(mf.xc)
 
     if hessobj.grids is not None:
         grids = hessobj.grids
     else:
         grids = mf.grids
+    grids = grids.copy()
     grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
 
@@ -3691,13 +3692,14 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     mol = hessobj.mol
     mf = hessobj.base
-    ni = mf._numint
+    ni = numint.NumInt()
     xctype = ni._xc_type(mf.xc)
 
     if hessobj.grids is not None:
         grids = hessobj.grids
     else:
         grids = mf.grids
+    grids = grids.copy()
     grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
 

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -4018,7 +4018,8 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
             # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_dtau, drho_dA_full_response[:,:,4,:])
             # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_dtau, drho_dA_full_response[:,:,4,:])
             depsilondnablarho_dnablarhodA = contract("xg,Adxg->Adg", depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
-            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drho_dA_full_response[:,:,0,:] * depsilon_drho + depsilondnablarho_dnablarhodA + drho_dA_full_response[:,:,4,:] * depsilon_dtau)
+            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA,
+                drho_dA_full_response[:,:,0,:] * depsilon_drho + depsilondnablarho_dnablarhodA + drho_dA_full_response[:,:,4,:] * depsilon_dtau)
             del depsilondnablarho_dnablarhodA
             del dw_dA
             d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)

--- a/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
+++ b/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
@@ -901,7 +901,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]
@@ -1036,7 +1036,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]
@@ -1177,7 +1177,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]

--- a/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
+++ b/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
@@ -917,7 +917,6 @@ class KnownValues(unittest.TestCase):
 
             drho_dA_orbital_response, drho_dA_grid_response = \
                 get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
-            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
 
             test_drho_dA_full_response[:, :, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
             test_drho_dA_orbital_response[:, :, g0:g1] = drho_dA_orbital_response
@@ -1053,7 +1052,6 @@ class KnownValues(unittest.TestCase):
 
             drho_dA_orbital_response, drho_dA_grid_response = \
                 get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
-            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
 
             test_drho_dA_full_response[:, :, :, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
             test_drho_dA_orbital_response[:, :, :, g0:g1] = drho_dA_orbital_response
@@ -1194,7 +1192,6 @@ class KnownValues(unittest.TestCase):
 
             drho_dA_orbital_response, drho_dA_grid_response = \
                 get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
-            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
 
             test_drho_dA_full_response[:, :, :, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
             test_drho_dA_orbital_response[:, :, :, g0:g1] = drho_dA_orbital_response

--- a/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
+++ b/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
@@ -21,9 +21,12 @@ from gpu4pyscf.dft import RKS
 from gpu4pyscf.hessian.rks import _get_exc_deriv2, _get_vxc_deriv1
 from gpu4pyscf.hessian.tests.test_vv10_hessian import numerical_d2e_dft
 from gpu4pyscf.dft import gen_grid
+from gpu4pyscf.dft import numint
+from gpu4pyscf.hessian.rks import get_d2mu_dr2, get_d3mu_dr3, take_last2d, \
+    get_drho_dA_full, get_drho_dA_sparse, get_d2rho_dAdB_full, contract_d2rho_dAdB_sparse
 
 def setUpModule():
-    global mol
+    global mol, mol2
 
     mol = pyscf.M(
         atom = '''
@@ -39,10 +42,25 @@ def setUpModule():
         verbose = 0,
     )
 
+    mol2 = pyscf.M(
+        atom = """
+            C      0.000000    0.000000    0.000000
+            Br     0.000000    0.000000    1.940000
+            H      1.027662    0.000000   -0.363333
+            H     -0.513831    0.889981   -0.363333
+            H     -0.513831   -0.889981   -0.363333
+        """,
+        basis = "def2-svp",
+        verbose = 0,
+        output='/dev/null',
+    )
+
 def tearDownModule():
-    global mol
+    global mol, mol2
     mol.stdout.close()
     del mol
+    mol2.stdout.close()
+    del mol2
 
 def _get_exc_deriv2_numerical(hessobj, mo_coeff, mo_occ, max_memory):
     """
@@ -806,6 +824,410 @@ class KnownValues(unittest.TestCase):
         ref_hessian = np.zeros((1,1,3,3))
 
         assert np.max(np.abs(test_hessian - ref_hessian)) < 1e-10
+
+    def test_d2rho_lda(self):
+        mol = mol2
+        cp.random.seed(100)
+
+        mf = RKS(mol, xc = "LDA")
+        mf.grids.atom_grid = (20,26)
+
+        dm0 = cp.random.rand(mol.nao, mol.nao) * 2 - 1
+
+        grids = mf.grids
+        grids.build(sort_grids_of_each_atom = True)
+        ngrids = grids.coords.shape[0]
+
+        weight_depsilon_drho = cp.random.rand(ngrids) * 2 - 1
+
+        ni = mf._numint
+        xctype = ni._xc_type(mf.xc)
+
+        natm = mol.natm
+        aoslices = mol.aoslice_by_atom()
+
+        from gpu4pyscf.__config__ import min_grid_blksize
+        ngrids_per_batch = min_grid_blksize
+
+        ref_drho_dA_full_response = cp.zeros((natm, 3, ngrids))
+        ref_drho_dA_orbital_response = cp.zeros((natm, 3, ngrids))
+        ref_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        ref_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        for g0 in range(0, ngrids, ngrids_per_batch):
+            g1 = min(g0 + ngrids_per_batch, ngrids)
+            split_grids_coords = grids.coords[g0:g1, :]
+            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
+
+            mu = split_ao[0]
+            dmu_dr = split_ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(split_ao)
+
+            grid_to_atom_index_map = grids.atm_idx[g0:g1]
+            atom_to_grid_index_map = [cp.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
+            grid_to_atom_index_map = None
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                    get_drho_dA_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2)
+
+            ref_drho_dA_full_response[:, :, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:, :, g0:g1] = drho_dA_orbital_response
+
+            d2rho_dAdB_orbital_response, d2rho_dAdB_grid_response = get_d2rho_dAdB_full(
+                dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2
+            )
+
+            ref_d2E_dAdB_full_response += (d2rho_dAdB_orbital_response + d2rho_dAdB_grid_response) @ weight_depsilon_drho[g0:g1]
+            ref_d2E_dAdB_orbital_response += d2rho_dAdB_orbital_response @ weight_depsilon_drho[g0:g1]
+
+        ni.gdftopt = None
+        ni.build(mol, grids.coords)
+        opt = ni.gdftopt
+
+        _sorted_mol = opt._sorted_mol
+        nao = _sorted_mol.nao
+        dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
+        dm_mask_buf = cp.empty(nao * nao)
+
+        ao_loc_sorted = _sorted_mol.ao_loc
+        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+        from pyscf.gto.mole import ATOM_OF
+        i_atom_of_aos = np.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+        i_atom_of_aos = cp.asarray(i_atom_of_aos, dtype = cp.int32)
+
+        test_drho_dA_full_response = cp.zeros((natm, 3, ngrids))
+        test_drho_dA_orbital_response = cp.zeros((natm, 3, ngrids))
+        test_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
+            g1 = g0 + weight.shape[0]
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cp.max(cp.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+
+            test_drho_dA_full_response[:, :, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            test_drho_dA_orbital_response[:, :, g0:g1] = drho_dA_orbital_response
+
+            test_d2E_dAdB_full_response += contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[g0:g1],
+            )
+            test_d2E_dAdB_orbital_response += contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[g0:g1],
+                with_grid_response = False,
+            )
+
+            g0 = g1
+        assert g1 == ngrids
+
+        diff_drhodA_full = cp.max(cp.abs(test_drho_dA_full_response - ref_drho_dA_full_response))
+        diff_drhodA_orbital = cp.max(cp.abs(test_drho_dA_orbital_response - ref_drho_dA_orbital_response))
+        max_drhodA_full = cp.max(cp.abs(ref_drho_dA_full_response))
+
+        assert diff_drhodA_full < 1e-9 and diff_drhodA_full / max_drhodA_full < 1e-12
+        assert diff_drhodA_orbital < 1e-9 and diff_drhodA_orbital / max_drhodA_full < 1e-12
+
+        diff_d2EdAdB_full = cp.max(cp.abs(test_d2E_dAdB_full_response - ref_d2E_dAdB_full_response))
+        diff_d2EdAdB_orbital = cp.max(cp.abs(test_d2E_dAdB_orbital_response - ref_d2E_dAdB_orbital_response))
+        max_d2EdAdB_full = cp.max(cp.abs(ref_d2E_dAdB_full_response))
+
+        assert diff_d2EdAdB_full < 1e-5 and diff_d2EdAdB_full / max_d2EdAdB_full < 1e-9
+        assert diff_d2EdAdB_orbital < 1e-5 and diff_d2EdAdB_orbital / max_d2EdAdB_full < 1e-9
+
+    def test_d2rho_gga(self):
+        mol = mol2
+        cp.random.seed(101)
+
+        mf = RKS(mol, xc = "PBE")
+        mf.grids.atom_grid = (20,26)
+
+        dm0 = cp.random.rand(mol.nao, mol.nao) * 2 - 1
+
+        grids = mf.grids
+        grids.build(sort_grids_of_each_atom = True)
+        ngrids = grids.coords.shape[0]
+
+        weight_depsilon_drho = cp.random.rand(ngrids) * 2 - 1
+        weight_depsilon_dnablarho = cp.random.rand(3, ngrids) * 2 - 1
+
+        ni = mf._numint
+        xctype = ni._xc_type(mf.xc)
+
+        natm = mol.natm
+        aoslices = mol.aoslice_by_atom()
+
+        from gpu4pyscf.__config__ import min_grid_blksize
+        ngrids_per_batch = min_grid_blksize
+
+        ref_drho_dA_full_response = cp.zeros((natm, 3, 4, ngrids))
+        ref_drho_dA_orbital_response = cp.zeros((natm, 3, 4, ngrids))
+        ref_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        ref_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        for g0 in range(0, ngrids, ngrids_per_batch):
+            g1 = min(g0 + ngrids_per_batch, ngrids)
+            split_grids_coords = grids.coords[g0:g1, :]
+            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 3, gdftopt = None, transpose = False)
+
+            mu = split_ao[0]
+            dmu_dr = split_ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(split_ao)
+            d3mu_dr3 = get_d3mu_dr3(split_ao)
+
+            grid_to_atom_index_map = grids.atm_idx[g0:g1]
+            atom_to_grid_index_map = [cp.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
+            grid_to_atom_index_map = None
+
+            drho_dA_orbital_response, dnablarho_dA_orbital_response, \
+                drho_dA_grid_response, dnablarho_dA_grid_response = \
+                get_drho_dA_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2)
+
+            ref_drho_dA_full_response[:, :, 0, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:, :, 0, g0:g1] = drho_dA_orbital_response
+            ref_drho_dA_full_response[:, :, 1:4, g0:g1] = dnablarho_dA_orbital_response + dnablarho_dA_grid_response
+            ref_drho_dA_orbital_response[:, :, 1:4, g0:g1] = dnablarho_dA_orbital_response
+
+            d2rho_dAdB_orbital_response, d2nablarho_dAdB_orbital_response, \
+                d2rho_dAdB_grid_response, d2nablarho_dAdB_grid_response, = \
+                get_d2rho_dAdB_full(
+                    dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                )
+
+            ref_d2E_dAdB_full_response += (d2rho_dAdB_orbital_response + d2rho_dAdB_grid_response) @ weight_depsilon_drho[g0:g1]
+            ref_d2E_dAdB_orbital_response += d2rho_dAdB_orbital_response @ weight_depsilon_drho[g0:g1]
+            ref_d2E_dAdB_full_response += cp.einsum("ABdDxg,xg->ABdD", d2nablarho_dAdB_orbital_response + d2nablarho_dAdB_grid_response, weight_depsilon_dnablarho[:, g0:g1])
+            ref_d2E_dAdB_orbital_response += cp.einsum("ABdDxg,xg->ABdD", d2nablarho_dAdB_orbital_response, weight_depsilon_dnablarho[:, g0:g1])
+
+        ni.gdftopt = None
+        ni.build(mol, grids.coords)
+        opt = ni.gdftopt
+
+        _sorted_mol = opt._sorted_mol
+        nao = _sorted_mol.nao
+        dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
+        dm_mask_buf = cp.empty(nao * nao)
+
+        ao_loc_sorted = _sorted_mol.ao_loc
+        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+        from pyscf.gto.mole import ATOM_OF
+        i_atom_of_aos = np.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+        i_atom_of_aos = cp.asarray(i_atom_of_aos, dtype = cp.int32)
+
+        test_drho_dA_full_response = cp.zeros((natm, 3, 4, ngrids))
+        test_drho_dA_orbital_response = cp.zeros((natm, 3, 4, ngrids))
+        test_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+            g1 = g0 + weight.shape[0]
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cp.max(cp.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+
+            test_drho_dA_full_response[:, :, :, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            test_drho_dA_orbital_response[:, :, :, g0:g1] = drho_dA_orbital_response
+
+            test_d2E_dAdB_full_response += contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[g0:g1], weight_depsilon_dnablarho[:, g0:g1],
+            )
+            test_d2E_dAdB_orbital_response += contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[g0:g1], weight_depsilon_dnablarho[:, g0:g1],
+                with_grid_response = False,
+            )
+
+            g0 = g1
+        assert g1 == ngrids
+
+        diff_drhodA_full = cp.max(cp.abs(test_drho_dA_full_response - ref_drho_dA_full_response))
+        diff_drhodA_orbital = cp.max(cp.abs(test_drho_dA_orbital_response - ref_drho_dA_orbital_response))
+        max_drhodA_full = cp.max(cp.abs(ref_drho_dA_full_response))
+
+        assert diff_drhodA_full < 1e-6 and diff_drhodA_full / max_drhodA_full < 1e-9
+        assert diff_drhodA_orbital < 1e-6 and diff_drhodA_orbital / max_drhodA_full < 1e-9
+
+        diff_d2EdAdB_full = cp.max(cp.abs(test_d2E_dAdB_full_response - ref_d2E_dAdB_full_response))
+        diff_d2EdAdB_orbital = cp.max(cp.abs(test_d2E_dAdB_orbital_response - ref_d2E_dAdB_orbital_response))
+        max_d2EdAdB_full = cp.max(cp.abs(ref_d2E_dAdB_full_response))
+
+        assert diff_d2EdAdB_full < 1e-2 and diff_d2EdAdB_full / max_d2EdAdB_full < 1e-8
+        assert diff_d2EdAdB_orbital < 1e-2 and diff_d2EdAdB_orbital / max_d2EdAdB_full < 1e-8
+
+    def test_d2rho_mgga(self):
+        mol = mol2
+        cp.random.seed(103)
+
+        mf = RKS(mol, xc = "r2SCAN")
+        mf.grids.atom_grid = (20,26)
+
+        dm0 = cp.random.rand(mol.nao, mol.nao) * 2 - 1
+
+        grids = mf.grids
+        grids.build(sort_grids_of_each_atom = True)
+        ngrids = grids.coords.shape[0]
+
+        weight_depsilon_drho = cp.random.rand(ngrids) * 2 - 1
+        weight_depsilon_dnablarho = cp.random.rand(3, ngrids) * 2 - 1
+        weight_depsilon_dtau = cp.random.rand(ngrids) * 2 - 1
+
+        ni = mf._numint
+        xctype = ni._xc_type(mf.xc)
+
+        natm = mol.natm
+        aoslices = mol.aoslice_by_atom()
+
+        from gpu4pyscf.__config__ import min_grid_blksize
+        ngrids_per_batch = min_grid_blksize
+
+        ref_drho_dA_full_response = cp.zeros((natm, 3, 5, ngrids))
+        ref_drho_dA_orbital_response = cp.zeros((natm, 3, 5, ngrids))
+        ref_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        ref_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        for g0 in range(0, ngrids, ngrids_per_batch):
+            g1 = min(g0 + ngrids_per_batch, ngrids)
+            split_grids_coords = grids.coords[g0:g1, :]
+            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 3, gdftopt = None, transpose = False)
+
+            mu = split_ao[0]
+            dmu_dr = split_ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(split_ao)
+            d3mu_dr3 = get_d3mu_dr3(split_ao)
+
+            grid_to_atom_index_map = grids.atm_idx[g0:g1]
+            atom_to_grid_index_map = [cp.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
+            grid_to_atom_index_map = None
+
+            drho_dA_orbital_response, dnablarho_dA_orbital_response, dtau_dA_orbital_response, \
+                drho_dA_grid_response, dnablarho_dA_grid_response, dtau_dA_grid_response = \
+                get_drho_dA_full(dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2)
+
+            ref_drho_dA_full_response[:, :, 0, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:, :, 0, g0:g1] = drho_dA_orbital_response
+            ref_drho_dA_full_response[:, :, 1:4, g0:g1] = dnablarho_dA_orbital_response + dnablarho_dA_grid_response
+            ref_drho_dA_orbital_response[:, :, 1:4, g0:g1] = dnablarho_dA_orbital_response
+            ref_drho_dA_full_response[:, :, 4, g0:g1] = dtau_dA_orbital_response + dtau_dA_grid_response
+            ref_drho_dA_orbital_response[:, :, 4, g0:g1] = dtau_dA_orbital_response
+
+            d2rho_dAdB_orbital_response, d2nablarho_dAdB_orbital_response, d2tau_dAdB_orbital_response, \
+                d2rho_dAdB_grid_response, d2nablarho_dAdB_grid_response, d2tau_dAdB_grid_response = \
+                get_d2rho_dAdB_full(
+                    dm0, xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                )
+
+            ref_d2E_dAdB_full_response += (d2rho_dAdB_orbital_response + d2rho_dAdB_grid_response) @ weight_depsilon_drho[g0:g1]
+            ref_d2E_dAdB_orbital_response += d2rho_dAdB_orbital_response @ weight_depsilon_drho[g0:g1]
+            ref_d2E_dAdB_full_response += cp.einsum("ABdDxg,xg->ABdD", d2nablarho_dAdB_orbital_response + d2nablarho_dAdB_grid_response, weight_depsilon_dnablarho[:, g0:g1])
+            ref_d2E_dAdB_orbital_response += cp.einsum("ABdDxg,xg->ABdD", d2nablarho_dAdB_orbital_response, weight_depsilon_dnablarho[:, g0:g1])
+            ref_d2E_dAdB_full_response += (d2tau_dAdB_orbital_response + d2tau_dAdB_grid_response) @ weight_depsilon_dtau[g0:g1]
+            ref_d2E_dAdB_orbital_response += d2tau_dAdB_orbital_response @ weight_depsilon_dtau[g0:g1]
+
+        ni.gdftopt = None
+        ni.build(mol, grids.coords)
+        opt = ni.gdftopt
+
+        _sorted_mol = opt._sorted_mol
+        nao = _sorted_mol.nao
+        dm0_sorted = opt.sort_orbitals(dm0, axis=[0,1])
+        dm_mask_buf = cp.empty(nao * nao)
+
+        ao_loc_sorted = _sorted_mol.ao_loc
+        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+        from pyscf.gto.mole import ATOM_OF
+        i_atom_of_aos = np.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+        i_atom_of_aos = cp.asarray(i_atom_of_aos, dtype = cp.int32)
+
+        test_drho_dA_full_response = cp.zeros((natm, 3, 5, ngrids))
+        test_drho_dA_orbital_response = cp.zeros((natm, 3, 5, ngrids))
+        test_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
+            g1 = g0 + weight.shape[0]
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cp.max(cp.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+
+            test_drho_dA_full_response[:, :, :, g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            test_drho_dA_orbital_response[:, :, :, g0:g1] = drho_dA_orbital_response
+
+            test_d2E_dAdB_full_response += contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[g0:g1], weight_depsilon_dnablarho[:, g0:g1], weight_depsilon_dtau[g0:g1],
+            )
+            test_d2E_dAdB_orbital_response += contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[g0:g1], weight_depsilon_dnablarho[:, g0:g1], weight_depsilon_dtau[g0:g1],
+                with_grid_response = False,
+            )
+
+            g0 = g1
+        assert g1 == ngrids
+
+        diff_drhodA_full = cp.max(cp.abs(test_drho_dA_full_response - ref_drho_dA_full_response))
+        diff_drhodA_orbital = cp.max(cp.abs(test_drho_dA_orbital_response - ref_drho_dA_orbital_response))
+        max_drhodA_full = cp.max(cp.abs(ref_drho_dA_full_response))
+
+        assert diff_drhodA_full < 1e-5 and diff_drhodA_full / max_drhodA_full < 1e-9
+        assert diff_drhodA_orbital < 1e-5 and diff_drhodA_orbital / max_drhodA_full < 1e-9
+
+        diff_d2EdAdB_full = cp.max(cp.abs(test_d2E_dAdB_full_response - ref_d2E_dAdB_full_response))
+        diff_d2EdAdB_orbital = cp.max(cp.abs(test_d2E_dAdB_orbital_response - ref_d2E_dAdB_orbital_response))
+        max_d2EdAdB_full = cp.max(cp.abs(ref_d2E_dAdB_full_response))
+
+        assert diff_d2EdAdB_full < 1e-1 and diff_d2EdAdB_full / max_d2EdAdB_full < 1e-7
+        assert diff_d2EdAdB_orbital < 1e-1 and diff_d2EdAdB_orbital / max_d2EdAdB_full < 1e-7
+
 
 if __name__ == "__main__":
     print("Tests for KS hessian with grid response")

--- a/gpu4pyscf/hessian/tests/test_uks_hessian_grid_response.py
+++ b/gpu4pyscf/hessian/tests/test_uks_hessian_grid_response.py
@@ -21,9 +21,14 @@ from gpu4pyscf.dft import UKS
 from gpu4pyscf.hessian.uks import _get_exc_deriv2, _get_vxc_deriv1
 from gpu4pyscf.hessian.tests.test_vv10_hessian import numerical_d2e_dft
 from gpu4pyscf.hessian.tests.test_rks_hessian_grid_response import _get_exc_deriv2_numerical, _get_vxc_deriv1_numerical
+from gpu4pyscf.hessian.rks import get_d2mu_dr2, get_d3mu_dr3, take_last2d
+from gpu4pyscf.hessian.rks import get_drho_dA_sparse as rks_get_drho_dA_sparse
+from gpu4pyscf.hessian.rks import contract_d2rho_dAdB_sparse as rks_contract_d2rho_dAdB_sparse
+from gpu4pyscf.hessian.uks import get_drho_dA_sparse as uks_get_drho_dA_sparse
+from gpu4pyscf.hessian.uks import contract_d2rho_dAdB_sparse as uks_contract_d2rho_dAdB_sparse
 
 def setUpModule():
-    global mol
+    global mol, mol2
 
     mol = pyscf.M(
         atom = '''
@@ -39,10 +44,27 @@ def setUpModule():
         verbose = 0,
     )
 
+    mol2 = pyscf.M(
+        atom = """
+            C      0.000000    0.000000    0.000000
+            Br     0.000000    0.000000    1.940000
+            H      1.027662    0.000000   -0.363333
+            H     -0.513831    0.889981   -0.363333
+            H     -0.513831   -0.889981   -0.363333
+        """,
+        basis = "def2-svp",
+        charge = 1,
+        spin = 1,
+        verbose = 0,
+        output='/dev/null',
+    )
+
 def tearDownModule():
-    global mol
+    global mol, mol2
     mol.stdout.close()
     del mol
+    mol2.stdout.close()
+    del mol2
 
 class KnownValues(unittest.TestCase):
     # All reference results from the same calculation with mf.level_shift = 0
@@ -636,6 +658,380 @@ class KnownValues(unittest.TestCase):
         ref_hessian = np.zeros((1,1,3,3))
 
         assert np.max(np.abs(test_hessian - ref_hessian)) < 1e-9
+
+    def test_uks_d2rho_lda(self):
+        mol = mol2
+        cp.random.seed(200)
+
+        mf = UKS(mol, xc = "BN05")
+        mf.grids.atom_grid = (20,26)
+
+        dm0 = cp.random.rand(2, mol.nao, mol.nao) * 2 - 1
+
+        grids = mf.grids
+        grids.build(sort_grids_of_each_atom = True)
+        ngrids = grids.coords.shape[0]
+
+        weight_depsilon_drho = cp.random.rand(2, ngrids) * 2 - 1
+
+        ni = mf._numint
+        xctype = ni._xc_type(mf.xc)
+
+        ni.gdftopt = None
+        ni.build(mol, grids.coords)
+        opt = ni.gdftopt
+
+        _sorted_mol = opt._sorted_mol
+        nao = _sorted_mol.nao
+        dm0_sorted = opt.sort_orbitals(dm0, axis=[1,2])
+        dm_mask_buf = cp.empty(2 * nao * nao)
+
+        ao_loc_sorted = _sorted_mol.ao_loc
+        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+        from pyscf.gto.mole import ATOM_OF
+        i_atom_of_aos = np.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+        i_atom_of_aos = cp.asarray(i_atom_of_aos, dtype = cp.int32)
+
+        natm = _sorted_mol.natm
+
+        ref_drho_dA_full_response = cp.zeros((natm, 3, 2, ngrids))
+        ref_drho_dA_orbital_response = cp.zeros((natm, 3, 2, ngrids))
+        ref_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        ref_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+        test_drho_dA_full_response = cp.zeros((natm, 3, 2, ngrids))
+        test_drho_dA_orbital_response = cp.zeros((natm, 3, 2, ngrids))
+        test_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cp.max(cp.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                rks_get_drho_dA_sparse(dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            ref_drho_dA_full_response[:,:,0,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:,:,0,g0:g1] = drho_dA_orbital_response
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                rks_get_drho_dA_sparse(dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            ref_drho_dA_full_response[:,:,1,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:,:,1,g0:g1] = drho_dA_orbital_response
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                uks_get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            test_drho_dA_full_response[:,:,:,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            test_drho_dA_orbital_response[:,:,:,g0:g1] = drho_dA_orbital_response
+
+            ref_d2E_dAdB_full_response += rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[0, g0:g1],
+            ) + rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[1, g0:g1],
+            )
+            test_d2E_dAdB_full_response += uks_contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[:, g0:g1],
+            )
+
+            ref_d2E_dAdB_orbital_response += rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[0, g0:g1],
+                with_grid_response = False,
+            ) + rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[1, g0:g1],
+                with_grid_response = False,
+            )
+            test_d2E_dAdB_orbital_response += uks_contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, None,
+                weight_depsilon_drho[:, g0:g1],
+                with_grid_response = False,
+            )
+
+            g0 = g1
+        assert g1 == ngrids
+
+        diff_drhodA_full = cp.max(cp.abs(test_drho_dA_full_response - ref_drho_dA_full_response))
+        diff_drhodA_orbital = cp.max(cp.abs(test_drho_dA_orbital_response - ref_drho_dA_orbital_response))
+        max_drhodA_full = cp.max(cp.abs(ref_drho_dA_full_response))
+
+        assert diff_drhodA_full < 1e-9 and diff_drhodA_full / max_drhodA_full < 1e-12
+        assert diff_drhodA_orbital < 1e-9 and diff_drhodA_orbital / max_drhodA_full < 1e-12
+
+        diff_d2EdAdB_full = cp.max(cp.abs(test_d2E_dAdB_full_response - ref_d2E_dAdB_full_response))
+        diff_d2EdAdB_orbital = cp.max(cp.abs(test_d2E_dAdB_orbital_response - ref_d2E_dAdB_orbital_response))
+        max_d2EdAdB_full = cp.max(cp.abs(ref_d2E_dAdB_full_response))
+
+        assert diff_d2EdAdB_full < 1e-5 and diff_d2EdAdB_full / max_d2EdAdB_full < 1e-9
+        assert diff_d2EdAdB_orbital < 1e-5 and diff_d2EdAdB_orbital / max_d2EdAdB_full < 1e-9
+
+    def test_uks_d2rho_gga(self):
+        mol = mol2
+        cp.random.seed(201)
+
+        mf = UKS(mol, xc = "B3PW91")
+        mf.grids.atom_grid = (20,26)
+
+        dm0 = cp.random.rand(2, mol.nao, mol.nao) * 2 - 1
+
+        grids = mf.grids
+        grids.build(sort_grids_of_each_atom = True)
+        ngrids = grids.coords.shape[0]
+
+        weight_depsilon_drho = cp.random.rand(2, ngrids) * 2 - 1
+        weight_depsilon_dnablarho = cp.random.rand(2, 3, ngrids) * 2 - 1
+
+        ni = mf._numint
+        xctype = ni._xc_type(mf.xc)
+
+        ni.gdftopt = None
+        ni.build(mol, grids.coords)
+        opt = ni.gdftopt
+
+        _sorted_mol = opt._sorted_mol
+        nao = _sorted_mol.nao
+        dm0_sorted = opt.sort_orbitals(dm0, axis=[1,2])
+        dm_mask_buf = cp.empty(2 * nao * nao)
+
+        ao_loc_sorted = _sorted_mol.ao_loc
+        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+        from pyscf.gto.mole import ATOM_OF
+        i_atom_of_aos = np.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+        i_atom_of_aos = cp.asarray(i_atom_of_aos, dtype = cp.int32)
+
+        natm = _sorted_mol.natm
+
+        ref_drho_dA_full_response = cp.zeros((natm, 3, 2, 4, ngrids))
+        ref_drho_dA_orbital_response = cp.zeros((natm, 3, 2, 4, ngrids))
+        ref_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        ref_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+        test_drho_dA_full_response = cp.zeros((natm, 3, 2, 4, ngrids))
+        test_drho_dA_orbital_response = cp.zeros((natm, 3, 2, 4, ngrids))
+        test_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cp.max(cp.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                rks_get_drho_dA_sparse(dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            ref_drho_dA_full_response[:,:,0,:,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:,:,0,:,g0:g1] = drho_dA_orbital_response
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                rks_get_drho_dA_sparse(dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            ref_drho_dA_full_response[:,:,1,:,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:,:,1,:,g0:g1] = drho_dA_orbital_response
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                uks_get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            test_drho_dA_full_response[:,:,:,:,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            test_drho_dA_orbital_response[:,:,:,:,g0:g1] = drho_dA_orbital_response
+
+            ref_d2E_dAdB_full_response += rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[0, g0:g1], weight_depsilon_dnablarho[0, :, g0:g1],
+            ) + rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[1, g0:g1], weight_depsilon_dnablarho[1, :, g0:g1],
+            )
+            test_d2E_dAdB_full_response += uks_contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[:, g0:g1], weight_depsilon_dnablarho[:, :, g0:g1],
+            )
+
+            ref_d2E_dAdB_orbital_response += rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[0, g0:g1], weight_depsilon_dnablarho[0, :, g0:g1],
+                with_grid_response = False,
+            ) + rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[1, g0:g1], weight_depsilon_dnablarho[1, :, g0:g1],
+                with_grid_response = False,
+            )
+            test_d2E_dAdB_orbital_response += uks_contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[:, g0:g1], weight_depsilon_dnablarho[:, :, g0:g1],
+                with_grid_response = False,
+            )
+
+            g0 = g1
+        assert g1 == ngrids
+
+        diff_drhodA_full = cp.max(cp.abs(test_drho_dA_full_response - ref_drho_dA_full_response))
+        diff_drhodA_orbital = cp.max(cp.abs(test_drho_dA_orbital_response - ref_drho_dA_orbital_response))
+        max_drhodA_full = cp.max(cp.abs(ref_drho_dA_full_response))
+
+        assert diff_drhodA_full < 1e-6 and diff_drhodA_full / max_drhodA_full < 1e-9
+        assert diff_drhodA_orbital < 1e-6 and diff_drhodA_orbital / max_drhodA_full < 1e-9
+
+        diff_d2EdAdB_full = cp.max(cp.abs(test_d2E_dAdB_full_response - ref_d2E_dAdB_full_response))
+        diff_d2EdAdB_orbital = cp.max(cp.abs(test_d2E_dAdB_orbital_response - ref_d2E_dAdB_orbital_response))
+        max_d2EdAdB_full = cp.max(cp.abs(ref_d2E_dAdB_full_response))
+
+        assert diff_d2EdAdB_full < 1e-2 and diff_d2EdAdB_full / max_d2EdAdB_full < 1e-8
+        assert diff_d2EdAdB_orbital < 1e-2 and diff_d2EdAdB_orbital / max_d2EdAdB_full < 1e-8
+
+    def test_uks_d2rho_mgga(self):
+        mol = mol2
+        cp.random.seed(202)
+
+        mf = UKS(mol, xc = "TPSSH")
+        mf.grids.atom_grid = (20,26)
+
+        dm0 = cp.random.rand(2, mol.nao, mol.nao) * 2 - 1
+
+        grids = mf.grids
+        grids.build(sort_grids_of_each_atom = True)
+        ngrids = grids.coords.shape[0]
+
+        weight_depsilon_drho = cp.random.rand(2, ngrids) * 2 - 1
+        weight_depsilon_dnablarho = cp.random.rand(2, 3, ngrids) * 2 - 1
+        weight_depsilon_dtau = cp.random.rand(2, ngrids) * 2 - 1
+
+        ni = mf._numint
+        xctype = ni._xc_type(mf.xc)
+
+        ni.gdftopt = None
+        ni.build(mol, grids.coords)
+        opt = ni.gdftopt
+
+        _sorted_mol = opt._sorted_mol
+        nao = _sorted_mol.nao
+        dm0_sorted = opt.sort_orbitals(dm0, axis=[1,2])
+        dm_mask_buf = cp.empty(2 * nao * nao)
+
+        ao_loc_sorted = _sorted_mol.ao_loc
+        ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+        from pyscf.gto.mole import ATOM_OF
+        i_atom_of_aos = np.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+        i_atom_of_aos = cp.asarray(i_atom_of_aos, dtype = cp.int32)
+
+        natm = _sorted_mol.natm
+
+        ref_drho_dA_full_response = cp.zeros((natm, 3, 2, 5, ngrids))
+        ref_drho_dA_orbital_response = cp.zeros((natm, 3, 2, 5, ngrids))
+        ref_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        ref_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+        test_drho_dA_full_response = cp.zeros((natm, 3, 2, 5, ngrids))
+        test_drho_dA_orbital_response = cp.zeros((natm, 3, 2, 5, ngrids))
+        test_d2E_dAdB_full_response = cp.zeros((natm, natm, 3, 3))
+        test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
+
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cp.max(cp.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                rks_get_drho_dA_sparse(dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            ref_drho_dA_full_response[:,:,0,:,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:,:,0,:,g0:g1] = drho_dA_orbital_response
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                rks_get_drho_dA_sparse(dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            ref_drho_dA_full_response[:,:,1,:,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            ref_drho_dA_orbital_response[:,:,1,:,g0:g1] = drho_dA_orbital_response
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                uks_get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            test_drho_dA_full_response[:,:,:,:,g0:g1] = drho_dA_orbital_response + drho_dA_grid_response
+            test_drho_dA_orbital_response[:,:,:,:,g0:g1] = drho_dA_orbital_response
+
+            ref_d2E_dAdB_full_response += rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[0, g0:g1], weight_depsilon_dnablarho[0, :, g0:g1], weight_depsilon_dtau[0, g0:g1],
+            ) + rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[1, g0:g1], weight_depsilon_dnablarho[1, :, g0:g1], weight_depsilon_dtau[1, g0:g1],
+            )
+            test_d2E_dAdB_full_response += uks_contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[:, g0:g1], weight_depsilon_dnablarho[:, :, g0:g1], weight_depsilon_dtau[:, g0:g1],
+            )
+
+            ref_d2E_dAdB_orbital_response += rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[0], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[0, g0:g1], weight_depsilon_dnablarho[0, :, g0:g1], weight_depsilon_dtau[0, g0:g1],
+                with_grid_response = False,
+            ) + rks_contract_d2rho_dAdB_sparse(
+                dm0_masked[1], xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[1, g0:g1], weight_depsilon_dnablarho[1, :, g0:g1], weight_depsilon_dtau[1, g0:g1],
+                with_grid_response = False,
+            )
+            test_d2E_dAdB_orbital_response += uks_contract_d2rho_dAdB_sparse(
+                dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                weight_depsilon_drho[:, g0:g1], weight_depsilon_dnablarho[:, :, g0:g1], weight_depsilon_dtau[:, g0:g1],
+                with_grid_response = False,
+            )
+
+            g0 = g1
+        assert g1 == ngrids
+
+        diff_drhodA_full = cp.max(cp.abs(test_drho_dA_full_response - ref_drho_dA_full_response))
+        diff_drhodA_orbital = cp.max(cp.abs(test_drho_dA_orbital_response - ref_drho_dA_orbital_response))
+        max_drhodA_full = cp.max(cp.abs(ref_drho_dA_full_response))
+
+        assert diff_drhodA_full < 1e-5 and diff_drhodA_full / max_drhodA_full < 1e-9
+        assert diff_drhodA_orbital < 1e-5 and diff_drhodA_orbital / max_drhodA_full < 1e-9
+
+        diff_d2EdAdB_full = cp.max(cp.abs(test_d2E_dAdB_full_response - ref_d2E_dAdB_full_response))
+        diff_d2EdAdB_orbital = cp.max(cp.abs(test_d2E_dAdB_orbital_response - ref_d2E_dAdB_orbital_response))
+        max_d2EdAdB_full = cp.max(cp.abs(ref_d2E_dAdB_full_response))
+
+        assert diff_d2EdAdB_full < 1e-1 and diff_d2EdAdB_full / max_d2EdAdB_full < 1e-7
+        assert diff_d2EdAdB_orbital < 1e-1 and diff_d2EdAdB_orbital / max_d2EdAdB_full < 1e-7
 
 if __name__ == "__main__":
     print("Tests for UKS hessian with grid response")

--- a/gpu4pyscf/hessian/uks.py
+++ b/gpu4pyscf/hessian/uks.py
@@ -1234,6 +1234,9 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     return d2e
 
 def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
+    if hessobj.grid_response:
+        return _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
+
     mol = hessobj.mol
     mf = hessobj.base
     log = logger.new_logger(mol, mol.verbose)
@@ -1409,432 +1412,6 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
             ao_dm0a = ao_dm0b = aow = None
             t1 = log.timer_debug2('integration', *t1)
 
-    if hessobj.grid_response:
-        t2 = log.init_timer()
-        grid_start, grid_end = 0, grids.coords.shape[0]
-        dm0 = (dm0a, dm0b)
-
-        if xctype == 'LDA':
-            # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
-            available_gpu_memory = get_avail_mem()
-            available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-            ao_nbytes_per_grid = ((4 + 3 + 2 + 3*2 + 1) * mol.nao + (3*2) * mol.natm + 16 + 4) * 8
-            ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-            if ngrids_per_batch < 16:
-                raise MemoryError(f"Out of GPU memory for LDA Fock first derivative, available gpu memory = {get_avail_mem()}"
-                                  f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}")
-            ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-            ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-            for g0 in range(grid_start, grid_end, ngrids_per_batch):
-                g1 = min(g0 + ngrids_per_batch, grid_end)
-                split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
-                split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 1, gdftopt = None, transpose = False)
-
-                mu = split_ao[0]
-                dmu_dr = split_ao[1:4]
-
-                rhoa = numint.eval_rho2(mol, mu, mo_coeff[0], mo_occ[0], xctype=xctype)
-                rhob = numint.eval_rho2(mol, mu, mo_coeff[1], mo_occ[1], xctype=xctype)
-                rho = cupy.asarray((rhoa, rhob))
-                vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
-                rho = None
-
-                depsilon_drho = vxc[:,0,:] # Just of shape (2,ngrids)
-                d2epsilon_drho2 = fxc[:,0,:,0,:] # Just of shape (2,2,ngrids)
-
-                dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-                # # Negative here to cancel the overall negative sign before return
-                dwdA_depsilondrho = contract("Adg,ug->uAdg", dw_dA, depsilon_drho)
-                dw_dA = None
-                mu_occ = (mu.T @ mocca, mu.T @ moccb)
-                for i_atom in range(natm):
-                    dwdA_depsilondrho_mu = contract("udg,pg->udpg", dwdA_depsilondrho[:, i_atom, :, :], mu)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu[1], mu_occ[1])
-                    dwdA_depsilondrho_mu = None
-                dwdA_depsilondrho = None
-
-                grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
-                atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-                grid_to_atom_index_map = None
-
-                drho_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-                for i_dm in range(2):
-                    _, drho_dA_grid_response_i = \
-                        get_drho_dA_full(dm0[i_dm], xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, with_orbital_response = False)
-                    drho_dA_grid_response[i_dm] = drho_dA_grid_response_i
-                    drho_dA_grid_response_i = None
-
-                weight = cupy.asarray(grids.weights)[g0:g1]
-                # # Negative here to cancel the overall negative sign before return
-                weight_d2epsilondrho2_drhodA_grid_response = contract("uAdg,uvg->vAdg", drho_dA_grid_response, d2epsilon_drho2 * weight)
-                drho_dA_grid_response = None
-                for i_atom in range(natm):
-                    weight_d2epsilondrho2_drhodA_grid_response_mu = contract("vdg,pg->vdpg", weight_d2epsilondrho2_drhodA_grid_response[:, i_atom, :, :], mu)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_d2epsilondrho2_drhodA_grid_response_mu[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_d2epsilondrho2_drhodA_grid_response_mu[1], mu_occ[1])
-                    weight_d2epsilondrho2_drhodA_grid_response_mu = None
-                mu_occ = None
-
-                for i_atom in range(natm):
-                    associated_grid_index = atom_to_grid_index_map[i_atom]
-                    if len(associated_grid_index) == 0:
-                        continue
-
-                    mu_grid_i = mu[:, associated_grid_index]
-                    weight_depsilondrho_dmudr_grid_i = contract("dpg,ug->udpg",
-                                                                dmu_dr[:, :, associated_grid_index],
-                                                                depsilon_drho[:, associated_grid_index] * weight[associated_grid_index])
-                    mu_occ_grid_i = (mu_grid_i.T @ mocca, mu_grid_i.T @ moccb)
-                    vmata[i_atom, :, :, :] -= weight_depsilondrho_dmudr_grid_i[0] @ mu_occ_grid_i[0]
-                    vmatb[i_atom, :, :, :] -= weight_depsilondrho_dmudr_grid_i[1] @ mu_occ_grid_i[1]
-                    mu_occ_grid_i = None
-
-                    weight_depsilondrho_dmudr_occ_grid_i = contract("dqg,qj->djg", weight_depsilondrho_dmudr_grid_i[0], mocca)
-                    vmata[i_atom, :, :, :] -= contract("pg,djg->dpj", mu_grid_i, weight_depsilondrho_dmudr_occ_grid_i)
-                    weight_depsilondrho_dmudr_occ_grid_i = contract("dqg,qj->djg", weight_depsilondrho_dmudr_grid_i[1], moccb)
-                    vmatb[i_atom, :, :, :] -= contract("pg,djg->dpj", mu_grid_i, weight_depsilondrho_dmudr_occ_grid_i)
-                    weight_depsilondrho_dmudr_grid_i = None
-                    weight_depsilondrho_dmudr_occ_grid_i = None
-                    mu_grid_i = None
-
-        elif xctype == 'GGA':
-            # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
-            available_gpu_memory = get_avail_mem()
-            available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-            ao_nbytes_per_grid = ((10 + 9 + 2 + 3*2 + 2 + 3*2 + 3*3 + 9 + 4*3) * mol.nao + (3 + 3 + 9 + 3*4*2) * mol.natm + 4*2 + 16*2 + 2 + 2) * 8
-            ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-            if ngrids_per_batch < 16:
-                raise MemoryError(f"Out of GPU memory for GGA Fock first derivative, available gpu memory = {get_avail_mem()}"
-                                  f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}")
-            ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-            ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-            for g0 in range(grid_start, grid_end, ngrids_per_batch):
-                g1 = min(g0 + ngrids_per_batch, grid_end)
-                split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
-                split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
-
-                mu = split_ao[0]
-                dmu_dr = split_ao[1:4]
-                d2mu_dr2 = get_d2mu_dr2(split_ao)
-
-                rho_drhoa = numint.eval_rho2(mol, split_ao[:4], mo_coeff[0], mo_occ[0], xctype=xctype)
-                rho_drhob = numint.eval_rho2(mol, split_ao[:4], mo_coeff[1], mo_occ[1], xctype=xctype)
-                rho_drho = cupy.asarray((rho_drhoa, rho_drhob))
-                vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 2, xctype=xctype)[1:3]
-                rho_drho = None
-
-                depsilon_drho = vxc[:, 0, :]
-                depsilon_dnablarho = vxc[:, 1:4, :]
-
-                dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-                depsilondnablarho_dmudr = contract("uxg,xpg->upg", depsilon_dnablarho, dmu_dr)
-                depsilondrho_mu = contract("pg,ug->upg", mu, depsilon_drho)
-                mu_occ = (mu.T @ mocca, mu.T @ moccb)
-                for i_atom in range(natm):
-                    dwdA_depsilondrho_mu = contract("dg,upg->udpg", dw_dA[i_atom, :, :], depsilondrho_mu + depsilondnablarho_dmudr)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu[1], mu_occ[1])
-                    dwdA_depsilondrho_mu = None
-                depsilondrho_mu = None
-                mu_occ = None
-                depsilondnablarho_dmudr_occ = (depsilondnablarho_dmudr[0].T @ mocca, depsilondnablarho_dmudr[1].T @ moccb)
-                depsilondnablarho_dmudr = None
-                for i_atom in range(natm):
-                    dwdA_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], mu)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ[1])
-                    dwdA_mu = None
-                depsilondnablarho_dmudr_occ = None
-                dw_dA = None
-
-                grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
-                atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-                grid_to_atom_index_map = None
-
-                drho_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-                dnablarho_dA_grid_response = cp.zeros((2, natm, 3, 3, g1-g0))
-                for i_dm in range(2):
-                    _, _, drho_dA_grid_response_i, dnablarho_dA_grid_response_i = \
-                        get_drho_dA_full(dm0[i_dm], xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, with_orbital_response = False)
-                    drho_dA_grid_response[i_dm] = drho_dA_grid_response_i
-                    dnablarho_dA_grid_response[i_dm] = dnablarho_dA_grid_response_i
-                    drho_dA_grid_response_i = None
-                    dnablarho_dA_grid_response_i = None
-
-                weight = cupy.asarray(grids.weights)[g0:g1]
-                # # Negative here to cancel the overall negative sign before return
-                combined_d_dA_grid_response = cupy.concatenate((drho_dA_grid_response[:, :, :, None, :], dnablarho_dA_grid_response), axis = 3)
-                drho_dA_grid_response = None
-                dnablarho_dA_grid_response = None
-
-                fwxc = fxc * weight
-                fxc = None
-                drhodA_grid_response_fwxc = contract("uxvyg,vAdyg->uAdxg", fwxc, combined_d_dA_grid_response)
-                combined_d_dA_grid_response = None
-                fwxc = None
-
-                mu_occ = (mu.T @ mocca, mu.T @ moccb)
-                dmudr_occ = (
-                    contract("dqg,qj->dgj", dmu_dr, mocca),
-                    contract("dqg,qj->dgj", dmu_dr, moccb),
-                )
-                for i_atom in range(natm):
-                    drhodA_grid_response_fwxc_rho_term_mu = contract("udg,pg->udpg", drhodA_grid_response_fwxc[:, i_atom, :, 0, :], mu)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu[1], mu_occ[1])
-                    drhodA_grid_response_fwxc_rho_term_mu = None
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[0, i_atom, :, 1:4, :], dmudr_occ[0])
-                    vmata[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[1, i_atom, :, 1:4, :], dmudr_occ[1])
-                    vmatb[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = None
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr = contract("udxg,xpg->udpg", drhodA_grid_response_fwxc[:, i_atom, :, 1:4, :], dmu_dr)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr[1], mu_occ[1])
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr = None
-                drhodA_grid_response_fwxc = None
-                mu_occ = None
-                dmudr_occ = None
-
-                for i_atom in range(natm):
-                    associated_grid_index = atom_to_grid_index_map[i_atom]
-                    if len(associated_grid_index) == 0:
-                        continue
-                    # # Negative here to cancel the overall negative sign before return
-                    mu_grid_i = mu[:, associated_grid_index]
-                    dmu_dr_grid_i = dmu_dr[:, :, associated_grid_index]
-
-                    mu_occ_grid_i = (mu_grid_i.T @ mocca, mu_grid_i.T @ moccb)
-                    dmudr_occ_grid_i = (
-                        contract("dqg,qj->dgj", dmu_dr_grid_i, mocca),
-                        contract("dqg,qj->dgj", dmu_dr_grid_i, moccb),
-                    )
-
-                    weight_depsilondrho_grid_i = depsilon_drho[:, associated_grid_index] * weight[associated_grid_index]
-                    vmata[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i[0]) @ mu_occ_grid_i[0]
-                    vmatb[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i[1]) @ mu_occ_grid_i[1]
-                    vmata[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i[0], dmudr_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i[1], dmudr_occ_grid_i[1])
-                    weight_depsilondrho_grid_i = None
-
-                    d2mu_dr2_grid_i = d2mu_dr2[:, :, :, associated_grid_index]
-
-                    weight_depsilondnablarho_grid_i = depsilon_dnablarho[:, :, associated_grid_index] * weight[associated_grid_index]
-                    weight_depsilondnablarho_d2mudr2 = contract("uDg,dDpg->udpg", weight_depsilondnablarho_grid_i, d2mu_dr2_grid_i)
-                    d2mu_dr2_grid_i = None
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2[0], mu_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2[1], mu_occ_grid_i[1])
-                    mu_occ_grid_i = None
-                    weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2[0], mocca)
-                    vmata[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
-                    weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2[1], moccb)
-                    vmatb[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
-                    weight_depsilondnablarho_d2mudr2 = None
-                    mu_grid_i = None
-                    weight_depsilondnablarho_d2mudr2_occ = None
-                    weight_depsilondnablarho_dmudr = contract("uDg,Dpg->upg", weight_depsilondnablarho_grid_i, dmu_dr_grid_i)
-                    vmata[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr[0], dmudr_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr[1], dmudr_occ_grid_i[1])
-                    dmudr_occ_grid_i = None
-                    weight_depsilondnablarho_dmudr_occ = (weight_depsilondnablarho_dmudr[0].T @ mocca, weight_depsilondnablarho_dmudr[1].T @ moccb)
-                    weight_depsilondnablarho_dmudr = None
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ[1])
-                    weight_depsilondnablarho_dmudr_occ = None
-                    dmu_dr_grid_i = None
-                    weight_depsilondnablarho_grid_i = None
-
-        elif xctype == 'MGGA':
-            # If you wonder why not using ni.block_loop(), because I need the exact grid index range (g0, g1).
-            available_gpu_memory = get_avail_mem()
-            available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-            ao_nbytes_per_grid = ((10 + 9 + 24 + 4*2 + 24 + 3 + 24) * mol.nao + (3 + 15*3) * mol.natm + 5*2 + 25*2 + 2 + 2) * 8
-            ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-            if ngrids_per_batch < 16:
-                raise MemoryError(f"Out of GPU memory for mGGA Fock first derivative, available gpu memory = {get_avail_mem()}"
-                                  f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids (one GPU) = {grid_end - grid_start}")
-            ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-            ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
-
-            for g0 in range(grid_start, grid_end, ngrids_per_batch):
-                g1 = min(g0 + ngrids_per_batch, grid_end)
-                split_grids_coords = cupy.asarray(grids.coords)[g0:g1, :]
-                split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
-
-                mu = split_ao[0]
-                dmu_dr = split_ao[1:4]
-                d2mu_dr2 = get_d2mu_dr2(split_ao)
-
-                rho_drho_taua = numint.eval_rho2(mol, split_ao[:4], mo_coeff[0], mo_occ[0], xctype=xctype)
-                rho_drho_taub = numint.eval_rho2(mol, split_ao[:4], mo_coeff[1], mo_occ[1], xctype=xctype)
-                rho_drho_tau = cupy.asarray((rho_drho_taua, rho_drho_taub))
-                vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho_tau, deriv = 2, xctype=xctype)[1:3]
-                rho_drho_tau = None
-
-                depsilon_drho = vxc[:, 0, :]
-                depsilon_dnablarho = vxc[:, 1:4, :]
-                depsilon_dtau = vxc[:, 4, :]
-
-                dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-                depsilondnablarho_dmudr = contract("uxg,xpg->upg", depsilon_dnablarho, dmu_dr)
-                depsilondrho_mu = contract("pg,ug->upg", mu, depsilon_drho)
-                mu_occ = (mu.T @ mocca, mu.T @ moccb)
-                for i_atom in range(natm):
-                    dwdA_depsilondrho_mu = contract("dg,upg->udpg", dw_dA[i_atom, :, :], depsilondrho_mu + depsilondnablarho_dmudr)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_depsilondrho_mu[1], mu_occ[1])
-                    dwdA_depsilondrho_mu = None
-                depsilondrho_mu = None
-                mu_occ = None
-                depsilondnablarho_dmudr_occ = (depsilondnablarho_dmudr[0].T @ mocca, depsilondnablarho_dmudr[1].T @ moccb)
-                depsilondnablarho_dmudr = None
-                for i_atom in range(natm):
-                    dwdA_mu = contract("dg,pg->dpg", dw_dA[i_atom, :, :], mu)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", dwdA_mu, depsilondnablarho_dmudr_occ[1])
-                    dwdA_mu = None
-                depsilondnablarho_dmudr_occ = None
-                depsilondtau_dmudr = contract("dpg,ug->udpg", dmu_dr, depsilon_dtau)
-                depsilondtau_dmudr_occ = (
-                    depsilondtau_dmudr[0].transpose(0,2,1) @ mocca,
-                    depsilondtau_dmudr[1].transpose(0,2,1) @ moccb,
-                )
-                depsilondtau_dmudr = None
-                for i_atom in range(natm):
-                    dwdA_dmudr = contract("dg,xpg->dpxg", dw_dA[i_atom, :, :], dmu_dr)
-                    vmata[i_atom, :, :, :] -= 0.5 * contract("dpxg,xgj->dpj", dwdA_dmudr, depsilondtau_dmudr_occ[0])
-                    vmatb[i_atom, :, :, :] -= 0.5 * contract("dpxg,xgj->dpj", dwdA_dmudr, depsilondtau_dmudr_occ[1])
-                    dwdA_dmudr = None
-                depsilondtau_dmudr_occ = None
-                dw_dA = None
-
-                grid_to_atom_index_map = cupy.asarray(grids.atm_idx)[g0:g1]
-                atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-                grid_to_atom_index_map = None
-
-                drho_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-                dnablarho_dA_grid_response = cp.zeros((2, natm, 3, 3, g1-g0))
-                dtau_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-                for i_dm in range(2):
-                    _, _, _, drho_dA_grid_response_i, dnablarho_dA_grid_response_i, dtau_dA_grid_response_i = \
-                        get_drho_dA_full(dm0[i_dm], xctype, natm, g1 - g0, None, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2, with_orbital_response = False)
-                    drho_dA_grid_response[i_dm] = drho_dA_grid_response_i
-                    dnablarho_dA_grid_response[i_dm] = dnablarho_dA_grid_response_i
-                    dtau_dA_grid_response[i_dm] = dtau_dA_grid_response_i
-                    drho_dA_grid_response_i = None
-                    dnablarho_dA_grid_response_i = None
-                    dtau_dA_grid_response_i = None
-
-                weight = cupy.asarray(grids.weights)[g0:g1]
-                combined_d_dA_grid_response = cupy.concatenate(
-                    (drho_dA_grid_response[:, :, :, None, :], dnablarho_dA_grid_response, dtau_dA_grid_response[:, :, :, None, :]),
-                    axis = 3
-                )
-                drho_dA_grid_response = None
-                dnablarho_dA_grid_response = None
-                dtau_dA_grid_response = None
-
-                fwxc = fxc * weight
-                fxc = None
-                drhodA_grid_response_fwxc = contract("uxvyg,vAdyg->uAdxg", fwxc, combined_d_dA_grid_response)
-                combined_d_dA_grid_response = None
-                fwxc = None
-
-                mu_occ = (mu.T @ mocca, mu.T @ moccb)
-                dmudr_occ = (
-                    contract("dqg,qj->dgj", dmu_dr, mocca),
-                    contract("dqg,qj->dgj", dmu_dr, moccb),
-                )
-                for i_atom in range(natm):
-                    drhodA_grid_response_fwxc_rho_term_mu = contract("udg,pg->udpg", drhodA_grid_response_fwxc[:, i_atom, :, 0, :], mu)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_rho_term_mu[1], mu_occ[1])
-                    drhodA_grid_response_fwxc_rho_term_mu = None
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[0, i_atom, :, 1:4, :], dmudr_occ[0])
-                    vmata[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = contract("dxg,xgj->dgj", drhodA_grid_response_fwxc[1, i_atom, :, 1:4, :], dmudr_occ[1])
-                    vmatb[i_atom, :, :, :] -= contract("dgj,pg->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr_occ, mu)
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr_occ = None
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr = contract("udxg,xpg->udpg", drhodA_grid_response_fwxc[:, i_atom, :, 1:4, :], dmu_dr)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr[0], mu_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", drhodA_grid_response_fwxc_nablarho_term_dmudr[1], mu_occ[1])
-                    drhodA_grid_response_fwxc_nablarho_term_dmudr = None
-                    drhodA_grid_response_fwxc_tau_term_dmudr = contract("udg,xpg->udpxg", drhodA_grid_response_fwxc[:, i_atom, :, 4, :], dmu_dr)
-                    vmata[i_atom, :, :, :] -= 0.5 * contract("dpxg,xgj->dpj", drhodA_grid_response_fwxc_tau_term_dmudr[0], dmudr_occ[0])
-                    vmatb[i_atom, :, :, :] -= 0.5 * contract("dpxg,xgj->dpj", drhodA_grid_response_fwxc_tau_term_dmudr[1], dmudr_occ[1])
-                    drhodA_grid_response_fwxc_tau_term_dmudr = None
-                drhodA_grid_response_fwxc = None
-                mu_occ = None
-                dmudr_occ = None
-
-                for i_atom in range(natm):
-                    associated_grid_index = atom_to_grid_index_map[i_atom]
-                    if len(associated_grid_index) == 0:
-                        continue
-                    # # Negative here to cancel the overall negative sign before return
-                    mu_grid_i = mu[:, associated_grid_index]
-                    dmu_dr_grid_i = dmu_dr[:, :, associated_grid_index]
-
-                    mu_occ_grid_i = (mu_grid_i.T @ mocca, mu_grid_i.T @ moccb)
-                    dmudr_occ_grid_i = (
-                        contract("dqg,qj->dgj", dmu_dr_grid_i, mocca),
-                        contract("dqg,qj->dgj", dmu_dr_grid_i, moccb),
-                    )
-
-                    weight_depsilondrho_grid_i = depsilon_drho[:, associated_grid_index] * weight[associated_grid_index]
-                    vmata[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i[0]) @ mu_occ_grid_i[0]
-                    vmatb[i_atom, :, :, :] -= (dmu_dr_grid_i * weight_depsilondrho_grid_i[1]) @ mu_occ_grid_i[1]
-                    vmata[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i[0], dmudr_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i * weight_depsilondrho_grid_i[1], dmudr_occ_grid_i[1])
-                    weight_depsilondrho_grid_i = None
-
-                    d2mu_dr2_grid_i = d2mu_dr2[:, :, :, associated_grid_index]
-
-                    weight_depsilondnablarho_grid_i = depsilon_dnablarho[:, :, associated_grid_index] * weight[associated_grid_index]
-                    weight_depsilondnablarho_d2mudr2 = contract("uDg,dDpg->udpg", weight_depsilondnablarho_grid_i, d2mu_dr2_grid_i)
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2[0], mu_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", weight_depsilondnablarho_d2mudr2[1], mu_occ_grid_i[1])
-                    mu_occ_grid_i = None
-                    weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2[0], mocca)
-                    vmata[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
-                    weight_depsilondnablarho_d2mudr2_occ = contract("dpg,pj->dgj", weight_depsilondnablarho_d2mudr2[1], moccb)
-                    vmatb[i_atom, :, :, :] -= contract("pg,dgj->dpj", mu_grid_i, weight_depsilondnablarho_d2mudr2_occ)
-                    weight_depsilondnablarho_d2mudr2 = None
-                    mu_grid_i = None
-                    weight_depsilondnablarho_d2mudr2_occ = None
-                    weight_depsilondnablarho_dmudr = contract("uDg,Dpg->upg", weight_depsilondnablarho_grid_i, dmu_dr_grid_i)
-                    vmata[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr[0], dmudr_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= contract("pg,dgj->dpj", weight_depsilondnablarho_dmudr[1], dmudr_occ_grid_i[1])
-                    weight_depsilondnablarho_dmudr_occ = (weight_depsilondnablarho_dmudr[0].T @ mocca, weight_depsilondnablarho_dmudr[1].T @ moccb)
-                    weight_depsilondnablarho_dmudr = None
-                    vmata[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ[0])
-                    vmatb[i_atom, :, :, :] -= contract("dpg,gj->dpj", dmu_dr_grid_i, weight_depsilondnablarho_dmudr_occ[1])
-                    weight_depsilondnablarho_dmudr_occ = None
-                    weight_depsilondnablarho_grid_i = None
-
-                    weight_depsilondrho_grid_i = depsilon_dtau[:, associated_grid_index] * weight[associated_grid_index]
-                    vmata[i_atom, :, :, :] -= 0.5 * cupy.einsum("dDpg,Dgj->dpj", d2mu_dr2_grid_i * weight_depsilondrho_grid_i[0], dmudr_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= 0.5 * cupy.einsum("dDpg,Dgj->dpj", d2mu_dr2_grid_i * weight_depsilondrho_grid_i[1], dmudr_occ_grid_i[1])
-                    dmudr_occ_grid_i = None
-                    d2mudr2_occ_grid_i = (
-                        contract("dDqg,qj->dDgj", d2mu_dr2_grid_i, mocca),
-                        contract("dDqg,qj->dDgj", d2mu_dr2_grid_i, moccb),
-                    )
-                    d2mu_dr2_grid_i = None
-                    vmata[i_atom, :, :, :] -= 0.5 * contract("Dpg,dDgj->dpj", dmu_dr_grid_i * weight_depsilondrho_grid_i[0], d2mudr2_occ_grid_i[0])
-                    vmatb[i_atom, :, :, :] -= 0.5 * contract("Dpg,dDgj->dpj", dmu_dr_grid_i * weight_depsilondrho_grid_i[1], d2mudr2_occ_grid_i[1])
-                    dmu_dr_grid_i = None
-                    d2mudr2_occ_grid_i = None
-
-        elif xctype == 'HF':
-            pass
-        else:
-            raise NotImplementedError(f"xctype = {xctype} not supported")
-        t2 = log.timer_debug2('grid response', *t2)
-
     va_mo = cupy.ndarray((natm,3,nmo,nocca), dtype=vmata.dtype, memptr=vmata.data)
     vb_mo = cupy.ndarray((natm,3,nmo,noccb), dtype=vmatb.dtype, memptr=vmatb.data)
     vmat_tmp = cupy.empty([3,nao,nao])
@@ -1854,6 +1431,433 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
         tmp += vmatb[ia]
         contract('xiq,ip->xpq', tmp, mo_coeff[1], alpha=-1., out=vb_mo[ia])
     return va_mo, vb_mo
+
+def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
+    mol = hessobj.mol
+    mf = hessobj.base
+    ni = mf._numint
+    xctype = ni._xc_type(mf.xc)
+
+    if hessobj.grids is not None:
+        grids = hessobj.grids
+    else:
+        grids = mf.grids
+    grids.build(sort_grids_of_each_atom = True)
+    ngrids = grids.coords.shape[0]
+
+    ni.gdftopt = None
+    ni.build(mol, grids.coords)
+    opt = ni.gdftopt
+
+    _sorted_mol = opt._sorted_mol
+    nao = _sorted_mol.nao
+    natm = mol.natm
+    mol = None
+
+    mo_occ = cupy.asarray(mo_occ)
+    mo_coeff = cupy.asarray(mo_coeff)
+    assert mo_coeff.ndim == 3 and mo_coeff.shape[0] == 2
+    mo_coeff_sorted = opt.sort_orbitals(mo_coeff, axis=[1])
+    mocca_sorted = mo_coeff_sorted[0][:, mo_occ[0] > 0]
+    moccb_sorted = mo_coeff_sorted[1][:, mo_occ[1] > 0]
+    nao = _sorted_mol.nao
+    # nmo = mo_coeff_sorted.shape[2]
+    nocca = mocca_sorted.shape[1]
+    noccb = moccb_sorted.shape[1]
+
+    dm0 = mf.make_rdm1(mo_coeff, mo_occ)
+    assert dm0.ndim == 3 and dm0.shape[0] == 2
+    dm0_sorted = opt.sort_orbitals(dm0, axis=[1,2])
+    dm_mask_buf = cupy.empty(2 * nao * nao)
+    dm0 = None
+    mo_coeff = None
+
+    nonzero_weight_mask = cupy.abs(grids.weights) > 1e-20 # There are d2rho/dAdB terms with very low weight but very big contribution
+
+    ao_loc_sorted = _sorted_mol.ao_loc
+    ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+    from pyscf.gto.mole import ATOM_OF
+    i_atom_of_aos = numpy.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+    i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
+
+    dFock_orbital_response_dmudA_nu_term = cupy.zeros((2, 3, nao, nao))
+    dFock_ao_occa = cupy.zeros((natm, 3, nao, nocca))
+    dFock_ao_occb = cupy.zeros((natm, 3, nao, noccb))
+
+    if xctype == 'LDA':
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            mocca_masked = mocca_sorted[idx, :]
+            moccb_masked = moccb_sorted[idx, :]
+
+            rhoa = numint.eval_rho(_sorted_mol, ao[0], dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao[0], dm0_masked[1], xctype = xctype, hermi = 1)
+            rho = cupy.asarray((rhoa, rhob))
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
+            del rhoa, rhob, rho
+
+            depsilon_drho = vxc[:, 0, :] # Just of shape (2, ngrids)
+            d2epsilon_drho2 = fxc[:, 0, :, 0, :] # Just of shape (2, 2, ngrids)
+            del vxc, fxc
+
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,g,pg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_drho, mu, mu, mocc_masked)
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
+
+            weight = weight[nonzero_weight_mask[g0:g1]]
+
+            # dFock_mo_occ += cupy.einsum("pi,g,Adg,pg,qg,qj->Adij", mo_coeff_masked, d2epsilon_drho2 * weight, drho_dA_full_response, mu, mu, mocc_masked)
+            mu_nu_term_prefactor = contract("Advg,uvg->Adug", drho_dA_full_response, d2epsilon_drho2 * weight)
+            mu_nu_term_prefactor += contract("Adg,ug->Adug", dw_dA, depsilon_drho)
+            del drho_dA_full_response, d2epsilon_drho2, dw_dA
+
+            dFock_sparse_ao_occa = cupy.zeros((natm, 3, mu.shape[0], nocca))
+            dFock_sparse_ao_occb = cupy.zeros((natm, 3, mu.shape[0], noccb))
+
+            mu_mocca = mu.T @ mocca_masked
+            mu_moccb = mu.T @ moccb_masked
+            for i_atom in range(natm):
+                prefactor_with_nu_mocc = contract("dg,gj->dgj", mu_nu_term_prefactor[i_atom, :, 0, :], mu_mocca)
+                dFock_sparse_ao_occa[i_atom, :, :, :] += contract("pg,dgj->dpj", mu, prefactor_with_nu_mocc)
+                del prefactor_with_nu_mocc
+                prefactor_with_nu_mocc = contract("dg,gj->dgj", mu_nu_term_prefactor[i_atom, :, 1, :], mu_moccb)
+                dFock_sparse_ao_occb[i_atom, :, :, :] += contract("pg,dgj->dpj", mu, prefactor_with_nu_mocc)
+                del prefactor_with_nu_mocc
+            del mu_mocca, mu_moccb
+            del mu_nu_term_prefactor
+
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
+            mu_vw = contract("pg,ug->upg", mu, depsilon_drho * weight)
+            dmudA_nu_ao = contract("dpg,uqg->udpq", dmu_dr, mu_vw)
+            del mu_vw
+            dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(2), range(3), idx, idx)] += dmudA_nu_ao
+
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum("pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,1,3,2)
+            del dmudA_nu_ao
+            dFock_sparse_ao_occa[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao[0], mocca_masked)
+            dFock_sparse_ao_occb[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao[1], moccb_masked)
+            del dmudA_nu_ao_ao
+
+            dFock_ao_occa[:, :, idx, :] += dFock_sparse_ao_occa
+            dFock_ao_occb[:, :, idx, :] += dFock_sparse_ao_occb
+            del dFock_sparse_ao_occa, dFock_sparse_ao_occb
+
+            g0 = g1
+        assert g1 == ngrids
+
+    elif xctype == 'GGA':
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            mocca_masked = mocca_sorted[idx, :]
+            moccb_masked = moccb_sorted[idx, :]
+
+            rhoa = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[1], xctype = xctype, hermi = 1)
+            rho = cupy.asarray((rhoa, rhob))
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
+            del rhoa, rhob, rho
+
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,g,pg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_drho, mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xpg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xqg,pg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            dwdA_vxc = contract("Adg,uxg->Aduxg", dw_dA, vxc)
+            del dw_dA
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
+
+            weight = weight[nonzero_weight_mask[g0:g1]]
+
+            fwxc = fxc * weight
+            del fxc
+            drhodA_fwxc = contract("uxvyg,Advyg->Aduxg", fwxc, drho_dA_full_response)
+            del drho_dA_full_response
+            del fwxc
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,pg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 0, :], mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xpg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xqg,pg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            mu_nu_term_prefactor = drhodA_fwxc + dwdA_vxc
+            del drhodA_fwxc, dwdA_vxc
+
+            dFock_sparse_ao_occa = cupy.zeros((natm, 3, mu.shape[0], nocca))
+            dFock_sparse_ao_occb = cupy.zeros((natm, 3, mu.shape[0], noccb))
+
+            mu_mocca = mu.T @ mocca_masked
+            mu_moccb = mu.T @ moccb_masked
+            dmudr_mocca = contract("dqg,qj->djg", dmu_dr, mocca_masked)
+            dmudr_moccb = contract("dqg,qj->djg", dmu_dr, moccb_masked)
+            for i_atom in range(natm):
+                mu_on_right_term = contract("xpg,duxg->udpg", ao[0:4], mu_nu_term_prefactor[i_atom, :, :, 0:4, :])
+                dFock_sparse_ao_occa[i_atom, :, :, :] += contract("dpg,gj->dpj", mu_on_right_term[0], mu_mocca)
+                dFock_sparse_ao_occb[i_atom, :, :, :] += contract("dpg,gj->dpj", mu_on_right_term[1], mu_moccb)
+                del mu_on_right_term
+                nablarho_dmudr_on_right_term = contract("dxg,xjg->djg", mu_nu_term_prefactor[i_atom, :, 0, 1:4, :], dmudr_mocca)
+                dFock_sparse_ao_occa[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
+                nablarho_dmudr_on_right_term = contract("dxg,xjg->djg", mu_nu_term_prefactor[i_atom, :, 1, 1:4, :], dmudr_moccb)
+                dFock_sparse_ao_occb[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
+                del nablarho_dmudr_on_right_term
+            del mu_mocca, mu_moccb, dmudr_mocca, dmudr_moccb
+            del mu_nu_term_prefactor
+
+            wv = vxc * weight
+            del vxc
+            weight_depsilon_drho = wv[:, 0, :]
+            weight_depsilon_dnablarho = wv[:, 1:4, :]
+            del wv
+
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dxpg,qg->dpq", depsilon_dnablarho * weight, d2mu_dr2, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum("xg,dpg,xqg->dpq", depsilon_dnablarho * weight, dmu_dr, dmu_dr)
+            mu_weight_depsilondrho = contract("pg,ug->upg", mu, weight_depsilon_drho)
+            dmudr_weight_depsilondnablarho = contract("uxg,xpg->upg", weight_depsilon_dnablarho, dmu_dr)
+            dmudA_nu_ao = contract("dpg,uqg->udpq", dmu_dr, mu_weight_depsilondrho + dmudr_weight_depsilondnablarho)
+            del mu_weight_depsilondrho, dmudr_weight_depsilondnablarho
+            d2mudr2_weight_depsilondnablarho = contract("dxpg,uxg->udpg", d2mu_dr2, weight_depsilon_dnablarho)
+            dmudA_nu_ao += contract("udpg,qg->udpq", d2mudr2_weight_depsilondnablarho, mu)
+            del d2mudr2_weight_depsilondnablarho
+
+            dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(2), range(3), idx, idx)] += dmudA_nu_ao
+
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,1,3,2)
+            del dmudA_nu_ao
+            dFock_sparse_ao_occa[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao[0], mocca_masked)
+            dFock_sparse_ao_occb[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao[1], moccb_masked)
+            del dmudA_nu_ao_ao
+
+            dFock_ao_occa[:, :, idx, :] += dFock_sparse_ao_occa
+            dFock_ao_occb[:, :, idx, :] += dFock_sparse_ao_occb
+            del dFock_sparse_ao_occa, dFock_sparse_ao_occb
+
+            g0 = g1
+        assert g1 == ngrids
+
+    elif xctype == 'MGGA':
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
+
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
+
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            mocca_masked = mocca_sorted[idx, :]
+            moccb_masked = moccb_sorted[idx, :]
+
+            rhoa = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[1], xctype = xctype, hermi = 1)
+            rho = cupy.asarray((rhoa, rhob))
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
+            del rhoa, rhob, rho
+
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,g,pg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_drho, mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xpg,qg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adg,xg,xqg,pg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dnablarho, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += 0.5 * cupy.einsum("pi,Adg,g,xpg,xqg,qj->Adij", mo_coeff_masked, dw_dA, depsilon_dtau, dmu_dr, dmu_dr, mocc_masked)
+            dwdA_vxc = contract("Adg,uxg->Aduxg", dw_dA, vxc)
+            del dw_dA
+
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
+
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
+
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
+
+            weight = weight[nonzero_weight_mask[g0:g1]]
+
+            fwxc = fxc * weight
+            del fxc
+            drhodA_fwxc = contract("uxvyg,Advyg->Aduxg", fwxc, drho_dA_full_response)
+            del drho_dA_full_response
+            del fwxc
+
+            # dFock_mo_occ += cupy.einsum("pi,Adg,pg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 0, :], mu, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xpg,qg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += cupy.einsum("pi,Adxg,xqg,pg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 1:4, :], dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ += 0.5 * cupy.einsum("pi,Adg,xpg,xqg,qj->Adij", mo_coeff_masked, drhodA_fwxc[:, :, 4, :], dmu_dr, dmu_dr, mocc_masked)
+            mu_nu_term_prefactor = drhodA_fwxc + dwdA_vxc
+            del drhodA_fwxc, dwdA_vxc
+
+            dFock_sparse_ao_occa = cupy.zeros((natm, 3, mu.shape[0], nocca))
+            dFock_sparse_ao_occb = cupy.zeros((natm, 3, mu.shape[0], noccb))
+
+            mu_mocca = mu.T @ mocca_masked
+            mu_moccb = mu.T @ moccb_masked
+            dmudr_mocca = contract("dqg,qj->djg", dmu_dr, mocca_masked)
+            dmudr_moccb = contract("dqg,qj->djg", dmu_dr, moccb_masked)
+            for i_atom in range(natm):
+                mu_on_right_term = contract("xpg,duxg->udpg", ao[0:4], mu_nu_term_prefactor[i_atom, :, :, 0:4, :])
+                dFock_sparse_ao_occa[i_atom, :, :, :] += contract("dpg,gj->dpj", mu_on_right_term[0], mu_mocca)
+                dFock_sparse_ao_occb[i_atom, :, :, :] += contract("dpg,gj->dpj", mu_on_right_term[1], mu_moccb)
+                del mu_on_right_term
+                nablarho_dmudr_on_right_term = contract("dxg,xjg->djg", mu_nu_term_prefactor[i_atom, :, 0, 1:4, :], dmudr_mocca)
+                dFock_sparse_ao_occa[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
+                nablarho_dmudr_on_right_term = contract("dxg,xjg->djg", mu_nu_term_prefactor[i_atom, :, 1, 1:4, :], dmudr_moccb)
+                dFock_sparse_ao_occb[i_atom, :, :, :] += contract("pg,djg->dpj", mu, nablarho_dmudr_on_right_term)
+                del nablarho_dmudr_on_right_term
+                tau_term = contract("dg,xjg->dxjg", mu_nu_term_prefactor[i_atom, :, 0, 4, :], dmudr_mocca)
+                dFock_sparse_ao_occa[i_atom, :, :, :] += 0.5 * contract("xpg,dxjg->dpj", dmu_dr, tau_term)
+                tau_term = contract("dg,xjg->dxjg", mu_nu_term_prefactor[i_atom, :, 1, 4, :], dmudr_moccb)
+                dFock_sparse_ao_occb[i_atom, :, :, :] += 0.5 * contract("xpg,dxjg->dpj", dmu_dr, tau_term)
+                del tau_term
+            del mu_mocca, mu_moccb, dmudr_mocca, dmudr_moccb
+            del mu_nu_term_prefactor
+
+            wv = vxc * weight
+            del vxc
+            weight_depsilon_drho = wv[:, 0, :]
+            weight_depsilon_dnablarho = wv[:, 1:4, :]
+            weight_depsilon_dtau = wv[:, 4, :]
+            del wv
+
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum(
+            #     "g,dpg,qg->dpq", depsilon_drho * weight, dmu_dr, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum(
+            #     "xg,dxpg,qg->dpq", depsilon_dnablarho * weight, d2mu_dr2, mu)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += cupy.einsum(
+            #     "xg,dpg,xqg->dpq", depsilon_dnablarho * weight, dmu_dr, dmu_dr)
+            # dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(3), idx, idx)] += 0.5 * cupy.einsum(
+            #     "g,dxpg,xqg->dpq", depsilon_dtau * weight, d2mu_dr2, dmu_dr)
+            mu_weight_depsilondrho = contract("pg,ug->upg", mu, weight_depsilon_drho)
+            dmudr_weight_depsilondnablarho = contract("uxg,xpg->upg", weight_depsilon_dnablarho, dmu_dr)
+            dmudA_nu_ao = contract("dpg,uqg->udpq", dmu_dr, mu_weight_depsilondrho + dmudr_weight_depsilondnablarho)
+            del mu_weight_depsilondrho, dmudr_weight_depsilondnablarho
+            dmudr_weight_depsilondtau = 0.5 * contract("dpg,ug->udpg", dmu_dr, weight_depsilon_dtau)
+            mu_weight_depsilondnablarho = contract("uxg,qg->uxqg", weight_depsilon_dnablarho, mu)
+            dmudA_nu_ao += contract("dxpg,uxqg->udpq", d2mu_dr2, dmudr_weight_depsilondtau + mu_weight_depsilondnablarho)
+            del mu_weight_depsilondnablarho, dmudr_weight_depsilondtau
+
+            dFock_orbital_response_dmudA_nu_term[numpy.ix_(range(2), range(3), idx, idx)] += dmudA_nu_ao
+
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dpg,qg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,g,dqg,pg,qj->dij", mo_coeff_masked, depsilon_drho * weight, dmu_dr, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxpg,qg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dxqg,pg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, d2mu_dr2, mu, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dpg,xqg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += cupy.einsum(
+            #     "pi,xg,dqg,xpg,qj->dij", mo_coeff_masked, depsilon_dnablarho * weight, dmu_dr, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum(
+            #     "pi,g,dxpg,xqg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
+            # dFock_mo_occ[i_atom_of_grids, :, :, :] += 0.5 * cupy.einsum(
+            #     "pi,g,dxqg,xpg,qj->dij", mo_coeff_masked, depsilon_dtau * weight, d2mu_dr2, dmu_dr, mocc_masked)
+            dmudA_nu_ao_ao = dmudA_nu_ao + dmudA_nu_ao.transpose(0,1,3,2)
+            del dmudA_nu_ao
+            dFock_sparse_ao_occa[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao[0], mocca_masked)
+            dFock_sparse_ao_occb[i_atom_of_grids, :, :, :] += contract("dpq,qj->dpj", dmudA_nu_ao_ao[1], moccb_masked)
+            del dmudA_nu_ao_ao
+
+            dFock_ao_occa[:, :, idx, :] += dFock_sparse_ao_occa
+            dFock_ao_occb[:, :, idx, :] += dFock_sparse_ao_occb
+            del dFock_sparse_ao_occa, dFock_sparse_ao_occb
+
+            g0 = g1
+        assert g1 == ngrids
+
+    elif xctype == 'HF':
+        pass
+    else:
+        raise NotImplementedError(f"xctype = {xctype} not supported")
+
+    dFock_mo_occa = contract("Adpj,pi->Adij", dFock_ao_occa, mo_coeff_sorted[0])
+    dFock_mo_occb = contract("Adpj,pi->Adij", dFock_ao_occb, mo_coeff_sorted[1])
+    del dFock_ao_occa, dFock_ao_occb
+    for i_atom in range(0, natm):
+        ao_of_atom_i = cupy.where(i_atom_of_aos == i_atom)[0]
+        if ao_of_atom_i.size > 0:
+            dFock_ao_of_atom_i = dFock_orbital_response_dmudA_nu_term[:, :, ao_of_atom_i, :]
+
+            dFock_ao_of_atom_i_mocc = dFock_ao_of_atom_i[0] @ mocca_sorted
+            dFock_mo_occa[i_atom, :, :, :] -= cupy.einsum("pi,dpj->dij", mo_coeff_sorted[0][ao_of_atom_i, :], dFock_ao_of_atom_i_mocc)
+            dFock_ao_of_atom_i_mocc = dFock_ao_of_atom_i[0].transpose(0,2,1) @ mocca_sorted[ao_of_atom_i]
+            dFock_mo_occa[i_atom, :, :, :] -= cupy.einsum("pi,dpj->dij", mo_coeff_sorted[0], dFock_ao_of_atom_i_mocc)
+
+            dFock_ao_of_atom_i_mocc = dFock_ao_of_atom_i[1] @ moccb_sorted
+            dFock_mo_occb[i_atom, :, :, :] -= cupy.einsum("pi,dpj->dij", mo_coeff_sorted[1][ao_of_atom_i, :], dFock_ao_of_atom_i_mocc)
+            dFock_ao_of_atom_i_mocc = dFock_ao_of_atom_i[1].transpose(0,2,1) @ moccb_sorted[ao_of_atom_i]
+            dFock_mo_occb[i_atom, :, :, :] -= cupy.einsum("pi,dpj->dij", mo_coeff_sorted[1], dFock_ao_of_atom_i_mocc)
+            del dFock_ao_of_atom_i_mocc, dFock_ao_of_atom_i
+    del dFock_orbital_response_dmudA_nu_term
+
+    return (dFock_mo_occa, dFock_mo_occb)
 
 def get_veff_resp_mo(hessobj, mol, dms, mo_coeff, mo_occ, hermi=1):
     mol = hessobj.mol

--- a/gpu4pyscf/hessian/uks.py
+++ b/gpu4pyscf/hessian/uks.py
@@ -18,6 +18,7 @@ Non-relativistic UKS analytical Hessian
 
 
 import cupy
+import numpy
 import cupy as cp
 from pyscf import lib
 from gpu4pyscf.hessian import rhf as rhf_hess
@@ -28,7 +29,7 @@ from gpu4pyscf.hessian.rks import _get_enlc_deriv2, _get_vnlc_deriv1, nr_rks_fnl
 from gpu4pyscf.grad import rhf as rhf_grad
 from gpu4pyscf.grad import rks as rks_grad
 from gpu4pyscf.dft import numint
-from gpu4pyscf.lib.cupy_helper import (contract, add_sparse, get_avail_mem)
+from gpu4pyscf.lib.cupy_helper import (contract, add_sparse, get_avail_mem, take_last2d)
 from gpu4pyscf.lib import logger
 from gpu4pyscf.__config__ import min_grid_blksize
 
@@ -95,6 +96,11 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
 def _get_exc_deriv2(hessobj, mo_coeff, mo_occ, dm0, max_memory, atmlst = None, log = None):
     if log is None:
         log = logger.new_logger(hessobj)
+
+    if hessobj.grid_response:
+        log.info("Calculating grid response for unrestricted DFT Hessian")
+        return _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
+
     mol = hessobj.mol
     mf = hessobj.base
     dm0a = dm0[0]
@@ -122,9 +128,6 @@ def _get_exc_deriv2(hessobj, mo_coeff, mo_occ, dm0, max_memory, atmlst = None, l
             de2[i0,j0] += 2.0 * veffb_dm[:,:,q0:q1].sum(axis=2)
         for j0 in range(i0):
             de2[j0,i0] = de2[i0,j0].T
-    if hessobj.grid_response:
-        log.info("Calculating grid response for unrestricted DFT Hessian")
-        de2 += _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory)
 
     return de2
 
@@ -675,6 +678,240 @@ def _get_vxc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
             vmatb_dm[ia] += contract('yxqp,pq->xyp', ipipb[:,:,p0:p1], dm0b[:,p0:p1])
     return vmata_dm, vmatb_dm
 
+def get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = None, i_atom_of_grids = None,
+                       mu = None, dmu_dr = None, d2mu_dr2 = None,
+                       with_orbital_response = True, with_grid_response = True):
+    if xctype == "LDA":
+        with_nablarho = False
+        with_tau = False
+        n_component = 1
+    elif xctype == "GGA":
+        with_nablarho = True
+        with_tau = False
+        n_component = 4
+    elif xctype == "MGGA":
+        with_nablarho = True
+        with_tau = True
+        n_component = 5
+    else:
+        raise NotImplementedError(f"Unrecognized xctype = {xctype}")
+
+    nao = dm0_masked.shape[-1]
+    assert dm0_masked.shape == (2, nao, nao)
+    assert mu is not None
+    ngrids = mu.shape[1]
+    assert mu.shape == (nao, ngrids)
+    assert dmu_dr is not None and dmu_dr.shape == (3, nao, ngrids)
+    if with_nablarho or with_tau:
+        assert d2mu_dr2 is not None and d2mu_dr2.shape == (3, 3, nao, ngrids)
+
+    if with_orbital_response:
+        assert masked_i_atom_of_aos is not None
+        masked_i_atom_of_aos = cupy.asarray(masked_i_atom_of_aos, dtype = numpy.int32)
+        assert masked_i_atom_of_aos.shape == (nao,)
+    if with_grid_response:
+        assert i_atom_of_grids is not None
+        i_atom_of_grids = int(i_atom_of_grids)
+        assert 0 <= i_atom_of_grids and i_atom_of_grids < natm
+
+    dm_dmT = dm0_masked + dm0_masked.transpose(0,2,1)
+    dm_dot_mu_and_nu = dm_dmT @ mu
+    if with_nablarho:
+        dm_dot_dmu_and_dnu = contract('djg,uij->udig', dmu_dr, dm_dmT)
+
+    assert with_orbital_response or with_grid_response, "Why are you calling this function?"
+
+    drho_dA_orbital_response = None
+    if with_orbital_response:
+        drho_dA_orbital_response = cupy.zeros([natm, 3, 2, n_component, ngrids])
+    drho_dA_grid_response = None
+    if with_grid_response:
+        drho_dA_grid_response = cupy.zeros([natm, 3, 2, n_component, ngrids])
+
+    rho_response = contract("dig,uig->duig", dmu_dr, dm_dot_mu_and_nu)
+    if with_orbital_response:
+        cupy.add.at(drho_dA_orbital_response[:, :, :, 0, :], masked_i_atom_of_aos, rho_response.transpose(2,0,1,3))
+    if with_grid_response:
+        rho_response = cupy.einsum('duig->dug', rho_response)
+        drho_dA_grid_response[i_atom_of_grids, :, :, 0, :] = rho_response
+    del rho_response
+
+    if with_nablarho:
+        nablarho_response = contract("dDig,uig->duDig", d2mu_dr2, dm_dot_mu_and_nu)
+        nablarho_response += contract('dig,uDig->duDig', dmu_dr, dm_dot_dmu_and_dnu)
+        if with_orbital_response:
+            cupy.add.at(drho_dA_orbital_response[:, :, :, 1:4, :], masked_i_atom_of_aos, nablarho_response.transpose(3,0,1,2,4))
+        if with_grid_response:
+            nablarho_response = cupy.einsum('duDig->duDg', nablarho_response)
+            drho_dA_grid_response[i_atom_of_grids, :, :, 1:4, :] = nablarho_response
+        del nablarho_response
+
+    if with_tau:
+        tau_response = 0.5 * contract('dDig,uDig->duig', d2mu_dr2, dm_dot_dmu_and_dnu)
+        if with_orbital_response:
+            cupy.add.at(drho_dA_orbital_response[:, :, :, 4, :], masked_i_atom_of_aos, tau_response.transpose(2,0,1,3))
+        if with_grid_response:
+            tau_response = cupy.einsum('duig->dug', tau_response)
+            drho_dA_grid_response[i_atom_of_grids, :, :, 4, :] = tau_response
+        del tau_response
+
+    drho_dA_orbital_response *= -1
+
+    if xctype == "LDA":
+        if drho_dA_orbital_response is not None:
+            drho_dA_orbital_response = drho_dA_orbital_response[:, :, :, 0, :]
+        if drho_dA_grid_response is not None:
+            drho_dA_grid_response = drho_dA_grid_response[:, :, :, 0, :]
+    return drho_dA_orbital_response, drho_dA_grid_response
+
+def contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos = None, i_atom_of_grids = None,
+                               mu = None, dmu_dr = None, d2mu_dr2 = None, d3mu_dr3 = None,
+                               weight_depsilon_drho = None, weight_depsilon_dnablarho = None, weight_depsilon_dtau = None,
+                               with_orbital_response = True, with_grid_response = True):
+    """
+        This function is the unrestricted version of gpu4pyscf.hessian.rks.contract_d2rho_dAdB_sparse().
+    """
+    if xctype == "LDA":
+        with_nablarho = False
+        with_tau = False
+    elif xctype == "GGA":
+        with_nablarho = True
+        with_tau = False
+    elif xctype == "MGGA":
+        with_nablarho = True
+        with_tau = True
+    else:
+        raise NotImplementedError(f"Unrecognized xctype = {xctype}")
+
+    nao = dm0_masked.shape[-1]
+    assert dm0_masked.shape == (2, nao, nao)
+    assert mu is not None
+    ngrids = mu.shape[1]
+    assert mu.shape == (nao, ngrids)
+    assert dmu_dr is not None and dmu_dr.shape == (3, nao, ngrids)
+    assert d2mu_dr2 is not None and d2mu_dr2.shape == (3, 3, nao, ngrids)
+    if with_nablarho or with_tau:
+        assert d3mu_dr3 is not None and d3mu_dr3.shape == (3, 3, 3, nao, ngrids)
+
+    assert weight_depsilon_drho is not None and weight_depsilon_drho.shape == (2, ngrids)
+    if with_nablarho:
+        assert weight_depsilon_dnablarho is not None and weight_depsilon_dnablarho.shape == (2, 3, ngrids)
+    if with_tau:
+        assert weight_depsilon_dtau is not None and weight_depsilon_dtau.shape == (2, ngrids)
+
+    if with_orbital_response or with_grid_response: # There are cross terms in grid response
+        assert masked_i_atom_of_aos is not None
+        masked_i_atom_of_aos = cupy.asarray(masked_i_atom_of_aos, dtype = numpy.int32)
+        assert masked_i_atom_of_aos.shape == (nao,)
+    if with_grid_response:
+        assert i_atom_of_grids is not None
+        i_atom_of_grids = int(i_atom_of_grids)
+        assert 0 <= i_atom_of_grids and i_atom_of_grids < natm
+
+    dm_dmT = dm0_masked + dm0_masked.transpose(0,2,1)
+    dm_dot_mu = dm_dmT @ mu
+    dm_dot_dmudr = contract("uij,djg->udig", dm_dmT, dmu_dr)
+
+    d2e_ii_AA_ao_uncontracted = 0
+    d2V = 0
+    d2e_ji_AB_ao_uncontracted = 0
+
+    # d2mu/dAdB * nu
+    dm_mu_wv = contract("uig,ug->ig", dm_dot_mu, weight_depsilon_drho)
+    d2rhodAdG = contract("dDig,ig->dDi", d2mu_dr2, dm_mu_wv)
+    del dm_mu_wv
+    if with_orbital_response:
+        d2e_ii_AA_ao_uncontracted += d2rhodAdG
+    if with_grid_response:
+        d2e_ji_AB_ao_uncontracted += d2rhodAdG
+    del d2rhodAdG
+
+    # dmu/dA * dnu/dB
+    dmudr_wv = contract("dig,ug->udig", dmu_dr, weight_depsilon_drho)
+    if with_orbital_response:
+        d2rhodAdB = contract("dig,uDjg->udDij", dmu_dr, dmudr_wv)
+        d2V += d2rhodAdB
+        del d2rhodAdB
+    if with_grid_response:
+        d2rhodAdG = contract("udig,uDig->dDi", dmudr_wv, dm_dot_dmudr)
+        d2e_ji_AB_ao_uncontracted += d2rhodAdG
+        del d2rhodAdG
+    del dmudr_wv
+
+    if with_nablarho:
+        # d3mu/(dr dA dB) * nu
+        d3mudr3_wv = contract("dDxig,uxg->dDuig", d3mu_dr3, weight_depsilon_dnablarho)
+        d2nablarhodAdG = contract("dDuig,uig->dDi", d3mudr3_wv, dm_dot_mu)
+        del d3mudr3_wv
+        # d2mu/(dA dB) * dnu/dr
+        dm_dmudr_wv = contract("uxig,uxg->ig", dm_dot_dmudr, weight_depsilon_dnablarho)
+        d2nablarhodAdG += contract("dDig,ig->dDi", d2mu_dr2, dm_dmudr_wv)
+        del dm_dmudr_wv
+        d2mudr2_wv = contract("dxig,uxg->udig", d2mu_dr2, weight_depsilon_dnablarho)
+        if with_orbital_response:
+            d2e_ii_AA_ao_uncontracted += d2nablarhodAdG
+            # d2mu/(dr dA) * dnu/dB, A orbital, B orbital
+            d2mudr2_dnudr_wv = contract("udig,Djg->udDij", d2mudr2_wv, dmu_dr)
+            d2V += d2mudr2_dnudr_wv + d2mudr2_dnudr_wv.transpose(0,2,1,4,3)
+            del d2mudr2_dnudr_wv
+        if with_grid_response:
+            # d2mu/(dr dA) * dnu/dB, A orbital, B grid
+            d2nablarhodAdG += contract("udig,uDig->dDi", d2mudr2_wv, dm_dot_dmudr)
+            # d2mu/(dr dA) * dnu/dB, A grid, B orbital
+            dm_d2mudr2_wv = contract("uij,udjg->dig", dm_dmT, d2mudr2_wv)
+            d2nablarhodAdG += contract("dig,Dig->dDi", dmu_dr, dm_d2mudr2_wv)
+            del dm_d2mudr2_wv
+            d2e_ji_AB_ao_uncontracted += d2nablarhodAdG
+        del d2mudr2_wv
+        del d2nablarhodAdG
+
+    if with_tau:
+        # d3mu/(dA dB dr) * dnu/dr
+        dm_dmudr_wv = contract("udig,ug->dig", dm_dot_dmudr, weight_depsilon_dtau)
+        d2taudAdG = 0.5 * contract("dDxig,xig->dDi", d3mu_dr3, dm_dmudr_wv)
+        del dm_dmudr_wv
+        # d2mu/(dA dr) * d2nu/(dB dr)
+        d2mudr2_wv = contract("dxig,ug->udxig", d2mu_dr2, weight_depsilon_dtau)
+        d2mudAdr_d2nudBdr_wv = 0.5 * contract("dxig,uDxjg->udDij", d2mu_dr2, d2mudr2_wv)
+        del d2mudr2_wv
+        if with_orbital_response:
+            d2e_ii_AA_ao_uncontracted += d2taudAdG
+            d2V += d2mudAdr_d2nudBdr_wv
+        if with_grid_response:
+            d2taudAdG += contract("udDij,uij->dDi", d2mudAdr_d2nudBdr_wv, dm_dmT)
+            d2e_ji_AB_ao_uncontracted += d2taudAdG
+        del d2mudAdr_d2nudBdr_wv
+        del d2taudAdG
+
+    d2e = cupy.zeros([natm, natm, 3, 3])
+
+    if with_orbital_response:
+        d2e_ii_AA = cupy.zeros((natm, 3, 3))
+        d2e_ii_AA_ao_uncontracted = d2e_ii_AA_ao_uncontracted.transpose(2,0,1)
+        cupy.add.at(d2e_ii_AA, masked_i_atom_of_aos, d2e_ii_AA_ao_uncontracted)
+        del d2e_ii_AA_ao_uncontracted
+        for i_atom in range(natm):
+            d2e[i_atom, i_atom, :, :] += d2e_ii_AA[i_atom, :, :]
+        del d2e_ii_AA
+
+        d2V = contract("udDij,uij->dDij", d2V, dm_dmT)
+        d2V = d2V.transpose(2,3,0,1)
+        cupy.add.at(d2e, (masked_i_atom_of_aos[:, None], masked_i_atom_of_aos[None, :], slice(None), slice(None)), d2V)
+
+    if with_grid_response:
+        d2e[i_atom_of_grids, i_atom_of_grids, :, :] += cupy.einsum("dDi->dD", d2e_ji_AB_ao_uncontracted)
+
+        d2e_ji_AB = cupy.zeros((natm, 3, 3))
+        d2e_ji_AB_ao_uncontracted = d2e_ji_AB_ao_uncontracted.transpose(2,0,1)
+        cupy.add.at(d2e_ji_AB, masked_i_atom_of_aos, d2e_ji_AB_ao_uncontracted)
+        del d2e_ji_AB_ao_uncontracted
+        # Why is there a transpose for this equation? Because we're using j index at where it supposes to be i.
+        d2e[i_atom_of_grids, :, :, :] -= d2e_ji_AB.transpose(0,2,1)
+        d2e[:, i_atom_of_grids, :, :] -= d2e_ji_AB
+        del d2e_ji_AB
+
+    return d2e
+
 def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     """
         xc energy 2nd derivative grid response contribution
@@ -689,398 +926,305 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         grids = hessobj.grids
     else:
         grids = mf.grids
-    if grids.coords is None:
-        grids.build()
+    grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
 
+    ni.gdftopt = None
+    ni.build(mol, grids.coords)
+    opt = ni.gdftopt
+
+    _sorted_mol = opt._sorted_mol
+    nao = _sorted_mol.nao
     natm = mol.natm
-    aoslices = mol.aoslice_by_atom()
+    mol = None
 
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
     assert dm0.ndim == 3 and dm0.shape[0] == 2
+    dm0_sorted = opt.sort_orbitals(dm0, axis=[1,2])
+    dm_mask_buf = cupy.empty(2 * nao * nao)
+    dm0 = None
 
-    d2e = cupy.zeros([mol.natm, mol.natm, 3, 3])
+    nonzero_weight_mask = cupy.abs(grids.weights) > 1e-20 # There are d2rho/dAdB terms with very low weight but very big contribution
+
+    ao_loc_sorted = _sorted_mol.ao_loc
+    ao_expand = ao_loc_sorted[1:] - ao_loc_sorted[:-1]
+    from pyscf.gto.mole import ATOM_OF
+    i_atom_of_aos = numpy.repeat(_sorted_mol._bas[:,ATOM_OF], ao_expand)
+    i_atom_of_aos = cupy.asarray(i_atom_of_aos, dtype = cupy.int32)
+
+    d2e = cupy.zeros([natm, natm, 3, 3])
 
     if xctype == 'LDA':
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((1) * mol.nao + (9) * mol.natm * mol.natm + 2) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for LDA energy second derivative, available gpu memory = {get_avail_mem()}"
-                              f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 0, gdftopt = None, transpose = False)
-            rhoa = numint.eval_rho2(mol, split_ao, mo_coeff[0], mo_occ[0], xctype=xctype)
-            rhob = numint.eval_rho2(mol, split_ao, mo_coeff[1], mo_occ[1], xctype=xctype)
+            if ao.size == 0:
+                g0 = g1
+                continue
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            rhoa = numint.eval_rho(_sorted_mol, ao, dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao, dm0_masked[1], xctype = xctype, hermi = 1)
             rho = cupy.asarray((rhoa, rhob))
             exc = ni.eval_xc_eff(mf.xc, rho, deriv = 0, xctype=xctype)[0]
-            rho = None
+            del rho
 
             epsilon = exc[:, 0] * (rhoa + rhob)
-            rhoa = None
-            rhob = None
-            exc = None
+            del rhoa, rhob, exc
 
-            d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
+            d2w_dAdB = get_d2weight_dAdB(_sorted_mol, grids, (g0,g1))
             d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
-            d2w_dAdB = None
-            epsilon = None
+            del d2w_dAdB, epsilon
+            g0 = g1
+        assert g1 == ngrids
 
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((10 + 9 + 2 + 4*4) * mol.nao + (3*3 + 3) * mol.natm + 3 + 1 + 18*4) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for LDA energy second derivative, available gpu memory = {get_avail_mem()}"
-                              f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 2, gdftopt = None, transpose = False)
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
 
-            mu = split_ao[0]
-            dmu_dr = split_ao[1:4]
-            d2mu_dr2 = get_d2mu_dr2(split_ao)
+            if ao.size == 0:
+                g0 = g1
+                continue
 
-            rhoa = numint.eval_rho2(mol, mu, mo_coeff[0], mo_occ[0], xctype=xctype)
-            rhob = numint.eval_rho2(mol, mu, mo_coeff[1], mo_occ[1], xctype=xctype)
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            rhoa = numint.eval_rho(_sorted_mol, ao[0], dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao[0], dm0_masked[1], xctype = xctype, hermi = 1)
             rho = cupy.asarray((rhoa, rhob))
-            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype=xctype)[1:3]
-            rho = None
-            rhoa = None
-            rhob = None
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype = xctype)[1:3]
+            del rhoa, rhob, rho
 
             depsilon_drho = vxc[:,0,:] # Just of shape (2,ngrids)
-            d2epsilon_drho2 = fxc[:,0,:,0,:] # Just of shape (2,2,ngrids)
 
-            grid_to_atom_index_map = grids.atm_idx[g0:g1]
-            atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-            grid_to_atom_index_map = None
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
 
-            drho_dA_orbital_response = cp.zeros((2, natm, 3, g1-g0))
-            drho_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-            for i_dm in range(2):
-                drho_dA_orbital_response_i, drho_dA_grid_response_i = \
-                    get_drho_dA_full(dm0[i_dm], xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr)
-                drho_dA_orbital_response[i_dm] = drho_dA_orbital_response_i
-                drho_dA_grid_response[i_dm] = drho_dA_grid_response_i
-                drho_dA_orbital_response_i = None
-                drho_dA_grid_response_i = None
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
 
-            drho_dA_full = drho_dA_orbital_response + drho_dA_grid_response
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
 
-            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-            depsilondrho_drhodA = contract("uAdg,ug->Adg", drho_dA_full, depsilon_drho)
-            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, depsilondrho_drhodA)
-            depsilondrho_drhodA = None
-            drho_dA_full = None
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response)
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full_response)
+            drhodA_v = contract("Adug,ug->Adg", drho_dA_full_response, depsilon_drho)
+            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, drhodA_v)
+            del dw_dA, drhodA_v
             d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
-            d2e_dwdA_term = None
-            dw_dA = None
+            del d2e_dwdA_term
 
-            weight = grids.weights[g0:g1]
-            drhodA_grid_response_weight_d2epsilondrho2 = contract("uAdg,uvg->vAdg", drho_dA_grid_response, d2epsilon_drho2 * weight)
-            d2e_drhodA_cross_term = contract("uAdg,uBDg->ABdD", drho_dA_orbital_response, drhodA_grid_response_weight_d2epsilondrho2)
-            drho_dA_orbital_response = None
-            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
-            d2e_drhodA_cross_term += contract("uAdg,uBDg->ABdD", drho_dA_grid_response, drhodA_grid_response_weight_d2epsilondrho2)
-            drho_dA_grid_response = None
-            drhodA_grid_response_weight_d2epsilondrho2 = None
-            d2e += d2e_drhodA_cross_term
-            d2e_drhodA_cross_term = None
+            weight = weight[nonzero_weight_mask[g0:g1]]
+            fwxc = fxc[:,0,:,0,:] * weight # Just of shape (2,2,ngrids)
+            del fxc
+            drhodA_fw = contract("Adug,uvg->Advg", drho_dA_full_response, fwxc)
+            del fwxc
+            d2e += contract("Adug,BDug->ABdD", drho_dA_full_response, drhodA_fw)
+            del drhodA_fw, drho_dA_full_response
 
-            for i_dm in range(2):
-                d2e += contract_d2rho_dAdB_full(dm0[i_dm], xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
-                                                mu, dmu_dr, d2mu_dr2, None,
-                                                depsilon_drho[i_dm] * weight,
-                                                with_orbital_response = False)
+            d2e += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                                              mu, dmu_dr, d2mu_dr2, None,
+                                              depsilon_drho * weight)
+
+            g0 = g1
+        assert g1 == ngrids
 
     elif xctype == 'GGA':
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((4) * mol.nao + (9) * mol.natm * mol.natm + 4 + 1*2) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for GGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                              f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 1, gdftopt = None, transpose = False)
+            if ao.size == 0:
+                g0 = g1
+                continue
 
-            rho_drhoa = numint.eval_rho2(mol, split_ao, mo_coeff[0], mo_occ[0], xctype=xctype)
-            rho_drhob = numint.eval_rho2(mol, split_ao, mo_coeff[1], mo_occ[1], xctype=xctype)
-            rho_drho = cupy.asarray((rho_drhoa, rho_drhob))
-            rho_drhoa = None
-            rho_drhob = None
-            exc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 0, xctype=xctype)[0]
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            rhoa = numint.eval_rho(_sorted_mol, ao, dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao, dm0_masked[1], xctype = xctype, hermi = 1)
+            rho = cupy.asarray((rhoa, rhob))
+            exc = ni.eval_xc_eff(mf.xc, rho, deriv = 0, xctype=xctype)[0]
+            del rho
 
-            rho = rho_drho[:,0]
-            rho_drho = None
+            epsilon = exc[:, 0] * (rhoa[0, :] + rhob[0, :])
+            del rhoa, rhob, exc
 
-            epsilon = exc[:, 0] * (rho[0] + rho[1])
-            rho = None
-            exc = None
-
-            d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
+            d2w_dAdB = get_d2weight_dAdB(_sorted_mol, grids, (g0,g1))
             d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
-            d2w_dAdB = None
-            epsilon = None
+            del d2w_dAdB, epsilon
+            g0 = g1
+        assert g1 == ngrids
 
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((20 + 9 + 27 + 2 + 3*2 + 4*4 + 12*4) * mol.nao
-                              + (3*3 + 9*3 + 3 + 2*3 + 4*2*3) * mol.natm + 4*2 + 16*2 + 18*4 + 27*2*4) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for GGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                              f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 3, gdftopt = None, transpose = False)
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
 
-            mu = split_ao[0]
-            dmu_dr = split_ao[1:4]
-            d2mu_dr2 = get_d2mu_dr2(split_ao)
-            d3mu_dr3 = get_d3mu_dr3(split_ao)
+            if ao.size == 0:
+                g0 = g1
+                continue
 
-            rho_drhoa = numint.eval_rho2(mol, split_ao, mo_coeff[0], mo_occ[0], xctype=xctype)
-            rho_drhob = numint.eval_rho2(mol, split_ao, mo_coeff[1], mo_occ[1], xctype=xctype)
-            rho_drho = cupy.asarray((rho_drhoa, rho_drhob))
-            rho_drhoa = None
-            rho_drhob = None
-            vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho, deriv = 2, xctype=xctype)[1:3]
-            rho_drho = None
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            rhoa = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[1], xctype = xctype, hermi = 1)
+            rho = cupy.asarray((rhoa, rhob))
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype = xctype)[1:3]
+            del rhoa, rhob, rho
 
             depsilon_drho = vxc[:, 0, :]
             depsilon_dnablarho = vxc[:, 1:4, :]
 
-            grid_to_atom_index_map = grids.atm_idx[g0:g1]
-            atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-            grid_to_atom_index_map = None
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
 
-            drho_dA_orbital_response = cp.zeros((2, natm, 3, g1-g0))
-            drho_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-            dnablarho_dA_orbital_response = cp.zeros((2, natm, 3, 3, g1-g0))
-            dnablarho_dA_grid_response = cp.zeros((2, natm, 3, 3, g1-g0))
-            for i_dm in range(2):
-                drho_dA_orbital_response_i, dnablarho_dA_orbital_response_i, drho_dA_grid_response_i, dnablarho_dA_grid_response_i = \
-                    get_drho_dA_full(dm0[i_dm], xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2)
-                drho_dA_orbital_response[i_dm] = drho_dA_orbital_response_i
-                drho_dA_grid_response[i_dm] = drho_dA_grid_response_i
-                dnablarho_dA_orbital_response[i_dm] = dnablarho_dA_orbital_response_i
-                dnablarho_dA_grid_response[i_dm] = dnablarho_dA_grid_response_i
-                drho_dA_orbital_response_i = None
-                drho_dA_grid_response_i = None
-                dnablarho_dA_orbital_response_i = None
-                dnablarho_dA_grid_response_i = None
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
 
-            drho_dA_full = drho_dA_orbital_response + drho_dA_grid_response
-            dnablarho_dA_full = dnablarho_dA_orbital_response + dnablarho_dA_grid_response
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
 
-            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-            depsilondnablarho_dnablarhodA = contract("uxg,uAdxg->Adg", depsilon_dnablarho, dnablarho_dA_full)
-            dnablarho_dA_full = None
-            depsilondrho_drhodA = contract("uAdg,ug->Adg", drho_dA_full, depsilon_drho)
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->ABdD", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->BADd", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            depsilondrho_drhodA = contract("ug,Adug->Adg", depsilon_drho, drho_dA_full_response[:,:,:,0,:])
+            depsilondnablarho_dnablarhodA = contract("uxg,Aduxg->Adg", depsilon_dnablarho, drho_dA_full_response[:,:,:,1:4,:])
             d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, depsilondrho_drhodA + depsilondnablarho_dnablarhodA)
-            depsilondrho_drhodA = None
-            drho_dA_full = None
-            depsilondnablarho_dnablarhodA = None
-            dw_dA = None
+            del depsilondrho_drhodA, depsilondnablarho_dnablarhodA
+            del dw_dA
             d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
-            d2e_dwdA_term = None
+            del d2e_dwdA_term
 
-            weight = grids.weights[g0:g1]
-            combined_d_dA_orbital_response = cupy.concatenate((drho_dA_orbital_response[:, :, :, None, :], dnablarho_dA_orbital_response), axis = 3)
-            combined_d_dA_grid_response    = cupy.concatenate((   drho_dA_grid_response[:, :, :, None, :],    dnablarho_dA_grid_response), axis = 3)
-            drho_dA_orbital_response = None
-            dnablarho_dA_orbital_response = None
-            drho_dA_grid_response = None
-            dnablarho_dA_grid_response = None
+            weight = weight[nonzero_weight_mask[g0:g1]]
             fwxc = fxc * weight
-            fxc = None
+            del fxc
+            drhodA_fwxc = contract("uxvyg,Advyg->Aduxg", fwxc, drho_dA_full_response)
+            del fwxc
+            d2e += contract("Aduxg,BDuxg->ABdD", drho_dA_full_response, drhodA_fwxc)
+            del drhodA_fwxc, drho_dA_full_response
 
-            drhodA_grid_response_fwxc = contract("uxvyg,vAdyg->uAdxg", fwxc, combined_d_dA_grid_response)
-            fwxc = None
-            d2e_drhodA_cross_term = contract("uAdxg,uBDxg->ABdD", combined_d_dA_orbital_response, drhodA_grid_response_fwxc)
-            combined_d_dA_orbital_response = None
-            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
-            d2e_drhodA_cross_term += contract("uAdxg,uBDxg->ABdD", combined_d_dA_grid_response, drhodA_grid_response_fwxc)
-            combined_d_dA_grid_response = None
-            drhodA_grid_response_fwxc = None
-            d2e += d2e_drhodA_cross_term
-            d2e_drhodA_cross_term = None
+            d2e += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                                              mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                                              depsilon_drho * weight, depsilon_dnablarho * weight)
 
-            for i_dm in range(2):
-                d2e += contract_d2rho_dAdB_full(dm0[i_dm], xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
-                                                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
-                                                depsilon_drho[i_dm] * weight, depsilon_dnablarho[i_dm] * weight,
-                                                with_orbital_response = False)
+            g0 = g1
+        assert g1 == ngrids
 
     elif xctype == 'MGGA':
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((4) * mol.nao + (9) * mol.natm * mol.natm + 5 + 1*2) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for mGGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                              f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 1, gdftopt = None, transpose = False)
+            if ao.size == 0:
+                g0 = g1
+                continue
 
-            rho_drho_taua = numint.eval_rho2(mol, split_ao, mo_coeff[0], mo_occ[0], xctype=xctype)
-            rho_drho_taub = numint.eval_rho2(mol, split_ao, mo_coeff[1], mo_occ[1], xctype=xctype)
-            rho_drho_tau = cupy.asarray((rho_drho_taua, rho_drho_taub))
-            rho_drho_taua = None
-            rho_drho_taub = None
-            exc = ni.eval_xc_eff(mf.xc, rho_drho_tau, deriv = 0, xctype=xctype)[0]
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+            rhoa = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[1], xctype = xctype, hermi = 1)
+            rho = cupy.asarray((rhoa, rhob))
+            exc = ni.eval_xc_eff(mf.xc, rho, deriv = 0, xctype=xctype)[0]
+            del rho
 
-            rho = rho_drho_tau[:, 0]
-            rho_drho_tau = None
+            epsilon = exc[:, 0] * (rhoa[0, :] + rhob[0, :])
+            del rhoa, rhob, exc
 
-            epsilon = exc[:, 0] * (rho[0] + rho[1])
-            rho = None
-            exc = None
-
-            d2w_dAdB = get_d2weight_dAdB(mol, grids, (g0,g1))
+            d2w_dAdB = get_d2weight_dAdB(_sorted_mol, grids, (g0,g1))
             d2e += contract("ABdDg,g->ABdD", d2w_dAdB, epsilon)
-            d2w_dAdB = None
-            epsilon = None
+            del d2w_dAdB, epsilon
+            g0 = g1
+        assert g1 == ngrids
 
-        available_gpu_memory = get_avail_mem()
-        available_gpu_memory = int(available_gpu_memory * 0.5) # Don't use too much gpu memory
-        ao_nbytes_per_grid = ((20 + 9 + 27 + 2 + 3*2 + 4*4 + 12*4 + 9*4) * mol.nao
-                              + (3*3 + 9*3 + 3*3 + 3 + 3*3 + 5*2*3) * mol.natm + 5*2 + 25*2 + 18*4 + 27*2*4 + 18*4) * 8
-        ngrids_per_batch = int(available_gpu_memory / ao_nbytes_per_grid)
-        if ngrids_per_batch < 16:
-            raise MemoryError(f"Out of GPU memory for mGGA energy second derivative, available gpu memory = {get_avail_mem()}"
-                              f" bytes, nao = {mol.nao}, natm = {mol.natm}, ngrids = {ngrids}")
-        ngrids_per_batch = (ngrids_per_batch + 16 - 1) // 16 * 16
-        ngrids_per_batch = min(ngrids_per_batch, min_grid_blksize)
+        g0 = 0
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+            g1 = g0 + weight.shape[0]
 
-        for g0 in range(0, ngrids, ngrids_per_batch):
-            g1 = min(g0 + ngrids_per_batch, ngrids)
-            split_grids_coords = grids.coords[g0:g1, :]
-            split_ao = numint.eval_ao(mol, split_grids_coords, deriv = 3, gdftopt = None, transpose = False)
+            ao = ao[:, :, nonzero_weight_mask[g0:g1]]
 
-            mu = split_ao[0]
-            dmu_dr = split_ao[1:4]
-            d2mu_dr2 = get_d2mu_dr2(split_ao)
-            d3mu_dr3 = get_d3mu_dr3(split_ao)
+            if ao.size == 0:
+                g0 = g1
+                continue
 
-            rho_drho_taua = numint.eval_rho2(mol, split_ao, mo_coeff[0], mo_occ[0], xctype=xctype)
-            rho_drho_taub = numint.eval_rho2(mol, split_ao, mo_coeff[1], mo_occ[1], xctype=xctype)
-            rho_drho_tau = cupy.asarray((rho_drho_taua, rho_drho_taub))
-            rho_drho_taua = None
-            rho_drho_taub = None
-            vxc, fxc = ni.eval_xc_eff(mf.xc, rho_drho_tau, deriv = 2, xctype=xctype)[1:3]
-            rho_drho_tau = None
+            mu = ao[0]
+            dmu_dr = ao[1:4]
+            d2mu_dr2 = get_d2mu_dr2(ao)
+            d3mu_dr3 = get_d3mu_dr3(ao)
+
+            dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
+
+            rhoa = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[0], xctype = xctype, hermi = 1)
+            rhob = numint.eval_rho(_sorted_mol, ao[:4], dm0_masked[1], xctype = xctype, hermi = 1)
+            rho = cupy.asarray((rhoa, rhob))
+            vxc, fxc = ni.eval_xc_eff(mf.xc, rho, deriv = 2, xctype = xctype)[1:3]
+            del rhoa, rhob, rho
 
             depsilon_drho = vxc[:, 0, :]
             depsilon_dnablarho = vxc[:, 1:4, :]
             depsilon_dtau = vxc[:, 4, :]
 
-            grid_to_atom_index_map = grids.atm_idx[g0:g1]
-            atom_to_grid_index_map = [cupy.where(grid_to_atom_index_map == i_atom)[0] for i_atom in range(natm)]
-            grid_to_atom_index_map = None
+            i_atom_of_grids = int(grids.atm_idx[g0])
+            assert cupy.max(cupy.abs(grids.atm_idx[g0:g1] - i_atom_of_grids)) == 0 # Guaranteed by grids.build(sort_grids_of_each_atom = True)
 
-            drho_dA_orbital_response = cp.zeros((2, natm, 3, g1-g0))
-            drho_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-            dnablarho_dA_orbital_response = cp.zeros((2, natm, 3, 3, g1-g0))
-            dnablarho_dA_grid_response = cp.zeros((2, natm, 3, 3, g1-g0))
-            dtau_dA_orbital_response = cp.zeros((2, natm, 3, g1-g0))
-            dtau_dA_grid_response = cp.zeros((2, natm, 3, g1-g0))
-            for i_dm in range(2):
-                drho_dA_orbital_response_i, dnablarho_dA_orbital_response_i, dtau_dA_orbital_response_i, \
-                    drho_dA_grid_response_i, dnablarho_dA_grid_response_i, dtau_dA_grid_response_i = \
-                    get_drho_dA_full(dm0[i_dm], xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map, mu, dmu_dr, d2mu_dr2)
-                drho_dA_orbital_response[i_dm] = drho_dA_orbital_response_i
-                drho_dA_grid_response[i_dm] = drho_dA_grid_response_i
-                dnablarho_dA_orbital_response[i_dm] = dnablarho_dA_orbital_response_i
-                dnablarho_dA_grid_response[i_dm] = dnablarho_dA_grid_response_i
-                dtau_dA_orbital_response[i_dm] = dtau_dA_orbital_response_i
-                dtau_dA_grid_response[i_dm] = dtau_dA_grid_response_i
-                drho_dA_orbital_response_i = None
-                drho_dA_grid_response_i = None
-                dnablarho_dA_orbital_response_i = None
-                dnablarho_dA_grid_response_i = None
-                dtau_dA_orbital_response_i = None
-                dtau_dA_grid_response_i = None
+            masked_i_atom_of_aos = i_atom_of_aos[idx]
 
-            drho_dA_full = drho_dA_orbital_response + drho_dA_grid_response
-            dnablarho_dA_full = dnablarho_dA_orbital_response + dnablarho_dA_grid_response
-            dtau_dA_full = dtau_dA_orbital_response + dtau_dA_grid_response
+            drho_dA_orbital_response, drho_dA_grid_response = \
+                get_drho_dA_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids, mu, dmu_dr, d2mu_dr2)
+            drho_dA_full_response = drho_dA_orbital_response + drho_dA_grid_response
+            del drho_dA_orbital_response, drho_dA_grid_response
 
-            dw_dA = get_dweight_dA(mol, grids, (g0,g1))
-            depsilondnablarho_dnablarhodA = contract("uxg,uAdxg->Adg", depsilon_dnablarho, dnablarho_dA_full)
-            dnablarho_dA_full = None
-            depsilondrho_drhodA = contract("uAdg,ug->Adg", drho_dA_full, depsilon_drho)
-            depsilondtau_drhodA = contract("uAdg,ug->Adg", dtau_dA_full, depsilon_dtau)
-            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA, depsilondrho_drhodA + depsilondnablarho_dnablarhodA + depsilondtau_drhodA)
-            depsilondrho_drhodA = None
-            depsilondtau_drhodA = None
-            drho_dA_full = None
-            dtau_dA_full = None
-            depsilondnablarho_dnablarhodA = None
-            dw_dA = None
+            dw_dA = get_dweight_dA(_sorted_mol, grids, (g0,g1))
+            dw_dA = dw_dA[:, :, nonzero_weight_mask[g0:g1]]
+
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_drho, drho_dA_full_response[:,:,0,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->ABdD", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            # d2e += cupy.einsum("Adg,xg,BDxg->BADd", dw_dA, depsilon_dnablarho, drho_dA_full_response[:,:,1:4,:])
+            # d2e += cupy.einsum("Adg,g,BDg->ABdD", dw_dA, depsilon_dtau, drho_dA_full_response[:,:,4,:])
+            # d2e += cupy.einsum("Adg,g,BDg->BADd", dw_dA, depsilon_dtau, drho_dA_full_response[:,:,4,:])
+            depsilondrho_drhodA = contract("ug,Adug->Adg", depsilon_drho, drho_dA_full_response[:,:,:,0,:])
+            depsilondnablarho_dnablarhodA = contract("uxg,Aduxg->Adg", depsilon_dnablarho, drho_dA_full_response[:,:,:,1:4,:])
+            depsilondtau_dtaudA = contract("ug,Adug->Adg", depsilon_dtau, drho_dA_full_response[:,:,:,4,:])
+            d2e_dwdA_term = contract("Adg,BDg->ABdD", dw_dA,
+                depsilondrho_drhodA + depsilondnablarho_dnablarhodA + depsilondtau_dtaudA)
+            del depsilondrho_drhodA, depsilondnablarho_dnablarhodA, depsilondtau_dtaudA
+            del dw_dA
             d2e += d2e_dwdA_term + d2e_dwdA_term.transpose(1,0,3,2)
-            d2e_dwdA_term = None
+            del d2e_dwdA_term
 
-            weight = grids.weights[g0:g1]
-            combined_d_dA_orbital_response = cupy.concatenate(
-                (drho_dA_orbital_response[:, :, :, None, :], dnablarho_dA_orbital_response, dtau_dA_orbital_response[:, :, :, None, :]),
-                axis = 3
-            )
-            combined_d_dA_grid_response    = cupy.concatenate(
-                (   drho_dA_grid_response[:, :, :, None, :],    dnablarho_dA_grid_response,    dtau_dA_grid_response[:, :, :, None, :]),
-                axis = 3
-            )
-            drho_dA_orbital_response = None
-            dnablarho_dA_orbital_response = None
-            dtau_dA_orbital_response = None
-            drho_dA_grid_response = None
-            dnablarho_dA_grid_response = None
-            dtau_dA_grid_response = None
+            weight = weight[nonzero_weight_mask[g0:g1]]
             fwxc = fxc * weight
-            fxc = None
+            del fxc
+            drhodA_fwxc = contract("uxvyg,Advyg->Aduxg", fwxc, drho_dA_full_response)
+            del fwxc
+            d2e += contract("Aduxg,BDuxg->ABdD", drho_dA_full_response, drhodA_fwxc)
+            del drhodA_fwxc, drho_dA_full_response
 
-            drhodA_grid_response_fwxc = contract("uxvyg,vAdyg->uAdxg", fwxc, combined_d_dA_grid_response)
-            fwxc = None
-            d2e_drhodA_cross_term = contract("uAdxg,uBDxg->ABdD", combined_d_dA_orbital_response, drhodA_grid_response_fwxc)
-            combined_d_dA_orbital_response = None
-            d2e_drhodA_cross_term += d2e_drhodA_cross_term.transpose(1,0,3,2)
-            d2e_drhodA_cross_term += contract("uAdxg,uBDxg->ABdD", combined_d_dA_grid_response, drhodA_grid_response_fwxc)
-            combined_d_dA_grid_response = None
-            drhodA_grid_response_fwxc = None
-            d2e += d2e_drhodA_cross_term
-            d2e_drhodA_cross_term = None
+            d2e += contract_d2rho_dAdB_sparse(dm0_masked, xctype, natm, masked_i_atom_of_aos, i_atom_of_grids,
+                                              mu, dmu_dr, d2mu_dr2, d3mu_dr3,
+                                              depsilon_drho * weight, depsilon_dnablarho * weight, depsilon_dtau * weight)
 
-            for i_dm in range(2):
-                d2e += contract_d2rho_dAdB_full(dm0[i_dm], xctype, natm, g1 - g0, aoslices, atom_to_grid_index_map,
-                                                mu, dmu_dr, d2mu_dr2, d3mu_dr3,
-                                                depsilon_drho[i_dm] * weight, depsilon_dnablarho[i_dm] * weight, depsilon_dtau[i_dm] * weight,
-                                                with_orbital_response = False)
+            g0 = g1
+        assert g1 == ngrids
 
     elif xctype == 'HF':
         pass

--- a/gpu4pyscf/hessian/uks.py
+++ b/gpu4pyscf/hessian/uks.py
@@ -919,13 +919,14 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     mol = hessobj.mol
     mf = hessobj.base
-    ni = mf._numint
+    ni = numint.NumInt()
     xctype = ni._xc_type(mf.xc)
 
     if hessobj.grids is not None:
         grids = hessobj.grids
     else:
         grids = mf.grids
+    grids = grids.copy()
     grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
 
@@ -1435,13 +1436,14 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
 def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
     mol = hessobj.mol
     mf = hessobj.base
-    ni = mf._numint
+    ni = numint.NumInt()
     xctype = ni._xc_type(mf.xc)
 
     if hessobj.grids is not None:
         grids = hessobj.grids
     else:
         grids = mf.grids
+    grids = grids.copy()
     grids.build(sort_grids_of_each_atom = True)
     ngrids = grids.coords.shape[0]
 


### PR DESCRIPTION
- [x] energy second derivative
- [x] Fock first derivative
- [x]  Unrestricted KS

Change to non-Hessian API: add `strict_grid_order` argument to `numint.block_loop()` function, so I can control it not skipping any grid, even if all AO evaluates to zero. It is necessary to match the grid order for weight derivatives.