### PR TITLE
Improve PBC RSJK efficiency by including more works in the LR part

### DIFF
--- a/gpu4pyscf/lib/pbc/create_tasks.cu
+++ b/gpu4pyscf/lib/pbc/create_tasks.cu
@@ -99,7 +99,6 @@ void _fill_sr_vk_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
     float omega = kmat.omega;
     float omega2 = omega * omega;
     float theta_ij = omega2 * aij / (aij + omega2);
-    float nbas_inv = 1.0000002f / nbas_cell0;
 
     extern __shared__ double shared_memory[];
     int *swap = (int *)shared_memory;
@@ -124,8 +123,8 @@ void _fill_sr_vk_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
             int lsh = bas_kl % NBAS_MAX;
             int _ksh = bas_mask_idx[ksh];
             int _lsh = bas_mask_idx[lsh];
-            int cell_k = _ksh * nbas_inv;
-            int cell_l = _lsh * nbas_inv;
+            int cell_k = _ksh / nbas_cell0;
+            int cell_l = _lsh / nbas_cell0;
             int ksh_cell0 = _ksh - cell_k * nbas_cell0;
             int lsh_cell0 = _lsh - cell_l * nbas_cell0;
             keep &= bas_ij_cell0 >= ksh_cell0*nbas_cell0+lsh_cell0;
@@ -243,7 +242,6 @@ void _fill_sr_ejk_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
     float omega = jk.omega;
     float omega2 = omega * omega;
     float theta_ij = omega2 * aij / (aij + omega2);
-    float nbas_inv = 1.0000002f / nbas_cell0;
     int do_j = jk.j_factor != 0;
     int do_k = jk.k_factor != 0;
 
@@ -266,8 +264,8 @@ void _fill_sr_ejk_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
             int lsh = bas_kl % NBAS_MAX;
             int _ksh = bas_mask_idx[ksh];
             int _lsh = bas_mask_idx[lsh];
-            int cell_k = _ksh * nbas_inv;
-            int cell_l = _lsh * nbas_inv;
+            int cell_k = _ksh / nbas_cell0;
+            int cell_l = _lsh / nbas_cell0;
             int ksh_cell0 = _ksh - cell_k * nbas_cell0;
             int lsh_cell0 = _lsh - cell_l * nbas_cell0;
             keep &= bas_ij_cell0 >= ksh_cell0*nbas_cell0+lsh_cell0;

--- a/gpu4pyscf/lib/pbc/create_tasks.cu
+++ b/gpu4pyscf/lib/pbc/create_tasks.cu
@@ -99,7 +99,7 @@ void _fill_sr_vk_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
     float omega = kmat.omega;
     float omega2 = omega * omega;
     float theta_ij = omega2 * aij / (aij + omega2);
-    float nbas_inv = 1.f / nbas_cell0;
+    float nbas_inv = 1.0000002f / nbas_cell0;
 
     extern __shared__ double shared_memory[];
     int *swap = (int *)shared_memory;
@@ -243,7 +243,7 @@ void _fill_sr_ejk_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
     float omega = jk.omega;
     float omega2 = omega * omega;
     float theta_ij = omega2 * aij / (aij + omega2);
-    float nbas_inv = 1.f / nbas_cell0;
+    float nbas_inv = 1.0000002f / nbas_cell0;
     int do_j = jk.j_factor != 0;
     int do_k = jk.k_factor != 0;
 

--- a/gpu4pyscf/lib/pbc/ft_ao.cu
+++ b/gpu4pyscf/lib/pbc/ft_ao.cu
@@ -300,10 +300,10 @@ void ft_aopair_kernel(double *out, PBCIntEnvVars envs, double *pool, int *shl_pa
         }
         __syncthreads();
 
-        double *expi = env + bas[ish*BAS_SLOTS+PTR_EXP];
-        double *expj = env + bas[jsh*BAS_SLOTS+PTR_EXP];
-        double *ci = env + bas[ish*BAS_SLOTS+PTR_COEFF];
-        double *cj = env + bas[jsh*BAS_SLOTS+PTR_COEFF];
+        int expi = bas[ish*BAS_SLOTS+PTR_EXP];
+        int expj = bas[jsh*BAS_SLOTS+PTR_EXP];
+        int ci = bas[ish*BAS_SLOTS+PTR_COEFF];
+        int cj = bas[jsh*BAS_SLOTS+PTR_COEFF];
         double *ri = env + bas[ish*BAS_SLOTS+PTR_BAS_COORD];
         double *rj = env + bas[jsh*BAS_SLOTS+PTR_BAS_COORD];
         double xi = ri[0];
@@ -325,13 +325,13 @@ void ft_aopair_kernel(double *out, PBCIntEnvVars envs, double *pool, int *shl_pa
         for (int ijp = 0; ijp < ijprim; ++ijp) {
             int ip = ijp / jprim;
             int jp = ijp % jprim;
-            double ai = expi[ip];
-            double aj = expj[jp];
+            double ai = env[expi+ip];
+            double aj = env[expj+jp];
             double aij = ai + aj;
             double aj_aij = aj / aij;
             double theta_ij = ai * aj_aij;
             double a2 = .5 / aij;
-            double fac = OVERLAP_FAC * ci[ip] * cj[jp] / (aij * sqrt(aij));
+            double fac = OVERLAP_FAC * env[ci+ip] * env[cj+jp] / (aij * sqrt(aij));
             for (int img = img0; img < img0+img_max; img++) {
                 __syncthreads();
                 int img_id = 0;

--- a/gpu4pyscf/lib/pbc/rys_contract_j.cu
+++ b/gpu4pyscf/lib/pbc/rys_contract_j.cu
@@ -85,7 +85,6 @@ void _fill_sr_vj_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
     float omega = jmat.omega;
     float omega2 = omega * omega;
     float theta_ij = omega2 * aij / (aij + omega2);
-    float nbas_inv = 1.0000002f / nbas_cell0;
 
     extern __shared__ double shared_memory[];
     int *swap = (int *)shared_memory;
@@ -106,8 +105,8 @@ void _fill_sr_vj_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
             int lsh = bas_kl % NBAS_MAX;
             int _ksh = bas_mask_idx[ksh];
             int _lsh = bas_mask_idx[lsh];
-            int cell_k = _ksh * nbas_inv;
-            int cell_l = _lsh * nbas_inv;
+            int cell_k = _ksh / nbas_cell0;
+            int cell_l = _lsh - nbas_cell0 * cell_k;
             int ksh_cell0 = _ksh - cell_k * nbas_cell0;
             int lsh_cell0 = _lsh - cell_l * nbas_cell0;
             keep &= bas_ij_cell0 >= ksh_cell0*nbas_cell0+lsh_cell0;

--- a/gpu4pyscf/lib/pbc/rys_contract_j.cu
+++ b/gpu4pyscf/lib/pbc/rys_contract_j.cu
@@ -106,7 +106,7 @@ void _fill_sr_vj_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
             int _ksh = bas_mask_idx[ksh];
             int _lsh = bas_mask_idx[lsh];
             int cell_k = _ksh / nbas_cell0;
-            int cell_l = _lsh - nbas_cell0 * cell_k;
+            int cell_l = _lsh / nbas_cell0;
             int ksh_cell0 = _ksh - cell_k * nbas_cell0;
             int lsh_cell0 = _lsh - cell_l * nbas_cell0;
             keep &= bas_ij_cell0 >= ksh_cell0*nbas_cell0+lsh_cell0;

--- a/gpu4pyscf/lib/pbc/rys_contract_j.cu
+++ b/gpu4pyscf/lib/pbc/rys_contract_j.cu
@@ -85,7 +85,7 @@ void _fill_sr_vj_tasks(int &ntasks, int &pair_kl0, int64_t *bas_kl_idx,
     float omega = jmat.omega;
     float omega2 = omega * omega;
     float theta_ij = omega2 * aij / (aij + omega2);
-    float nbas_inv = 1.f / nbas_cell0;
+    float nbas_inv = 1.0000002f / nbas_cell0;
 
     extern __shared__ double shared_memory[];
     int *swap = (int *)shared_memory;

--- a/gpu4pyscf/lib/pbc/supmol_sr_estimator.cu
+++ b/gpu4pyscf/lib/pbc/supmol_sr_estimator.cu
@@ -482,7 +482,7 @@ void sort_pair_ij_kernel(int64_t *pair_ij, int *ish, int *jsh, int nish, int njs
     size_t off = i_tile * tile * (size_t)njsh;
     // when nish not divisible by tile
     int nish_rem = min(tile, nish - i_tile * tile);
-    float div_tile = 1.f / tile;
+    float div_tile = 1.0000002f / tile;
     float div_tile2 = div_tile / nish_rem;
     int tile2 = nish_rem * tile;
     for (int n = t_id; n < nish_rem*njsh; n += threads) {

--- a/gpu4pyscf/lib/pbc/supmol_sr_estimator.cu
+++ b/gpu4pyscf/lib/pbc/supmol_sr_estimator.cu
@@ -482,13 +482,11 @@ void sort_pair_ij_kernel(int64_t *pair_ij, int *ish, int *jsh, int nish, int njs
     size_t off = i_tile * tile * (size_t)njsh;
     // when nish not divisible by tile
     int nish_rem = min(tile, nish - i_tile * tile);
-    float div_tile = 1.0000002f / tile;
-    float div_tile2 = div_tile / nish_rem;
     int tile2 = nish_rem * tile;
     for (int n = t_id; n < nish_rem*njsh; n += threads) {
-        int j_tile = n * div_tile2;
+        int j_tile = n / tile2;
         int ijr = n - j_tile * tile2;
-        int ir = ijr * div_tile;
+        int ir = ijr / tile;
         int jr = ijr - ir * tile;
         int njsh_rem = njsh - j_tile * tile;
         if (njsh_rem < tile) { // when njsh not divisible by tile

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_grad_krhf.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_grad_krhf.py
@@ -70,7 +70,7 @@ class KnownValues(unittest.TestCase):
         mfs = mf.as_scanner()
         e1 = mfs([['H', [0.0, 0.0, 0.0]], ['H', [1.5,1.5,1.1+disp/2.0]]])
         e2 = mfs([['H', [0.0, 0.0, 0.0]], ['H', [1.5,1.5,1.1-disp/2.0]]])
-        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, delta=1e-6)
+        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, delta=5e-6)
 
     def test_rhf_with_pseudo_grad(self):
         mf = cell.RHF().to_gpu()
@@ -93,7 +93,7 @@ class KnownValues(unittest.TestCase):
         g1 = mf.Gradients().kernel()
         self.assertAlmostEqual(g1[1,2], -0.125769199473623, 6)
         self.assertAlmostEqual(lib.fp(g1), -0.087662458760762, 6)
-        self.assertAlmostEqual(abs(g1 - g).max(), 0, 7)
+        self.assertAlmostEqual(abs(g1 - g).max(), 0, 6)
 
     def test_df_rhf_grad(self):
         cell = gto.Cell()

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_grad_kuhf.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_grad_kuhf.py
@@ -66,7 +66,7 @@ class KnownValues(unittest.TestCase):
         mfs = mf.as_scanner()
         e1 = mfs([['H', [0.0, 0.0, 0.0]], ['H', [1.5,1.5,1.1+disp/2.0]]])
         e2 = mfs([['H', [0.0, 0.0, 0.0]], ['H', [1.5,1.5,1.1-disp/2.0]]])
-        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, delta=1e-6)
+        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, delta=5e-6)
 
     def test_uhf_with_pseudo_grad(self):
         mf = cell.UHF().to_gpu()
@@ -82,7 +82,7 @@ class KnownValues(unittest.TestCase):
         e1 = mfs(atom_coords)
         atom_coords[1,2] -= disp
         e2 = mfs(atom_coords)
-        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, 6)
+        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, delta=5e-6)
 
         mf = cell.UHF().to_gpu()
         mf.with_df = AFTDF(cell)

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_grad_kuks.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_grad_kuks.py
@@ -377,7 +377,7 @@ class KnownValues(unittest.TestCase):
         mf.rsjk = PBCJKMatrixOpt(cell_no_pseudo)
         mf.j_engine = PBCJMatrixOpt(cell_no_pseudo)
         g = mf.Gradients().kernel()
-        self.assertAlmostEqual(abs(g - ref).max(), 0, delta=1e-6)
+        self.assertAlmostEqual(abs(g - ref).max(), 0, delta=5e-6)
 
 if __name__ == "__main__":
     print("Full Tests for KUKS Gradients")

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_grad_rks.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_grad_rks.py
@@ -275,7 +275,7 @@ class KnownValues(unittest.TestCase):
         mfs = mf.as_scanner()
         e1 = mfs([['Be', [0.0, 0.0, 0.0]], ['Be', [0.5,0.2,1.0+disp/2.0]]])
         e2 = mfs([['Be', [0.0, 0.0, 0.0]], ['Be', [0.5,0.2,1.0-disp/2.0]]])
-        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, 5)
+        self.assertAlmostEqual(g[1,2], (e1-e2)/disp, delta=1e-5)
 
     def test_wb97_grad(self):
         # ref = numerical_gradient(cell_orth, xc='wb97')

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_uks_stress.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_uks_stress.py
@@ -186,7 +186,7 @@ class KnownValues(unittest.TestCase):
         a += np.random.rand(3, 3) - .5
         cell = gto.M(atom='H 1 1 1; H 2 1.5 2.4',
                      basis=[[0, [1.5, 1]], [0, [.5, 1]], [1, [.8, 1]]],
-                     a=a, unit='Bohr', verbose=0)
+                     a=a, unit='Bohr', verbose=0, precision=1e-10)
         xc = 'pbe0'
         mf = cell.UKS(xc=xc).to_gpu()
         mf.j_engine = PBCJMatrixOpt(cell)

--- a/gpu4pyscf/pbc/scf/j_engine.py
+++ b/gpu4pyscf/pbc/scf/j_engine.py
@@ -34,7 +34,7 @@ from gpu4pyscf.gto.mole import groupby, extract_pgto_params, SortedCell
 from gpu4pyscf.scf.jk import (
     libvhf_rys, _vhf, RysIntEnvVars, _scale_sp_ctr_coeff, _nearest_power2)
 from gpu4pyscf.scf.j_engine import (
-    libvhf_md, _make_tile_max_hierarchy, _to_primitive_bas, THREADS, SHM_SIZE, LMAX)
+    libvhf_md, _make_tile_max_hierarchy, THREADS, SHM_SIZE, LMAX)
 from gpu4pyscf.pbc.df.fft import _check_kpts
 from gpu4pyscf.pbc.tools.pbc import get_coulG
 from gpu4pyscf.pbc.scf.rsjk import (

--- a/gpu4pyscf/pbc/scf/rsjk.py
+++ b/gpu4pyscf/pbc/scf/rsjk.py
@@ -220,7 +220,7 @@ class PBCJKMatrixOpt:
         # contribute to the kl-pair near the cutoff edges. Accurate estimation
         # for their contributions is hard to derive. Numerical tests show that
         # the contribution is approximately proportional to 1/(exp_min**3*vol**2).
-        double_lat_sum_penalty = max(1, 1e7/(exp_min**3*vol**2))
+        double_lat_sum_penalty = max(1, 1e6/(exp_min**3*vol**2))
         cutoff = precision / (lattice_sum_factor + double_lat_sum_penalty)
         logger.debug1(cell, 'rsjk integral theta=%g cutoff=%g '
                       'lattice_sum_factor=%g double_lat_sum_penalty=%g',
@@ -2049,7 +2049,7 @@ def _search_diffuse_pairs(cell, mesh):
         _pair_max = cp.abs(Gpq[0]).max(axis=0)
         _pair_max = condense('absmax', _pair_max, cell.ao_loc)
         pair_max = cp.where(pair_max > _pair_max, pair_max, _pair_max)
-    precision = cell.precision * 1e-1 * cell.vol
+    precision = cell.precision * max(1, 1e-2 * cell.vol)
     pair_mask = pair_max < precision
     return pair_mask
 
@@ -2280,7 +2280,7 @@ def _guess_omega(cell, kpts=None):
     else:
         nkpts = len(kpts)
     nao = cell.nao_nr(cart=True)
-    ng = int(5e4/(nao*nkpts**.6))
+    ng = int(5e4/(nao*nkpts**.65))
     ng = (max(3, ng) // 2) * 2 + 1
     if ng >= 11:
         ke_cutoff = estimate_ke_cutoff_for_omega(cell, OMEGA)

--- a/gpu4pyscf/pbc/scf/rsjk.py
+++ b/gpu4pyscf/pbc/scf/rsjk.py
@@ -2282,7 +2282,7 @@ def _guess_omega(cell, kpts=None):
     nao = cell.nao_nr(cart=True)
     ng = int(5e4/(nao*nkpts**.6))
     ng = (max(3, ng) // 2) * 2 + 1
-    if ng > 11:
+    if ng >= 11:
         ke_cutoff = estimate_ke_cutoff_for_omega(cell, OMEGA)
         mesh = cell.cutoff_to_mesh(ke_cutoff)
         mesh[mesh>ng] = ng

--- a/gpu4pyscf/pbc/scf/rsjk.py
+++ b/gpu4pyscf/pbc/scf/rsjk.py
@@ -2288,7 +2288,7 @@ def _guess_omega(cell, kpts=None):
     else:
         nkpts = len(kpts)
     nao = cell.nao_nr(cart=True)
-    ng = int(3.5e4/(nao*nkpts**.667))
+    ng = int(5e4/(nao*nkpts**.6))
     ng = (max(3, ng) // 2) * 2 + 1
     if ng >= 11:
         ke_cutoff = estimate_ke_cutoff_for_omega(cell, OMEGA)

--- a/gpu4pyscf/pbc/scf/rsjk.py
+++ b/gpu4pyscf/pbc/scf/rsjk.py
@@ -62,7 +62,7 @@ libpbc.PBC_per_atom_jk_ip1.restype = ctypes.c_int
 libpbc.PBC_jk_strain_deriv.restype = ctypes.c_int
 
 DD_CACHE_MAX = 101250 * (SHM_SIZE//48000)
-OMEGA = 0.5
+OMEGA = 0.4
 NBAS_MAX = 1048576
 Q_COND_MARGIN = 4.
 
@@ -220,7 +220,7 @@ class PBCJKMatrixOpt:
         # contribute to the kl-pair near the cutoff edges. Accurate estimation
         # for their contributions is hard to derive. Numerical tests show that
         # the contribution is approximately proportional to 1/(exp_min**3*vol**2).
-        double_lat_sum_penalty = max(1, 1e6/(exp_min**3*vol**2))
+        double_lat_sum_penalty = max(1, 1e7/(exp_min**3*vol**2))
         cutoff = precision / (lattice_sum_factor + double_lat_sum_penalty)
         logger.debug1(cell, 'rsjk integral theta=%g cutoff=%g '
                       'lattice_sum_factor=%g double_lat_sum_penalty=%g',

--- a/gpu4pyscf/pbc/scf/rsjk.py
+++ b/gpu4pyscf/pbc/scf/rsjk.py
@@ -62,7 +62,7 @@ libpbc.PBC_per_atom_jk_ip1.restype = ctypes.c_int
 libpbc.PBC_jk_strain_deriv.restype = ctypes.c_int
 
 DD_CACHE_MAX = 101250 * (SHM_SIZE//48000)
-OMEGA = 0.4
+OMEGA = 0.5
 NBAS_MAX = 1048576
 Q_COND_MARGIN = 4.
 
@@ -2028,7 +2028,7 @@ def _search_diffuse_pairs(cell, mesh):
     # Here, we directly evaluate the ft_aopair, and test whether the
     # contributions of G vectors at the edge can be discarded.
     mesh = np.asarray(mesh)
-    nx, ny, nz = mesh // 2
+    nx, ny, nz = (mesh+1) // 2
     mask = np.zeros(mesh+2, dtype=bool)
     mask[nx:nx+2,:,:] = True
     mask[:,ny:ny+2,:] = True
@@ -2041,7 +2041,7 @@ def _search_diffuse_pairs(cell, mesh):
     unit = cell.nao**2*2
     Gblksize = min(ngrids, int(avail_mem/(16*unit)))
     ft_opt = FTOpt(cell)
-    ft_opt.rcut = cell.rcut / 2
+    ft_opt.rcut = cell.rcut / 2 # reduce accuracy for an estimation of ke_cutoff
     ft_kern = ft_opt.gen_ft_kernel(transform_ao=False)
     pair_max = cp.zeros((cell.nbas, cell.nbas))
     for p0, p1 in lib.prange(0, ngrids, Gblksize):
@@ -2049,10 +2049,8 @@ def _search_diffuse_pairs(cell, mesh):
         _pair_max = cp.abs(Gpq[0]).max(axis=0)
         _pair_max = condense('absmax', _pair_max, cell.ao_loc)
         pair_max = cp.where(pair_max > _pair_max, pair_max, _pair_max)
-    # Seems LR integrals are more tolerable to the ke_cut errors. This setting
-    # can be further adjusted to include more orbital pairs in the LR part.
-    precision = cell.precision*1e2
-    pair_mask = pair_max < precision*cell.vol
+    precision = cell.precision * 1e-1 * cell.vol
+    pair_mask = pair_max < precision
     return pair_mask
 
 def _Ls_to_Bvk_Ts(supmol, kmesh):
@@ -2284,7 +2282,7 @@ def _guess_omega(cell, kpts=None):
     nao = cell.nao_nr(cart=True)
     ng = int(5e4/(nao*nkpts**.6))
     ng = (max(3, ng) // 2) * 2 + 1
-    if ng >= 11:
+    if ng > 11:
         ke_cutoff = estimate_ke_cutoff_for_omega(cell, OMEGA)
         mesh = cell.cutoff_to_mesh(ke_cutoff)
         mesh[mesh>ng] = ng

--- a/gpu4pyscf/pbc/scf/rsjk.py
+++ b/gpu4pyscf/pbc/scf/rsjk.py
@@ -120,6 +120,7 @@ class PBCJKMatrixOpt:
 
         self.omega = omega
         self.mesh = None
+        self.ke_cutoff = None
         self.supmol = None
         self.exclude_dd_block = True
 
@@ -156,17 +157,18 @@ class PBCJKMatrixOpt:
         if self.mesh is None: # when self.omega is specified by user
             ke_cutoff = estimate_ke_cutoff_for_omega(cell.cell, self.omega)
             self.mesh = cell.cutoff_to_mesh(ke_cutoff)
+        if self.ke_cutoff is None:
+            self.ke_cutoff = ke_cutoff
 
         cell.omega = -self.omega
         log.debug1('PBCJKMatrixOpt.build: omega = %g mesh = %s ke_cutoff = %g',
-                   self.omega, self.mesh, ke_cutoff)
+                   self.omega, self.mesh, self.ke_cutoff)
 
         self.supmol = ExtendedMole.from_cell(cell, self.omega)
 
         pair_mask = None
         if self.exclude_dd_block:
-            Ecut = _orbital_pair_Ecut(cell)
-            pair_mask = Ecut < ke_cutoff
+            pair_mask = _search_diffuse_pairs(cell, self.mesh)
             nao = cell.nao
             bas_ij_idx = np.where(pair_mask.ravel().get())[0]
             bas_ij_idx = np.asarray(bas_ij_idx, dtype=np.int32)
@@ -218,7 +220,7 @@ class PBCJKMatrixOpt:
         # contribute to the kl-pair near the cutoff edges. Accurate estimation
         # for their contributions is hard to derive. Numerical tests show that
         # the contribution is approximately proportional to 1/(exp_min**3*vol**2).
-        double_lat_sum_penalty = max(1, 1e7/(exp_min**3*vol**2))
+        double_lat_sum_penalty = max(1, 1e6/(exp_min**3*vol**2))
         cutoff = precision / (lattice_sum_factor + double_lat_sum_penalty)
         logger.debug1(cell, 'rsjk integral theta=%g cutoff=%g '
                       'lattice_sum_factor=%g double_lat_sum_penalty=%g',
@@ -2015,51 +2017,43 @@ def estimate_rcut(cell, omega, precision=None):
     rcut = r0
     return rcut
 
-def _orbital_pair_Ecut(cell):
+def _search_diffuse_pairs(cell, mesh):
     '''Return a mask identifying orbital pairs that can be converged within
-    cell.precision using the specified kinetic-energy cutoff in AFT Coulomb
-    formula.
+    cell.precision using the specified grids mesh in AFT Coulomb integrals.
     '''
-    nbas = cell.nbas
-    #:rirj = bas_coords[:,None,:] - bas_coords
-    #:dr = cp.linalg.norm(rirj, axis=2)
-    Ts = lib.cartesian_prod([np.array([-1, 0, 1])] * 3)
-    Ls = np.dot(Ts, cell.lattice_vectors())
-    bas_coords = cell.atom_coords()[cell._bas[:,gto.ATOM_OF]]
-    bas_coords = asarray(bas_coords + Ls[:,None,:]).reshape(-1,3)
-    dr = dist_matrix(bas_coords, bas_coords)
-    dr = dr.reshape(27,nbas,27,nbas).min(axis=(0,2))
+    # The cutoff estimation
+    #     exp(-G^2/(4*(ai+aj))) cs[:,None]*cs * exp(-theta*dr**2)
+    # is effective for orbital pairs with large ai+aj. However, its inaccurate
+    # for diffuse orbital pairs due to the contribution of lattice summation.
+    # Here, we directly evaluate the ft_aopair, and test whether the
+    # contributions of G vectors at the edge can be discarded.
+    mesh = np.asarray(mesh)
+    nx, ny, nz = mesh // 2
+    mask = np.zeros(mesh+2, dtype=bool)
+    mask[nx:nx+2,:,:] = True
+    mask[:,ny:ny+2,:] = True
+    mask[:,:,nz:nz+2] = True
+    Gv = cell.get_Gv(mesh + 2)
+    Gv = Gv[mask.ravel()]
+    ngrids = len(Gv)
 
-    rad = cell.vol**(-1./3) * cell.rcut + 1
-    surface = 4*np.pi * rad**2
-
-    es, cs = extract_pgto_params(cell, op='compact')
-    es = asarray(es)
-    cs = asarray(cs)
-    ls = asarray(cell._bas[:,gto.ANG_OF])
-    li = ls[:,None]
-    lj = ls
-    aij = es[:,None] + es
-    fi = es[:,None] / aij
-    fj = es[None,:] / aij
-    theta = es[:,None] * fj
-    # Factors for Ecut estimation should be
-    #     fac ~ cs[:,None]*cs * cp.exp(-theta*dr**2) * fac_dri * fac_drj
-    # where
-    #     fac_dri = (li * .5/aij + dri**2 + Ecut/2/aij**2)**(li*.5)
-    #             ~= (li * .5/aij + dri**2 + log(1./precision)/aij)**(li*.5)
-    #     fac_drj = (lj * .5/aij + drj**2 + Ecut/2/aij**2)**(lj*.5)
-    #             ~= (lj * .5/aij + drj**2 + log(1./precision)/aij)**(lj*.5)
-    dri = fj * dr
-    drj = fi * dr
-    G2_fac = math.log(surface/cell.precision) / aij # = (G/(2*aij))^2
-    fac_dri = (li*.5) * cp.log(li * .5/aij + dri**2 + G2_fac)
-    fac_drj = (lj*.5) * cp.log(lj * .5/aij + drj**2 + G2_fac)
-    fac_norm = cp.log(cs[:,None]*cs) + 1.5*cp.log(np.pi/aij)
-    log_ovlp = fac_norm - theta*dr**2 + fac_dri + fac_drj
-    log_fac = log_ovlp + math.log(surface/cell.precision)
-    Ecut = log_fac * (2*aij)
-    return Ecut
+    avail_mem = int(get_avail_mem(exclude_memory_pool=True) * .9)
+    unit = cell.nao**2*2
+    Gblksize = min(ngrids, int(avail_mem/(16*unit)))
+    ft_opt = FTOpt(cell)
+    ft_opt.rcut = cell.rcut / 2
+    ft_kern = ft_opt.gen_ft_kernel(transform_ao=False)
+    pair_max = cp.zeros((cell.nbas, cell.nbas))
+    for p0, p1 in lib.prange(0, ngrids, Gblksize):
+        Gpq = ft_kern(Gv[p0:p1])
+        _pair_max = cp.abs(Gpq[0]).max(axis=0)
+        _pair_max = condense('absmax', _pair_max, cell.ao_loc)
+        pair_max = cp.where(pair_max > _pair_max, pair_max, _pair_max)
+    # Seems LR integrals are more tolerable to the ke_cut errors. This setting
+    # can be further adjusted to include more orbital pairs in the LR part.
+    precision = cell.precision*1e2
+    pair_mask = pair_max < precision*cell.vol
+    return pair_mask
 
 def _Ls_to_Bvk_Ts(supmol, kmesh):
     cell = supmol.cell
@@ -2319,10 +2313,13 @@ def estimate_ke_cutoff_for_omega(cell, omega, precision=None):
     # sum_(G^2>Ecut) 4*pi/G^2 exp(-G^2/(4*omega^2))
     #     ~ 16\pi^2 \int_sqrt(2*Ecut)^inf exp(-G^2/(4*omega^2)) dG
     #     < 16\pi^2 * 2*omega^2 / sqrt(2*Ecut) exp(-Ecut/(2*omega^2))
-    fac = 16*np.pi**2 * 2*omega**2 / precision
+    exps, cs = extract_pgto_params(cell, 'compact')
+    exp_max = exps.max()
+    theta = 1./(1./(4*exp_max) + omega**-2)
+    fac = 16*np.pi**2/cell.vol * 2*theta / precision
     Ecut = 20.
-    Ecut = math.log(fac / (2*Ecut)**.5) * 2*omega**2
-    Ecut = math.log(fac / (2*Ecut)**.5) * 2*omega**2
+    Ecut = math.log(fac / (2*Ecut)**.5) * 2*theta
+    Ecut = math.log(fac / (2*Ecut)**.5) * 2*theta
     return Ecut
 
 def estimate_omega_for_ke_cutoff(cell, ke_cutoff, precision=None):
@@ -2333,10 +2330,14 @@ def estimate_omega_for_ke_cutoff(cell, ke_cutoff, precision=None):
     # estimation based on \int dk 4pi/k^2 exp(-k^2/4omega) sometimes is not
     # enough to converge the 2-electron integrals. A penalty term here is to
     # reduce the error in integrals
-    fac = 16*np.pi**2 / (2*ke_cutoff)**.5 / precision
+    exps, cs = extract_pgto_params(cell, 'compact')
+    exp_max = exps.max()
+    fac = 16*np.pi**2/cell.vol / (2*ke_cutoff)**.5 / precision
     omega = 0.5
-    omega = (.5 * ke_cutoff / math.log(fac*2*omega**2))**.5
-    omega = (.5 * ke_cutoff / math.log(fac*2*omega**2))**.5
+    theta = 1./(1./(4*exp_max) + omega**-2)
+    omega = (.5 * ke_cutoff / math.log(fac*2*theta))**.5
+    theta = 1./(1./(4*exp_max) + omega**-2)
+    omega = (.5 * ke_cutoff / math.log(fac*2*theta))**.5
     return omega
 
 def _group_by_split_points(q_cond, split_points):

--- a/gpu4pyscf/pbc/scf/tests/test_pbc_scf_jk.py
+++ b/gpu4pyscf/pbc/scf/tests/test_pbc_scf_jk.py
@@ -372,7 +372,7 @@ def test_vk_hermi0_gamma_point_vs_fft():
     cell.precision = 1e-10
     cell.build(0, 0)
     ref = fft.FFTDF(cell).get_jk(dm, hermi=0, with_j=False)[1].get()
-    assert abs(vk - ref).max() < 1e-8
+    assert abs(vk - ref).max() < 3e-8
 
 def test_vk_hermi0_kpts_vs_fft():
     cell = pyscf.M(
@@ -842,7 +842,7 @@ def test_ejk_strain_deriv_kpts():
     sigma+= with_rsjk._get_ejk_lr_strain_deriv(dm1, kpts=kpts, exxdiv='ewald')
     ref = aft_jk.get_ej_strain_deriv(mydf, dm1, kpts=kpts)
     ref-= aft_jk.get_ek_strain_deriv(mydf, dm1, kpts=kpts, exxdiv='ewald')
-    assert abs(ref - sigma).max() < 1e-6
+    assert abs(ref - sigma).max() < 3e-6
 
     def rsjk_sigma(dm, omega, exxdiv, lr_factor, sr_factor, kpts=None):
         with_rsjk = rsjk.PBCJKMatrixOpt(cell, 0.7).build(kpts=kpts)

--- a/gpu4pyscf/pbc/scf/tests/test_pbc_scf_jk.py
+++ b/gpu4pyscf/pbc/scf/tests/test_pbc_scf_jk.py
@@ -58,7 +58,7 @@ def test_sr_vk_hermi1_gamma_point_vs_cpu():
     omega = rsjk.OMEGA
     ref = with_rsjk.build(omega)._get_jk_sr(
         dm, hermi=1, kpts=np.zeros((1,3)), with_j=False)[0,0]
-    assert abs(vk - ref).max() < 1e-8
+    assert abs(vk - ref).max() < 3e-8
 
 def test_sr_vk_hermi1_kpts_vs_cpu():
     cell = pyscf.M(
@@ -797,14 +797,14 @@ def test_ejk_strain_deriv_gamma_point():
     # The error might be above 1e-7, to 1e-6 due to the reduced precision
     # settings estimate_cutoff_with_penalty(cell.precision**.5*1e-2)
     # in _get_ejk_sr_strain_deriv
-    assert abs(ref - sigma).max() < 1e-6
+    assert abs(ref - sigma).max() < 5e-6
 
     dm = cp.array([dm, dm])
     sigma = with_rsjk._get_ejk_sr_strain_deriv(dm)
     sigma+= with_rsjk._get_ejk_lr_strain_deriv(dm)
     ref = aft_jk.get_ej_strain_deriv(mydf, dm)
     ref-= aft_jk.get_ek_strain_deriv(mydf, dm)
-    assert abs(ref - sigma).max() < 2e-6
+    assert abs(ref - sigma).max() < 2e-5
 
 def test_ejk_strain_deriv_kpts():
     from gpu4pyscf.pbc.grad.rks_stress import _finite_diff_cells


### PR DESCRIPTION
* Using a more accurate energy-cutoff estimator to filter the diffuse orbital pairs. More diffuse-orbital pairs are evaluated using the AFT-get_jk formula.
* Fix orbital pair indexing bugs caused by the limited precision of float32 type.