### PR TITLE
Update auxiliary basis linear dependency treatment in PBC GDF

### DIFF
--- a/gpu4pyscf/pbc/df/rsdf_builder.py
+++ b/gpu4pyscf/pbc/df/rsdf_builder.py
@@ -50,9 +50,9 @@ from gpu4pyscf.pbc.df.int2c2e import sr_int2c2e
 # crystal orbitals have large impacts on the accuracy of Coulomb integrals. A
 # tight linear dependency threshold have to be applied to control the error,
 # even this may cause more numerical stability issues.
-LINEAR_DEP_THR = 1e-11
+LINEAR_DEP_THR = 1e-8
 # Use eigenvalue decomposition in decompose_j2c
-PREFER_ED = False
+PREFER_ED = True
 
 THREADS = 256
 

--- a/gpu4pyscf/pbc/df/tests/test_rsdf_builder.py
+++ b/gpu4pyscf/pbc/df/tests/test_rsdf_builder.py
@@ -55,7 +55,8 @@ C    D
     }
     auxcell.build()
     omega = 0.3
-    gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts=None)
+    with lib.temporary_env(rsdf_builder, PREFER_ED=False):
+        gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts=None)
 
     cell.precision = 1e-10
     auxcell.precision = 1e-10
@@ -109,7 +110,8 @@ C    D
     omega = 0.3
     kmesh = [6,1,1]
     kpts = cell.make_kpts(kmesh)
-    gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts)
+    with lib.temporary_env(rsdf_builder, PREFER_ED=False):
+        gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts)
 
     cell.precision = 1e-10
     auxcell.precision = 1e-10
@@ -162,7 +164,8 @@ C    D
     auxcell.build()
     kmesh = [1,3,4]
     kpts = cell.make_kpts(kmesh)
-    gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts, j_only=True)
+    with lib.temporary_env(rsdf_builder, PREFER_ED=False):
+        gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts, j_only=True)
 
     cell.precision = 1e-10
     auxcell.precision = 1e-10
@@ -215,8 +218,9 @@ C    D
     }
     auxcell.build()
     omega = 0.2
-    dat, dat_neg, idx = rsdf_builder.compressed_cderi_gamma_point(
-        cell, auxcell, omega=-omega)
+    with lib.temporary_env(rsdf_builder, PREFER_ED=False):
+        dat, dat_neg, idx = rsdf_builder.compressed_cderi_gamma_point(
+            cell, auxcell, omega=-omega)
     cp.cuda.get_current_stream().synchronize()
     assert abs(lib.fp(abs(dat[0])) - 3.25766577810573) < 1e-8
 
@@ -431,7 +435,8 @@ C    D
     omega = 0.2
     kmesh = [3,1,1]
     kpts = cell.make_kpts(kmesh)
-    gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts, omega=omega)
+    with lib.temporary_env(rsdf_builder, PREFER_ED=False):
+        gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts, omega=omega)
 
     auxcell.omega = cell.omega = -omega
     cell.precision = 1e-10
@@ -535,7 +540,8 @@ C    D
     omega = 0.2
     kmesh = [3,1,1]
     kpts = cell.make_kpts(kmesh)
-    gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts, omega=omega, j_only=True)
+    with lib.temporary_env(rsdf_builder, PREFER_ED=False):
+        gpu_dat, dat_neg = build_cderi(cell, auxcell, kpts, omega=omega, j_only=True)
 
     auxcell.omega = cell.omega = -omega
     cell.precision = 1e-10

--- a/gpu4pyscf/pbc/dft/tests/test_pbc_rks.py
+++ b/gpu4pyscf/pbc/dft/tests/test_pbc_rks.py
@@ -18,7 +18,7 @@ import numpy as np
 import cupy as cp
 from pyscf.pbc import gto as pbcgto
 from pyscf.pbc.dft import UniformGrids
-from pyscf.lib import unpack_tril
+from pyscf.lib import unpack_tril, temporary_env
 from gpu4pyscf.pbc import dft as pbcdft
 from gpu4pyscf.pbc.scf.rsjk import PBCJKMatrixOpt
 from gpu4pyscf.pbc.scf.j_engine import PBCJMatrixOpt
@@ -114,9 +114,11 @@ class KnownValues(unittest.TestCase):
 
     def test_lda_gdf(self):
         from pyscf.pbc.df.df import _load3c
+        from gpu4pyscf.pbc.df import rsdf_builder
         cell = self.cell
         xc = 'svwn'
-        mf = pbcdft.RKS(cell, xc=xc).density_fit().run()
+        with temporary_env(rsdf_builder, PREFER_ED=False):
+            mf = pbcdft.RKS(cell, xc=xc).density_fit().run()
         pcell = cell.copy()
         pcell.precision = 1e-10
         mf_ref = pcell.RKS(xc=xc).density_fit()


### PR DESCRIPTION
Previously, cholesky decomposition is used for PBC GDF. The default method is changed to eigenvalue decomposition, and linearly dependent basis functions are removed by default.
