### PR TITLE
Change DF gradient routine full/short-range j2c inversion algorithm to CD

### DIFF
--- a/gpu4pyscf/df/grad/rhf.py
+++ b/gpu4pyscf/df/grad/rhf.py
@@ -35,9 +35,10 @@ def _gen_metric_solver(int2c, decompose_j2c='CD', lindep=df.LINEAR_DEP_THR):
         try:
             j2c = cholesky(int2c)
             def j2c_solver(b):
-                out = solve_triangular(j2c, b.reshape(j2c.shape[0],-1), lower=True,
-                                        overwrite_b=False).reshape(b.shape)
-                return cp.asarray(out, order='A')
+                b_ = b.reshape(j2c.shape[0], -1)
+                y = solve_triangular(j2c, b_, lower=True, overwrite_b=False)
+                x = solve_triangular(j2c.conj().T, y, lower=False, overwrite_b=False)
+                return cp.asarray(x.reshape(b.shape), order='A')
             return j2c_solver
         except RuntimeError:
             pass
@@ -118,7 +119,7 @@ def _jk_energy_per_atom(int3c2e_opt, dm, j_factor=1, k_factor=1, hermi=0,
 
     j2c = int2c2e(auxmol)
     if mol.omega <= 0 and not auxmol.mol.cart:
-        metric = aux_coeff.dot(cp.linalg.solve(j2c, aux_coeff.T))
+        metric = aux_coeff.dot(_gen_metric_solver(j2c, 'CD')(aux_coeff.T))
     else:
         metric = aux_coeff.dot(_gen_metric_solver(j2c, 'ED')(aux_coeff.T))
     j2c = aux_coeff = None
@@ -252,7 +253,7 @@ def _j_energy_per_atom(int3c2e_opt, dm, hermi=0, auxbasis_response=True, verbose
 
     auxvec = auxmol.CT_dot_mat(auxvec)
     if mol.omega <= 0 and not auxmol.mol.cart:
-        auxvec = cp.linalg.solve(j2c, auxvec)
+        auxvec = _gen_metric_solver(j2c, 'CD')(auxvec)
     else:
         auxvec = _gen_metric_solver(j2c, 'ED')(auxvec)
     auxvec = auxmol.C_dot_mat(auxvec)

--- a/gpu4pyscf/df/grad/tdrhf.py
+++ b/gpu4pyscf/df/grad/tdrhf.py
@@ -97,7 +97,7 @@ def _jk_energy_per_atom(int3c2e_opt, dms, j_factor=None, k_factor=None, hermi=0,
 
     j2c = int2c2e(auxmol)
     if mol.omega <= 0 and not auxmol.mol.cart:
-        metric = aux_coeff.dot(cp.linalg.solve(j2c, aux_coeff.T))
+        metric = aux_coeff.dot(_gen_metric_solver(j2c, 'CD')(aux_coeff.T))
     else:
         metric = aux_coeff.dot(_gen_metric_solver(j2c, 'ED')(aux_coeff.T))
     j2c = aux_coeff = None
@@ -236,7 +236,7 @@ def _j_energy_per_atom(int3c2e_opt, dms, j_factor, hermi=0, verbose=None):
     n_dm = len(dms)
     assert len(j_factor) == n_dm
     if mol.omega <= 0 and not auxmol.mol.cart:
-        auxvec = cp.linalg.solve(j2c, auxvec.T).T
+        auxvec = _gen_metric_solver(j2c, 'CD')(auxvec.T).T
     else:
         auxvec = _gen_metric_solver(j2c, 'ED')(auxvec.T).T
     auxvec = cp.asarray(auxmol.apply_C_dot(auxvec, axis=1), order='C')
@@ -449,7 +449,7 @@ def _jk_energies_by_dm_factors(int3c2e_opt, dm_factors, j_factor, k_factor,
 
     j2c = int2c2e(auxmol)
     if mol.omega <= 0 and not auxmol.mol.cart:
-        metric = aux_coeff.dot(cp.linalg.solve(j2c, aux_coeff.T))
+        metric = aux_coeff.dot(_gen_metric_solver(j2c, 'CD')(aux_coeff.T))
     else:
         metric = aux_coeff.dot(_gen_metric_solver(j2c, 'ED')(aux_coeff.T))
     j2c = aux_coeff = None
@@ -631,7 +631,7 @@ def _j_energies_per_atom(int3c2e_opt, dm_pairs, j_factor,
     j2c = int2c2e(auxmol)
 
     if mol.omega <= 0 and not auxmol.mol.cart:
-        auxvec = cp.linalg.solve(j2c, auxvec.T).T
+        auxvec = _gen_metric_solver(j2c, 'CD')(auxvec.T).T
     else:
         auxvec = _gen_metric_solver(j2c, 'ED')(auxvec.T).T
     auxvec = cp.asarray(auxmol.apply_C_dot(auxvec, axis=1), order='C')

--- a/gpu4pyscf/df/grad/uhf.py
+++ b/gpu4pyscf/df/grad/uhf.py
@@ -96,7 +96,7 @@ def _jk_energy_per_atom(int3c2e_opt, dm, j_factor=1, k_factor=1, hermi=0,
 
     j2c = int2c2e(auxmol)
     if mol.omega <= 0 and not auxmol.mol.cart:
-        metric = aux_coeff.dot(cp.linalg.solve(j2c, aux_coeff.T))
+        metric = aux_coeff.dot(_gen_metric_solver(j2c, 'CD')(aux_coeff.T))
     else:
         metric = aux_coeff.dot(_gen_metric_solver(j2c, 'ED')(aux_coeff.T))
     j2c = aux_coeff = None

--- a/gpu4pyscf/df/tests/test_df_rhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_rhf_grad.py
@@ -219,12 +219,12 @@ class KnownValues(unittest.TestCase):
         ek1 = _jk_energy_per_atom(opt, tag_array(dm, mo_coeff=mo_coeff, mo_occ=mo_occ),
                                   j_factor=1, k_factor=1, hermi=1)
         assert abs(ek - ek1).max() < 1e-9
-        assert abs(lib.fp(ek) - -24.366562704166753) < 2e-9
+        assert abs(lib.fp(ek) - -24.366562704166753) < 3e-9
 
         # mimic insufficent memory, processing in small batches
         with lib.temporary_env(df_rhf_grad, get_avail_mem=(lambda **kw: 3000000)):
             ek = _jk_energy_per_atom(opt, dm, j_factor=1, k_factor=1, hermi=1)
-        assert abs(lib.fp(ek) - -24.366562704166753) < 2e-9
+        assert abs(lib.fp(ek) - -24.366562704166753) < 3e-9
 
         disp = 1e-3
         atom_coords = mol.atom_coords()

--- a/gpu4pyscf/df/tests/test_df_rhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_rhf_grad.py
@@ -219,12 +219,12 @@ class KnownValues(unittest.TestCase):
         ek1 = _jk_energy_per_atom(opt, tag_array(dm, mo_coeff=mo_coeff, mo_occ=mo_occ),
                                   j_factor=1, k_factor=1, hermi=1)
         assert abs(ek - ek1).max() < 1e-9
-        assert abs(lib.fp(ek) - -24.366562704166753) < 1e-9
+        assert abs(lib.fp(ek) - -24.366562704166753) < 2e-9
 
         # mimic insufficent memory, processing in small batches
         with lib.temporary_env(df_rhf_grad, get_avail_mem=(lambda **kw: 3000000)):
             ek = _jk_energy_per_atom(opt, dm, j_factor=1, k_factor=1, hermi=1)
-        assert abs(lib.fp(ek) - -24.366562704166753) < 1e-9
+        assert abs(lib.fp(ek) - -24.366562704166753) < 2e-9
 
         disp = 1e-3
         atom_coords = mol.atom_coords()

--- a/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
@@ -331,7 +331,7 @@ class KnownValues(unittest.TestCase):
             ref -= rhf_grad._jk_energy_per_atom(
                 opt, dm[i,1], j_factor=j_factor[i], k_factor=k_factor[i])
             ref *= .5
-            assert abs(ejk[i] - ref).max() < 3e-11
+            assert abs(ejk[i] - ref).max() < 5e-11
 
         ref = ejk
         dm = cp.vstack([dm]*4)

--- a/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
@@ -283,7 +283,7 @@ class KnownValues(unittest.TestCase):
         for i, jfac in enumerate(j_factor):
             ref += rhf_grad._jk_energy_per_atom(opt, dm[i], j_factor=jfac, k_factor=0)
         assert abs(ej - ref).max() < 1e-12
-        assert abs(lib.fp(ej) - -5.7379651745047555) < 1e-12
+        assert abs(lib.fp(ej) - -5.7379651745047555) < 2e-12
 
     def test_jk_energy_per_atom(self):
         cp.random.seed(8)
@@ -295,13 +295,13 @@ class KnownValues(unittest.TestCase):
         j_factor = [1, -1,  0]
         k_factor = [1, -1, -1]
         ejk = _jk_energy_per_atom(opt, dm, j_factor=j_factor, k_factor=k_factor)
-        assert abs(lib.fp(ejk) - 16.8821623565) < 1e-9
+        assert abs(lib.fp(ejk) - 16.8821623565) < 2e-9
         assert abs(ejk.sum(axis=0)).max() < 1e-9
 
         # mimic insufficent memory, processing in small batches
         with lib.temporary_env(df_tdrhf_grad, get_avail_mem=(lambda **kw: 3000000)):
             ejk = _jk_energy_per_atom(opt, dm, j_factor=j_factor, k_factor=k_factor)
-        assert abs(lib.fp(ejk) - 16.8821623565) < 1e-9
+        assert abs(lib.fp(ejk) - 16.8821623565) < 2e-9
 
         ref = 0
         for i in range(len(dm)):


### PR DESCRIPTION
Similar to PR #783, for a big system (`gpu4pyscf/benchmarks/molecules/organic/095_Azadirachtin.xyz`) with `def2-universal-jkfit` auxbasis, the smallest eigenvalue of the `j2c` matrix is close to threshold (1e-7 by default), and it introduces numerical instability to gradient calculation as well. Here we noticed that the general matrix solver `cp.linalg.solve` is not numerically stable enough (when changing GPU type from A100 to A30, a 1e-4 error on final gradient is introduced). Surprisingly, eigenvalue solver is also not stable enough (same magnitude of error as `cp.linalg.solve`). Only the Cholesky solver provides a reasonable stability (1e-5 error across GPUs). This conclusion might be coincidence on the particular system, and any suggestion is welcome.

This PR also fix the CD part in https://github.com/pyscf/gpu4pyscf/blob/3edad9f3aee6a2973be80020862ab4e273fb3734/gpu4pyscf/df/grad/rhf.py#L32
