### PR TITLE
Set per-device kernel shared memory on every GPU

### DIFF
--- a/gpu4pyscf/grad/rhf.py
+++ b/gpu4pyscf/grad/rhf.py
@@ -55,7 +55,7 @@ libvhf_rys.RYS_per_atom_jk_ip1.restype = ctypes.c_int
 #     dd_cache_size = nf * min(THREADS, _nearest_power2(SHM_SIZE//(g_size*3*8)))
 DD_CACHE_MAX = 101250 * (SHM_SIZE//(45*1024))
 
-libvhf_rys.RYS_build_vjk_ip1_init(ctypes.c_int(SHM_SIZE))
+libvhf_rys.RYS_build_vjk_ip1_init.restype = ctypes.c_int
 
 def _jk_energy_per_atom(vhfopt, dm, j_factor=1., k_factor=1., verbose=None):
     '''
@@ -97,6 +97,9 @@ def _jk_energy_per_atom(vhfopt, dm, j_factor=1., k_factor=1., verbose=None):
         device_id = cp.cuda.device.get_device_id()
         log = logger.new_logger(mol, verbose)
         cput0 = log.init_timer()
+        err = libvhf_rys.RYS_build_vjk_ip1_init(ctypes.c_int(SHM_SIZE))
+        if err != 0:
+            raise RuntimeError('RYS build_vjk_ip1 CUDA kernel initialization failed')
 
         timing_collection = _TimingCollector(log.timer_debug1)
         kern_counts = 0

--- a/gpu4pyscf/grad/tdrhf.py
+++ b/gpu4pyscf/grad/tdrhf.py
@@ -363,6 +363,9 @@ def _jk_energies_per_atom(vhfopt, dm_pairs, j_factor=None, k_factor=None,
         device_id = cp.cuda.device.get_device_id()
         log = logger.new_logger(mol, verbose)
         cput0 = log.init_timer()
+        err = libvhf_rys.RYS_build_vjk_ip1_init(ctypes.c_int(SHM_SIZE))
+        if err != 0:
+            raise RuntimeError('RYS build_vjk_ip1 CUDA kernel initialization failed')
 
         timing_collection = _TimingCollector(log.timer_debug1)
         kern_counts = 0

--- a/gpu4pyscf/hessian/rhf.py
+++ b/gpu4pyscf/hessian/rhf.py
@@ -51,8 +51,8 @@ GB = 1024*1024*1024
 ALIGNED = 4
 DD_CACHE_MAX = rhf_grad.DD_CACHE_MAX
 
-libvhf_rys.RYS_build_vjk_ip1_init(ctypes.c_int(SHM_SIZE))
-libvhf_rys.RYS_build_ejk_ip2_init(ctypes.c_int(SHM_SIZE))
+libvhf_rys.RYS_build_vjk_ip1_init.restype = ctypes.c_int
+libvhf_rys.RYS_build_ejk_ip2_init.restype = ctypes.c_int
 
 def hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
               mo1=None, mo_e1=None, h1mo=None,
@@ -209,6 +209,9 @@ def _partial_ejk_ip2(mol, dm, vhfopt=None, j_factor=1., k_factor=1., verbose=Non
 
         timing_collection = _TimingCollector(log.timer_debug1)
         kern_counts = 0
+        err = libvhf_rys.RYS_build_ejk_ip2_init(ctypes.c_int(SHM_SIZE))
+        if err != 0:
+            raise RuntimeError('RYS build_ejk_ip2 CUDA kernel initialization failed')
         kern1 = libvhf_rys.RYS_per_atom_jk_ip2_type12
         kern2 = libvhf_rys.RYS_per_atom_jk_ip2_type3
 
@@ -426,6 +429,9 @@ def _get_jk_ip1(mol, dm, with_j=True, with_k=True, atoms_slice=None, verbose=Non
         timing_collection = _TimingCollector(log.timer_debug1)
         kern_counts = 0
         kern = libvhf_rys.RYS_build_jk_ip1
+        err = libvhf_rys.RYS_build_vjk_ip1_init(ctypes.c_int(SHM_SIZE))
+        if err != 0:
+            raise RuntimeError('RYS build_vjk_ip1 CUDA kernel initialization failed')
 
         _dms = cp.asarray(dms)
 

--- a/gpu4pyscf/pbc/scf/j_engine.py
+++ b/gpu4pyscf/pbc/scf/j_engine.py
@@ -46,6 +46,7 @@ __all__ = [
 ]
 
 libvhf_md.PBC_build_j.restype = ctypes.c_int
+libvhf_md.init_mdj_constant.restype = ctypes.c_int
 
 def get_j(cell, dm, hermi=0, kpts=None, kpts_band=None, vhfopt=None,
           verbose=None):
@@ -242,6 +243,9 @@ class PBCJMatrixOpt:
 
             timing_collection = _TimingCollector(log.timer_debug1)
             kern_counts = 0
+            err = libvhf_md.init_mdj_constant(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError(f'MD-J kernel init failed on Device {device_id}')
             kern = libvhf_md.PBC_build_j
             rys_envs = self.rys_envs
 

--- a/gpu4pyscf/pbc/scf/rsjk.py
+++ b/gpu4pyscf/pbc/scf/rsjk.py
@@ -55,8 +55,9 @@ __all__ = [
 ]
 
 libpbc.PBC_build_k.restype = ctypes.c_int
-libpbc.PBC_build_k_init(ctypes.c_int(SHM_SIZE))
-libpbc.PBC_build_jk_ip1_init(ctypes.c_int(SHM_SIZE))
+libpbc.PBC_build_k_init.restype = ctypes.c_int
+libpbc.PBC_build_jk_ip1_init.restype = ctypes.c_int
+libpbc.PBC_build_j_init.restype = ctypes.c_int
 libpbc.PBC_per_atom_jk_ip1.restype = ctypes.c_int
 libpbc.PBC_jk_strain_deriv.restype = ctypes.c_int
 
@@ -349,6 +350,9 @@ class PBCJKMatrixOpt:
 
             timing_collection = _TimingCollector(log.timer_debug1)
             kern_counts = 0
+            err = libpbc.PBC_build_k_init(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError(f'PBC build_k kernel init failed on Device {device_id}')
             kern = libpbc.PBC_build_k
             rys_envs = self.rys_envs
             rsjk_omega = -self.omega
@@ -711,7 +715,6 @@ class PBCJKMatrixOpt:
 
         diffuse_exps, diffuse_ctr_coef = extract_pgto_params(supmol, 'diffuse')
 
-        libpbc.PBC_build_j_init(ctypes.c_int(SHM_SIZE))
         libpbc.PBC_build_j.restype = ctypes.c_int
 
         uniq_l_ctr = cell.uniq_l_ctr
@@ -747,6 +750,9 @@ class PBCJKMatrixOpt:
 
             timing_collection = _TimingCollector(log.timer_debug1)
             kern_counts = 0
+            err = libpbc.PBC_build_j_init(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError(f'PBC build_j kernel init failed on Device {device_id}')
             kern = libpbc.PBC_build_j
             rys_envs = self.rys_envs
             rsjk_omega = -self.omega
@@ -1003,6 +1009,9 @@ class PBCJKMatrixOpt:
             t1 = log.timer_debug1(f'ejk_sr initialization on Device {device_id}', *t0)
             timing_collection = _TimingCollector(log.timer_debug1)
             kern_counts = 0
+            err = libpbc.PBC_build_jk_ip1_init(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError(f'PBC build_jk_ip1 kernel init failed on Device {device_id}')
             kern = libpbc.PBC_per_atom_jk_ip1
             rys_envs = self.rys_envs
             omega = -self.omega
@@ -1433,6 +1442,9 @@ class PBCJKMatrixOpt:
             t1 = log.timer_debug1(f'ejk_sr_strain_deriv initialization on Device {device_id}', *t0)
             timing_collection = _TimingCollector(log.timer_debug1)
             kern_counts = 0
+            err = libpbc.PBC_build_jk_ip1_init(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError(f'PBC build_jk_ip1 kernel init failed on Device {device_id}')
             kern = libpbc.PBC_jk_strain_deriv
             rys_envs = self.rys_envs
             omega = -self.omega

--- a/gpu4pyscf/scf/j_engine.py
+++ b/gpu4pyscf/scf/j_engine.py
@@ -43,7 +43,7 @@ THREADS = 256
 
 libvhf_md = load_library('libgvhf_md')
 libvhf_md.MD_build_j.restype = ctypes.c_int
-libvhf_md.init_mdj_constant(ctypes.c_int(SHM_SIZE))
+libvhf_md.init_mdj_constant.restype = ctypes.c_int
 
 def get_j(mol, dm, hermi=1, vhfopt=None, verbose=None):
     '''Compute J matrix
@@ -161,6 +161,9 @@ class _VHFOpt(jk._VHFOpt):
             stream = cp.cuda.stream.get_current_stream()
             log = logger.new_logger(self.mol, verbose)
             t1 = log.init_timer()
+            err = libvhf_md.init_mdj_constant(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError('MD-J CUDA kernel initialization failed')
             dm_xyz = asarray(dm_xyz) # transfer to current device
             vj_xyz = cp.zeros_like(dm_xyz)
 

--- a/gpu4pyscf/scf/jk.py
+++ b/gpu4pyscf/scf/jk.py
@@ -58,8 +58,8 @@ THREADS = 256
 GROUP_SIZE = 256
 Q_COND_MARGIN = 4.
 
-libvhf_rys.RYS_build_k_init(ctypes.c_int(SHM_SIZE))
-libvhf_rys.RYS_build_jk_init(ctypes.c_int(SHM_SIZE))
+libvhf_rys.RYS_build_k_init.restype = ctypes.c_int
+libvhf_rys.RYS_build_jk_init.restype = ctypes.c_int
 
 def get_jk(mol, dm, hermi=0, vhfopt=None, with_j=True, with_k=True, verbose=None):
     '''Compute J, K matrices
@@ -444,6 +444,9 @@ class _VHFOpt:
             stream = cp.cuda.get_current_stream()
             log = logger.new_logger(mol, verbose)
             t0 = log.init_timer()
+            err = libvhf_rys.RYS_build_jk_init(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError('RYS build_jk CUDA kernel initialization failed')
             dms = cp.asarray(dms) # transfer to current device
             dm_cond = cp.asarray(dm_cond)
 
@@ -739,6 +742,9 @@ class _VHFOpt:
             stream = cp.cuda.stream.get_current_stream()
             log = logger.new_logger(mol, verbose)
             t0 = log.init_timer()
+            err = libvhf_rys.RYS_build_k_init(ctypes.c_int(SHM_SIZE))
+            if err != 0:
+                raise RuntimeError('RYS build_k CUDA kernel initialization failed')
             dms = cp.asarray(dms) # transfer to current device
             dm_cond = cp.asarray(dm_cond)
 


### PR DESCRIPTION
On a machine with more than one GPU, direct-SCF, gradient, and Hessian builds crash for any basis containing d or f shells with errors like `CUDA Error in MD_build_j: invalid argument` and `RuntimeError: MD_build_j kernel for (dp|dp) failed`; a single GPU always works and p-only bases work even on multiple GPUs.

The cause is that CUDA kernels needing more than 48 KB of dynamic shared memory require a per-device opt-in via `cudaFuncSetAttribute`, but the Python `*_init` wrappers were called only once at module import on device 0, while work is then distributed across all GPUs through `multi_gpu.run`, so any kernel launched on device 1 and beyond never received the opt-in and failed.

This was introduced in v1.5.0 and is still present through the current v1.7.4: commit 6af29a4 (#547) moved `init_mdj_constant` out of the per-device `proc` to module level, and a396d48 (#505) added the `RYS_build_jk`/`RYS_build_k` builders with module-level init from the start, with the later gradient, Hessian, and periodic kernels following the same broken pattern.

The condition is not covered by CI because the runners only have a single GPU, so they pass there and the regression went unnoticed.

The fix restores the original pattern by calling each `*_init(SHM_SIZE)` inside the per-device `proc` with an error check and demoting the module-level call to a `.restype` declaration, across ten `proc` sites in six files (scf/j_engine.py, scf/jk.py, grad/rhf.py, hessian/rhf.py, pbc/scf/j_engine.py, pbc/scf/rsjk.py), mirroring the rysj path that was always correct, with no change to single-GPU behaviour.

I verified it on four A100s: the SCF, gradient, Hessian, and periodic test suites that failed before now pass (j_engine 6, jk 12, grad 21, hessian 7, PBC j_engine+jk 36, PBC scf/stress 27), single-GPU runs are unchanged.

This fixes #623.