### PR TITLE
Make the add_sparse() function more tolerant to wrong-order input

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ There shouldn't be cupy or cutensor compilation during pip install process. If y
 ```
 <repo_path>/gpu4pyscf/lib/cutensor.py:<line_number>: UserWarning: using cupy as the tensor contraction engine.
 ```
+The following command may help when using `cupy-cuda12x==14.1.1` and `cutensor-cu12==2.7.0`:
+```sh
+export LD_LIBRARY_PATH="$(python -c 'import cutensor; print(cutensor.__path__._path[0])')/lib:${LD_LIBRARY_PATH}"
+```
 
 Features
 --------

--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ There shouldn't be cupy or cutensor compilation during pip install process. If y
 ```
 <repo_path>/gpu4pyscf/lib/cutensor.py:<line_number>: UserWarning: using cupy as the tensor contraction engine.
 ```
-The following command may help when using `cupy-cuda12x==14.1.1` and `cutensor-cu12==2.7.0`:
-```sh
-export LD_LIBRARY_PATH="$(python -c 'import cutensor; print(cutensor.__path__._path[0])')/lib:${LD_LIBRARY_PATH}"
-```
 
 Features
 --------

--- a/gpu4pyscf/lib/cupy_helper.py
+++ b/gpu4pyscf/lib/cupy_helper.py
@@ -291,7 +291,8 @@ def add_sparse(a, b, indices):
     '''
     assert a.device == b.device
     assert a.flags.c_contiguous
-    assert b.flags.c_contiguous
+    if not b.flags.c_contiguous:
+        b = cupy.ascontiguousarray(b)
     if len(indices) == 0: return a
     indices = cupy.asarray(indices, dtype=np.int32)
     n = a.shape[-1]


### PR DESCRIPTION
When using cupy (not cutensor) for contract() function, the returned matrix may not be in C-order.
It's ok to reshape b input of add_sparse(), since it is a unmodified input.