### PR TITLE
Downgrade scipy version in CI

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -55,4 +55,4 @@ jobs:
           -v $GITHUB_WORKSPACE:/workspace \
           -v ~/.cache/pip:/root/.cache/pip \
           pyscf/gpu4pyscf-devel:pyscf-2.14 \
-          /bin/bash -c "cd /workspace && pip3 install -r requirements.txt && pip3 install pyscf==2.8 && source build.sh && pytest -m 'not slow and not benchmark and not special' --cov=/workspace --durations=50 && rm -rf .pytest_cache"
+          /bin/bash -c "cd /workspace && pip3 install -r requirements.txt && pip3 install pyscf==2.8 scipy==1.17 && source build.sh && pytest -m 'not slow and not benchmark and not special' --cov=/workspace --durations=50 && rm -rf .pytest_cache"


### PR DESCRIPTION
To solve compatibility issues between pyscf 2.8 and scipy 1.18