### PR TITLE
Fix GPU OOM because of inaccurate DF workspace size estimation

### DIFF
--- a/gpu4pyscf/df/df.py
+++ b/gpu4pyscf/df/df.py
@@ -509,9 +509,9 @@ def _cholesky_eri(intopt, omega=None, use_gpu_memory=None):
     naux_per_device = min(naux, (naux + num_devices - 1) // num_devices)
 
     cp.get_default_memory_pool().free_all_blocks()
-    word_avail -= batch_size * naux
+    word_avail -= batch_size * naux_sorted
     if needs_recontraction:
-        word_avail -= cderi_batch_size * naux_per_device
+        word_avail -= batch_size * naux_per_device
 
     # Put cderi on GPU whenever possible
     on_gpu = True
@@ -571,7 +571,7 @@ def _cholesky_eri(intopt, omega=None, use_gpu_memory=None):
         def proc():
             device_id = cp.cuda.device.get_device_id()
             aux0 = naux_per_device * device_id
-            aux1 = min(int(aux_coef.shape[1]), aux0 + naux_per_device)
+            aux1 = min(naux, aux0 + naux_per_device)
             c = cp.asarray(aux_coef[:,aux0:aux1])
 
             _eval_j3c = eval_j3c


### PR DESCRIPTION
The real change is from `word_avail -= batch_size * naux` to `word_avail -= batch_size * naux_sorted`, given in later code `work = cp.empty(naux_sorted * batch_size)`.

One example that touch this edge case is shown in the following, reproduced on a A100-80GB card.
```python
import pyscf
from gpu4pyscf.dft import RKS

mol = pyscf.M(
    atom = """
ghost:N 0.73030900 1.00072700 1.19550400
ghost:C -0.06767700 1.66812200 1.97708100
ghost:C 0.68042800 2.62429000 2.79764100
ghost:C 4.14921400 -0.30991400 -1.11718800
ghost:C -1.84123200 -1.69972700 -3.35037700
ghost:C 3.59166200 -1.25852600 -2.16817700
ghost:C -0.48268200 -2.06520200 -3.62869700
ghost:C 1.99259900 2.44938400 2.44148200
ghost:C -3.77536000 0.57861800 1.54725300
ghost:C -4.26844100 -0.43253200 0.69634900
ghost:C 3.13446600 -0.18100100 -0.19505500
ghost:C -1.84939800 -1.66541000 -1.98380900
ghost:C 2.46684700 -1.79994600 -1.62417600
ghost:C 0.20625900 -2.33983200 -2.47789400
ghost:C 3.16705600 0.82340600 0.89389800
ghost:C -1.55564300 1.65344800 2.03678000
ghost:C -3.11747600 -1.42427400 -1.22297900
ghost:C 2.03925300 1.37578100 1.46505100
ghost:C -2.30317500 0.66388800 1.44926200
ghost:C -3.07153300 -0.85462400 0.02916800
ghost:N 2.14766200 -1.07917400 -0.48814800
ghost:N -0.68191200 -2.06317400 -1.43246400
ghost:N -1.90561300 -0.30336000 0.55303500
ghost:C 1.58272700 -2.87686200 -2.35273700
ghost:H 0.29062000 3.26853500 3.57577400
ghost:H 4.99076200 0.30882500 -1.18317600
ghost:H -2.61746000 -1.45615800 -4.06501400
ghost:H 4.02084200 -1.53270100 -3.14273000
ghost:H -0.14186000 -2.31822900 -4.66502400
ghost:H 2.87319100 2.81676500 2.97805700
ghost:H -4.43535000 1.13077000 2.12294300
ghost:H -5.28766100 -0.54667800 0.43547100
ghost:H 4.17938500 1.19910400 1.25394100
ghost:H -2.09248200 2.18974600 2.78309500
ghost:H -4.09469300 -1.52144200 -1.72580100
ghost:H 1.35722800 -1.33643700 0.13833300
ghost:H -0.51267500 -2.21249500 -0.43608900
ghost:H -0.96860900 -0.21313100 0.07061200
ghost:H 1.95665000 -3.10108600 -3.34863000
ghost:H 1.52374900 -3.77711400 -1.69758700
ghost:O -2.59348000 0.35145100 4.89927000
ghost:H -1.65668200 0.45524500 5.26722800
ghost:H -3.08354000 1.22642800 5.03349400
ghost:O 1.56679800 -0.24173400 -5.26806400
ghost:H 0.57144700 -0.41107000 -5.20202100
ghost:H 1.85453800 0.27118100 -4.44472500
ghost:O -6.09903600 0.62483900 4.21234600
ghost:H -6.41415900 -0.02219900 3.50114800
ghost:H -6.51799500 0.35411700 5.09265300
ghost:O 6.21696000 3.02349800 -1.49360200
ghost:H 7.11185300 3.46474900 -1.66160600
ghost:H 5.61177300 3.69898700 -1.04502300
ghost:O -4.44656400 -0.11036500 -5.31724100
ghost:H -5.11001000 -0.81341000 -5.01836300
ghost:H -4.84415600 0.80002900 -5.12523600
ghost:O -7.28021900 -1.22145600 2.35900700
ghost:H -7.86777200 -0.58479900 1.83631100
ghost:H -6.72468900 -1.75097600 1.69964600
ghost:O 6.83231900 1.48329600 0.67495600
ghost:H 7.59516800 0.97956500 0.24127700
ghost:H 6.44111000 2.11508900 -0.01174400
ghost:O -5.80199600 -3.05283500 0.42053800
ghost:H -6.30021600 -3.92893400 0.33115900
ghost:H -5.06537300 -3.17737300 1.10291400
ghost:O -0.85206800 -5.24809400 -1.25743200
ghost:H -0.82919600 -4.33758100 -1.69811500
ghost:H -1.73727100 -5.34341200 -0.77671400
ghost:O 5.14476300 3.59068600 2.00994600
ghost:H 4.76427600 4.24338100 1.33690900
ghost:H 5.85034500 3.03408100 1.54507500
ghost:O -6.48906300 2.50727200 2.39103800
ghost:H -6.22651900 1.83462200 3.09982000
ghost:H -7.49646900 2.60080400 2.40306000
ghost:O 6.09412800 0.98993900 3.18019700
ghost:H 5.66614300 0.09575600 2.97765100
ghost:H 6.42107800 1.38739500 2.30905300
ghost:O -1.25791100 3.68052700 5.99322700
ghost:H -1.15648000 2.76647900 5.57133800
ghost:H -2.14479300 3.70650000 6.47956900
ghost:O 5.28029500 1.40049800 -3.64526400
ghost:H 5.90908900 0.63225100 -3.84065500
ghost:H 5.66128900 1.93083900 -2.87238400
ghost:O 1.07515300 2.67172600 -1.16548700
ghost:H 0.37891700 2.47502700 -1.87282500
ghost:H 0.92651600 2.03683200 -0.39181000
O 1.71612000 -3.21117000 -6.75512600
H 1.68782600 -2.91602000 -7.72251700
H 1.57705400 -2.39563600 -6.17261100
ghost:O -3.99369900 3.97562600 2.52534800
ghost:H -4.68914800 3.28692400 2.26883000
ghost:H -3.38097700 4.11527700 1.73235900
ghost:O 0.71786700 -3.00520900 1.19288800
ghost:H 0.75075700 -3.96204000 1.52023100
ghost:H 0.99386900 -2.40127100 1.95632900
ghost:O 4.20944400 1.58538200 5.23998900
ghost:H 4.83730100 1.42610400 4.46269400
ghost:H 4.18727800 2.57919300 5.42868500
ghost:O -0.24953700 -4.80506500 -5.95790800
ghost:H 0.53570800 -4.36649900 -6.42138400
ghost:H 0.11190100 -5.47676900 -5.29312400
    """,
    basis = "def2-TZVPD",
    verbose = 4,
)

mf = RKS(mol, xc = "wB97MV").density_fit(auxbasis = "def2-universal-jkfit")
mf.grids.atom_grid = (99, 590)
mf.nlcgrids.atom_grid = (50, 194)

mf.kernel()

gobj = mf.Gradients()
gobj.grid_response = True
gobj.kernel()
```