### PR TITLE
Fix UHF LUMO logging for zero beta electrons

### DIFF
--- a/gpu4pyscf/scf/tests/test_uhf.py
+++ b/gpu4pyscf/scf/tests/test_uhf.py
@@ -86,6 +86,16 @@ def tearDownModule():
     del mol, mol1
 
 class KnownValues(unittest.TestCase):
+    def test_get_occ_zero_beta_electrons(self):
+        mol_h = pyscf.M(atom='H 0 0 0', basis='6-31g', spin=1)
+        mf = scf.UHF(mol_h)
+        mf.verbose = pyscf.lib.logger.INFO
+        mo_energy = cupy.asarray([[-0.5, 0.2], [-0.4, 0.3]])
+
+        mo_occ = mf.get_occ(mo_energy)
+
+        self.assertTrue(cupy.array_equal(mo_occ, cupy.asarray([[1, 0], [0, 0]])))
+
     def test_get_jk(self):
         np.random.seed(1)
         nao = mol.nao

--- a/gpu4pyscf/scf/uhf.py
+++ b/gpu4pyscf/scf/uhf.py
@@ -288,7 +288,7 @@ class UHF(hf.SCF):
                 if homo_b is not None:
                     logger.info(self, 'beta HOMO = %.12g  LUMO = %.12g', homo_b, lumo_b)
                 else:
-                    logger.info(self, 'beta               LUMO = %.12g', homo_b)
+                    logger.info(self, 'beta               LUMO = %.12g', lumo_b)
                 if homo+1e-3 > lumo:
                     logger.warn(self, 'HOMO %.15g >= LUMO %.15g', homo, lumo)
                 else:


### PR DESCRIPTION
## Summary

- log the beta LUMO instead of the absent beta HOMO when there are zero beta electrons
- add a regression test for UHF occupation assignment at INFO verbosity with `(n_alpha, n_beta) = (1, 0)`

`homo_b` is intentionally `None` in this case. Formatting it with `%.12g` raises `TypeError` and aborts the SCF calculation.

## Testing

- End-to-end calculation on an A10 GPU for neutral doublet H with wB97M-D3BJ/Grimme vDZP converged to `-0.497600044012713` Hartree after applying this patch.
- `python3 -m compileall -q gpu4pyscf/scf/uhf.py gpu4pyscf/scf/tests/test_uhf.py`
- `git diff --check`