### PR TITLE
Fix a CUDA_ILLEGAL_MEMORY_ACCESS bug for PBC RSDF + large system + multigpu

### DIFF
--- a/gpu4pyscf/df/int3c2e_bdiv.py
+++ b/gpu4pyscf/df/int3c2e_bdiv.py
@@ -544,7 +544,6 @@ class Int3c2eEnvVars(ctypes.Structure):
         return Int3c2eEnvVars.new(self.natm, self.nbas, atm, bas, env, ao_loc,
                                   self.log_cutoff)
 
-@multi_gpu.lru_cache
 def int3c2e_scheme(*, short_range=False, shm_size=SHM_SIZE, gout_width=None,
                    gout_ndim='ijk', deriv=None, cache_cart_idx=False,
                    angular_inc=None):

--- a/gpu4pyscf/df/int3c2e_bdiv.py
+++ b/gpu4pyscf/df/int3c2e_bdiv.py
@@ -544,7 +544,6 @@ class Int3c2eEnvVars(ctypes.Structure):
         return Int3c2eEnvVars.new(self.natm, self.nbas, atm, bas, env, ao_loc,
                                   self.log_cutoff)
 
-@lru_cache
 def int3c2e_scheme(*, short_range=False, shm_size=SHM_SIZE, gout_width=None,
                    gout_ndim='ijk', deriv=None, cache_cart_idx=False,
                    angular_inc=None):

--- a/gpu4pyscf/df/int3c2e_bdiv.py
+++ b/gpu4pyscf/df/int3c2e_bdiv.py
@@ -16,7 +16,6 @@
 3-center 2-electron Coulomb integral helper functions
 '''
 
-from functools import lru_cache
 import ctypes
 import math
 import numpy as np
@@ -32,6 +31,7 @@ from gpu4pyscf.lib.cupy_helper import (
     load_library, contract, dist_matrix, asarray, hermi_triu, transpose_sum,
     ndarray)
 from gpu4pyscf.lib.utils import splits_by_blocksize
+from gpu4pyscf.lib import multi_gpu
 from gpu4pyscf.gto.mole import (
     PTR_BAS_COORD, SortedMole, RysIntEnvVars, extract_pgto_params, groupby)
 from gpu4pyscf.scf.jk import (
@@ -544,6 +544,7 @@ class Int3c2eEnvVars(ctypes.Structure):
         return Int3c2eEnvVars.new(self.natm, self.nbas, atm, bas, env, ao_loc,
                                   self.log_cutoff)
 
+@multi_gpu.lru_cache
 def int3c2e_scheme(*, short_range=False, shm_size=SHM_SIZE, gout_width=None,
                    gout_ndim='ijk', deriv=None, cache_cart_idx=False,
                    angular_inc=None):

--- a/gpu4pyscf/df/j_engine_3c2e.py
+++ b/gpu4pyscf/df/j_engine_3c2e.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import lru_cache
 import ctypes
 import math
 import numpy as np
@@ -229,7 +228,6 @@ class Int3c2eOpt:
             vj = vj[0]
         return vj
 
-@lru_cache
 def _int3c2e_dm_scheme():
     li = np.arange(LMAX*2+1)
     lk = np.arange(L_AUX_MAX+1)
@@ -249,7 +247,6 @@ def _int3c2e_dm_scheme():
     nsp_lookup = cp.asarray(nsp_per_block, dtype=np.int32)
     return nsp_lookup, shm_size
 
-@lru_cache
 def _int3c2e_auxvec_scheme():
     li = np.arange(LMAX*2+1)
     lk = np.arange(L_AUX_MAX+1)


### PR DESCRIPTION
In https://github.com/pyscf/gpu4pyscf/blob/ff6b09bdc322a5749aefdca7e5822b1cccf19029/gpu4pyscf/pbc/df/rsdf_builder.py#L411 it calls https://github.com/pyscf/gpu4pyscf/blob/ff6b09bdc322a5749aefdca7e5822b1cccf19029/gpu4pyscf/pbc/df/rsdf_builder.py#L346 where https://github.com/pyscf/gpu4pyscf/blob/ff6b09bdc322a5749aefdca7e5822b1cccf19029/gpu4pyscf/pbc/df/int3c2e.py#L387 the `gout_stride` variable always resides on one particular GPU, because of the cache.

I believe the correct solution is to remove all `lru_cache` that could possibly cache a device memory piece, as this is always a trap for multigpu application. And this simple and fast function doesn't require a cache at all.

This bug is only triggered for big enough system, because otherwise only one GPU (device_id = 0 in practice) will get to the `eval_j3c` part, other GPUs will early quit.

