### PR TITLE
fix multigrid v2 stress spike 

### DIFF
--- a/gpu4pyscf/pbc/dft/multigrid_v2.py
+++ b/gpu4pyscf/pbc/dft/multigrid_v2.py
@@ -1832,6 +1832,36 @@ def get_veff_ip1(
 
     return veff_gradient.get()
 
+def _neighboring_image_translations(ni):
+    lattice_vectors = asarray(ni.cell.lattice_vectors())
+    # Preserve the image topology referenced by the cached pair and block indices.
+    return [
+        cp.rint(cp.linalg.solve(lattice_vectors.T, pair['neighboring_images'].T).T).astype(cp.int32)
+        for pair in ni.sorted_gaussian_pairs
+    ]
+
+def _copy_numint_for_strained_cell(ni, cell, image_translations):
+    atom_coords = asarray(cell.atom_coords().ravel())
+    atm = ni.sorted_gaussian_pairs[0]['atm']
+    atom_coords_address = (cp.asarray(atm[:,PTR_COORD,None]) + cp.arange(3)).ravel()
+    lattice_vectors = cell.lattice_vectors()
+    lattice_vectors_gpu = asarray(lattice_vectors)
+    pairs = []
+    for pair0, translations in zip(ni.sorted_gaussian_pairs, image_translations):
+        pair = pair0.copy()
+        env = pair['env'].copy()
+        env[atom_coords_address] = atom_coords
+        pair['env'] = env
+        pair['is_non_orthogonal'] = 1
+        pair['dxyz_dabc'] = lattice_vectors / pair['mesh'][:,None] # update the mesh.
+        pair['neighboring_images'] = translations @ lattice_vectors_gpu
+        pairs.append(pair)
+
+    ni_copy = ni.copy()
+    ni_copy.cell = cell
+    ni_copy.sorted_gaussian_pairs = pairs
+    return ni_copy
+
 def _rks_exc_strain_deriv(ni, xc_code, dm_kpts, kpts=None, with_j=False, with_nuc=False):
     '''Strain derivatives for Coulomb and Exc with k-point samples
 
@@ -1864,26 +1894,7 @@ def _rks_exc_strain_deriv(ni, xc_code, dm_kpts, kpts=None, with_j=False, with_nu
     rho0 = ifft_in_place(rho0.reshape(-1,*mesh)).real.reshape(nvar, ngrids)
     rho0 *= ngrids / cell.vol
 
-    ni_copy = ni.copy()
-    def update_pairs_info(cell1):
-        r = asarray(cell1.atom_coords().ravel())
-        atm = ni.sorted_gaussian_pairs[0]['atm']
-        atom_coords_address = (cp.asarray(atm[:,PTR_COORD,None]) + cp.arange(3)).ravel()
-        lattice_vectors = cell1.lattice_vectors()
-        neighboring_images = asarray(gto.eval_gto.get_lattice_Ls(cell1))
-        pairs = []
-        for pair in ni.sorted_gaussian_pairs:
-            pair = pair.copy()
-            pairs.append(pair)
-            env = pair['env'].copy()
-            env[atom_coords_address] = r
-            pair['env'] = env
-            pair['is_non_orthogonal'] = 1
-            pair['dxyz_dabc'] = lattice_vectors / pair['mesh'][:,None]
-            pair['neighboring_images'] = neighboring_images
-        ni_copy.cell = cell1
-        ni_copy.sorted_gaussian_pairs = pairs
-
+    image_translations = _neighboring_image_translations(ni)
     disp = 1e-4
     scaled_kpts = kpts.dot(cell.lattice_vectors().T)
     rho1 = cp.empty((3, 3, nvar, ngrids))
@@ -1893,12 +1904,12 @@ def _rks_exc_strain_deriv(ni, xc_code, dm_kpts, kpts=None, with_j=False, with_nu
             kpts1 = scaled_kpts.dot(cell1.reciprocal_vectors(norm_to=1))
             kpts2 = scaled_kpts.dot(cell2.reciprocal_vectors(norm_to=1))
 
-            update_pairs_info(cell1)
+            ni_copy = _copy_numint_for_strained_cell(ni, cell1, image_translations)
             rho_plus = evaluate_density_on_g_mesh(ni_copy, dm_kpts, kpts1, xctype)
             rho_plus = ifft_in_place(rho_plus.reshape(-1, *mesh)).real
             rho_plus *= ngrids / cell1.vol
 
-            update_pairs_info(cell2)
+            ni_copy = _copy_numint_for_strained_cell(ni, cell2, image_translations)
             rho_minus = evaluate_density_on_g_mesh(ni_copy, dm_kpts, kpts2, xctype)
             rho_minus = ifft_in_place(rho_minus.reshape(-1, *mesh)).real
             rho_minus *= ngrids / cell2.vol
@@ -1947,26 +1958,7 @@ def _uks_exc_strain_deriv(ni, xc_code, dm_kpts, kpts=None, with_j=False, with_nu
     rho0 = ifft_in_place(rho0.reshape(-1,*mesh)).real.reshape(2, nvar, ngrids)
     rho0 *= ngrids / cell.vol
 
-    ni_copy = ni.copy()
-    def update_pairs_info(cell1):
-        r = asarray(cell1.atom_coords().ravel())
-        atm = ni.sorted_gaussian_pairs[0]['atm']
-        atom_coords_address = (cp.asarray(atm[:,PTR_COORD,None]) + cp.arange(3)).ravel()
-        lattice_vectors = cell1.lattice_vectors()
-        neighboring_images = asarray(gto.eval_gto.get_lattice_Ls(cell1))
-        pairs = []
-        for pair in ni.sorted_gaussian_pairs:
-            pair = pair.copy()
-            pairs.append(pair)
-            env = pair['env'].copy()
-            env[atom_coords_address] = r
-            pair['env'] = env
-            pair['is_non_orthogonal'] = 1
-            pair['dxyz_dabc'] = lattice_vectors / pair['mesh'][:,None]
-            pair['neighboring_images'] = neighboring_images
-        ni_copy.cell = cell1
-        ni_copy.sorted_gaussian_pairs = pairs
-
+    image_translations = _neighboring_image_translations(ni)
     disp = 1e-4
     scaled_kpts = kpts.dot(cell.lattice_vectors().T)
     rho1 = cp.empty((3, 3, 2, nvar, ngrids))
@@ -1976,12 +1968,12 @@ def _uks_exc_strain_deriv(ni, xc_code, dm_kpts, kpts=None, with_j=False, with_nu
             kpts1 = scaled_kpts.dot(cell1.reciprocal_vectors(norm_to=1))
             kpts2 = scaled_kpts.dot(cell2.reciprocal_vectors(norm_to=1))
 
-            update_pairs_info(cell1)
+            ni_copy = _copy_numint_for_strained_cell(ni, cell1, image_translations)
             rho_plus = evaluate_density_on_g_mesh(ni_copy, dm_kpts, kpts1, xctype)
             rho_plus = ifft_in_place(rho_plus.reshape(-1, *mesh)).real
             rho_plus *= ngrids / cell1.vol
 
-            update_pairs_info(cell2)
+            ni_copy = _copy_numint_for_strained_cell(ni, cell2, image_translations)
             rho_minus = evaluate_density_on_g_mesh(ni_copy, dm_kpts, kpts2, xctype)
             rho_minus = ifft_in_place(rho_minus.reshape(-1, *mesh)).real
             rho_minus *= ngrids / cell2.vol

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
@@ -217,13 +217,26 @@ class KnownValues(unittest.TestCase):
         dm = np.eye(cell.nao)[None]
         xc = 'r2scan'
 
-        ni = MultiGridNumInt(cell)
-        ni.mesh = np.asarray(cell.mesh)
-        ni.build('MGGA', gamma_point=False)
-        # The following import is a bug of ruff
-        from gpu4pyscf.pbc.dft.multigrid_v2 import _rks_exc_strain_deriv
-        dat = _rks_exc_strain_deriv(ni, xc, dm, kpts, with_j=False, with_nuc=False)
+        from gpu4pyscf.pbc.dft.multigrid_v2 import (
+            MultiGridNumInt as MultiGridNumIntV2,
+            _rks_exc_strain_deriv,
+        )
+        ni_v2 = MultiGridNumIntV2(cell)
+        ni_v2.mesh = np.asarray(cell.mesh)
+        ni_v2.build('MGGA', gamma_point=False)
+        dat = _rks_exc_strain_deriv(
+            ni_v2, xc, dm, kpts, with_j=False, with_nuc=False)
         assert abs(dat / cell.vol).max() < 1e-3
+
+        # V3 evaluates strain derivatives analytically without rebuilding
+        # neighboring images for displaced cells.
+        for enable_aft in (True, False):
+            ni_v3 = MultiGridNumInt(cell)
+            ni_v3.enable_aft = enable_aft
+            ni_v3.mesh = np.asarray(cell.mesh)
+            dat = ni_v3.energy_strain_gradient(
+                xc, dm, kpts, spin=0, with_j=False, with_nuc=False)
+            assert abs(dat / cell.vol).max() < 1e-3
 
     def test_get_j(self):
         a = np.eye(3) * 5

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
@@ -220,6 +220,7 @@ class KnownValues(unittest.TestCase):
         ni = MultiGridNumInt(cell)
         ni.mesh = np.asarray(cell.mesh)
         ni.build('MGGA', gamma_point=False)
+        from gpu4pyscf.pbc.dft.multigrid_v2 import _rks_exc_strain_deriv
         dat = _rks_exc_strain_deriv(ni, xc, dm, kpts, with_j=False, with_nuc=False)
         assert abs(dat / cell.vol).max() < 1e-3
 

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
@@ -220,6 +220,8 @@ class KnownValues(unittest.TestCase):
         ni = MultiGridNumInt(cell)
         ni.mesh = np.asarray(cell.mesh)
         ni.build('MGGA', gamma_point=False)
+        # The following import is a bug of ruff
+        from gpu4pyscf.pbc.dft.multigrid_v2 import _rks_exc_strain_deriv
         dat = _rks_exc_strain_deriv(ni, xc, dm, kpts, with_j=False, with_nuc=False)
         assert abs(dat / cell.vol).max() < 1e-3
 

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
@@ -220,7 +220,6 @@ class KnownValues(unittest.TestCase):
         ni = MultiGridNumInt(cell)
         ni.mesh = np.asarray(cell.mesh)
         ni.build('MGGA', gamma_point=False)
-        from gpu4pyscf.pbc.dft.multigrid_v2 import _rks_exc_strain_deriv
         dat = _rks_exc_strain_deriv(ni, xc, dm, kpts, with_j=False, with_nuc=False)
         assert abs(dat / cell.vol).max() < 1e-3
 

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
@@ -185,6 +185,44 @@ class KnownValues(unittest.TestCase):
             assert abs(dat1[i,j] - (exc1 - exc2)/2e-4) < 1e-7
             assert abs(dat2[i,j] - (exc1 - exc2)/2e-4) < 1e-7
 
+    def test_multigrid_image_boundary_strain_deriv(self):
+        # The structure is from t-HfO2, all elements are changed to H for fast Cell construction.
+        cell = gto.Cell()
+        cell.atom = [
+            ('H', (1.767935803700000, 1.767935803726000, 2.595423152457000)),
+            ('H', (-0.000000000170000, -0.000000000413000, -0.000000000009000)),
+            ('H', (-0.000000000217000, 1.767935803226000, 3.539517351764000)),
+            ('H', (1.767935803466000, -0.000000000847000, 4.246760404410000)),
+            ('H', (1.767935803449000, -0.000000000675000, 1.651328953277000)),
+            ('H', (-0.000000000265000, 1.767935803396000, 0.944085900686000)),
+        ]
+        cell.a = [
+            [3.535871610000000, 0.000000000293102, -0.000000000005598],
+            [0.000000000293102, 3.535871610000000, -0.000000000129270],
+            [-0.000000000007998, -0.000000000189320, 5.190846310000000],
+        ]
+        cell.unit = 'Angstrom'
+        cell.basis = [[0, [1.0, 1.0]]]
+        cell.rcut = 34.71833632109211
+        cell.precision = 1e-10
+        cell.mesh = [15, 15, 21]
+        cell.build()
+
+        cell_plus, cell_minus = _finite_diff_cells(cell, 0, 0, disp=1e-4)
+        assert len(gto.eval_gto.get_lattice_Ls(cell_plus)) == 946
+        # The minus will have one extra image.
+        assert len(gto.eval_gto.get_lattice_Ls(cell_minus)) == 947
+
+        kpts = cell.make_kpts([1, 1, 1], with_gamma_point=True)
+        dm = np.eye(cell.nao)[None]
+        xc = 'r2scan'
+
+        ni = MultiGridNumInt(cell)
+        ni.mesh = np.asarray(cell.mesh)
+        ni.build('MGGA', gamma_point=False)
+        dat = _rks_exc_strain_deriv(ni, xc, dm, kpts, with_j=False, with_nuc=False)
+        assert abs(dat / cell.vol).max() < 1e-3
+
     def test_get_j(self):
         a = np.eye(3) * 5
         np.random.seed(5)

--- a/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
+++ b/gpu4pyscf/pbc/grad/tests/test_pbc_krks_stress.py
@@ -186,7 +186,7 @@ class KnownValues(unittest.TestCase):
             assert abs(dat2[i,j] - (exc1 - exc2)/2e-4) < 1e-7
 
     def test_multigrid_image_boundary_strain_deriv(self):
-        # The structure is from t-HfO2, all elements are changed to H for fast Cell construction.
+        # The structure is from t-HfO2, all elements are changed to H.
         cell = gto.Cell()
         cell.atom = [
             ('H', (1.767935803700000, 1.767935803726000, 2.595423152457000)),


### PR DESCRIPTION
`_rks_exc_strain_deriv` reused the base cell's cached `image_indices` and block mappings for strained cells while eplacing `neighboring_images` with a new list from `get_lattice_Ls(cell_strained)`. Because `get_lattice_Ls` applies `distance < rcut` cutoff, a boundary image can enter or leave the list under a 1e-4 strain (946 vs 947 images on t-HfO2 -xx/-yy), shifting all subsequent indices and causing pairs to reference wrong translations. A demo example is added as the unit test, and listed here
```python
import numpy as np
from pyscf.data.nist import BOHR
from pyscf.pbc import gto


# Lattice and atomic coordinates of t-HfO2; all elements are changed to H for fast Cell construction.
LATTICE = np.array([
    [3.535871610000000, 0.000000000293102, -0.000000000005598],
    [0.000000000293102, 3.535871610000000, -0.000000000129270],
    [-0.000000000007998, -0.000000000189320, 5.190846310000000],
])
COORDS = [
    (1.767935803700000, 1.767935803726000, 2.595423152457000),
    (-0.000000000170000, -0.000000000413000, -0.000000000009000),
    (-0.000000000217000, 1.767935803226000, 3.539517351764000),
    (1.767935803466000, -0.000000000847000, 4.246760404410000),
    (1.767935803449000, -0.000000000675000, 1.651328953277000),
    (-0.000000000265000, 1.767935803396000, 0.944085900686000),
]


def strained_cell(cell, strain):
    lattice = cell.lattice_vectors()
    coords = cell.atom_coords()
    lattice *= BOHR
    coords *= BOHR
    transform = np.eye(3)
    transform[0, 0] += strain
    new_cell = cell.set_geom_(coords @ transform.T, inplace=False)
    new_cell.a = lattice @ transform.T
    return new_cell


def integer_images(cell):
    images = gto.eval_gto.get_lattice_Ls(cell)
    return np.rint(images @ np.linalg.inv(cell.lattice_vectors())).astype(int)


cell = gto.Cell()
cell.atom = [('H', xyz) for xyz in COORDS]
cell.a = LATTICE
cell.unit = 'Angstrom'
cell.basis = [[0, [1.0, 1.0]]]
cell.rcut = 34.71833632109211
cell.verbose = 0
cell.build()

base = integer_images(cell)
plus = integer_images(strained_cell(cell, +1e-4))
minus = integer_images(strained_cell(cell, -1e-4))

first_mismatch = next(
    i for i, (base_image, minus_image) in enumerate(zip(base, minus))
    if not np.array_equal(base_image, minus_image)
)

assert len(base) == len(plus) == 946
assert len(minus) == 947
assert first_mismatch == 15
```