### PR TITLE
fix: PBC GDF gradient illegal memory access and numerical instability

### DIFF
--- a/gpu4pyscf/pbc/df/grad/krhf.py
+++ b/gpu4pyscf/pbc/df/grad/krhf.py
@@ -25,10 +25,10 @@ from gpu4pyscf.lib import logger
 from gpu4pyscf.lib.cupy_helper import (
     contract, asarray, ndarray, unpack_tril, transpose_sum, get_avail_mem,
     empty_aligned)
-from gpu4pyscf.lib.utils import nearest_power2
 from gpu4pyscf.__config__ import props as gpu_specs
 from gpu4pyscf.pbc.df.int3c2e import libpbc, POOL_SIZE, MAX_IMGS_PER_TASK
-from gpu4pyscf.pbc.df.rsdf_builder import _weighted_coulG_kpts
+from gpu4pyscf.pbc.df.rsdf_builder import (
+    _weighted_coulG_kpts, LINEAR_DEP_THR)
 from gpu4pyscf.pbc.tools.pbc import madelung, _Gv_wrap_around
 from gpu4pyscf.pbc.df import ft_ao, aft_jk
 from gpu4pyscf.pbc.df.grad import rhf
@@ -44,7 +44,8 @@ from gpu4pyscf.pbc.lib.kpts_helper import (
 
 
 def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_factor=1.,
-                        exxdiv=None, omega=None, verbose=None):
+                        exxdiv=None, omega=None, verbose=None,
+                        linear_dep_threshold=LINEAR_DEP_THR):
     '''
     Computes the first-order derivatives of the energy contributions from
     J and K terms per atom.
@@ -52,13 +53,16 @@ def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_fact
     if kpts is None:
         assert dm.ndim == 2
         return rhf._jk_energy_per_atom(
-            int3c2e_opt, dm, hermi, j_factor, k_factor, exxdiv, omega, verbose)
+            int3c2e_opt, dm, hermi, j_factor, k_factor, exxdiv, omega, verbose,
+            linear_dep_threshold)
 
     if hermi == 2:
         j_factor = 0
 
     if k_factor == 0:
-        return _j_energy_per_atom(int3c2e_opt, dm, kpts, hermi, omega, verbose) * j_factor
+        return _j_energy_per_atom(
+            int3c2e_opt, dm, kpts, hermi, omega, verbose,
+            linear_dep_threshold) * j_factor
 
     # Must be symmetric density matrices, otherwise, dm_tensor needs to be
     # symmetrized since PBCsr_ejk_int3c2e_ip1 only handles the tril pairs
@@ -244,7 +248,12 @@ def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_fact
     buf1 = cp.empty((naux, nkpts, nocc, nocc), dtype=np.complex128)
     dm_aux = cp.empty((nkpts_uniq, naux, naux), dtype=np.complex128)
     for j2c_idx, (kp, kp_conj, ki_idx, kj_idx) in enumerate(kpt_iters):
-        metric = aux_coeff.dot(cp.linalg.solve(j2c[j2c_idx], aux_coeff.T))
+        j2c_k = j2c[j2c_idx]
+        if kp == kp_conj:
+            j2c_k = j2c_k.real
+        solve_j2c = rhf._gen_metric_solver(
+            j2c_k, linear_dep_threshold, auxcell.dimension)
+        metric = aux_coeff.dot(solve_j2c(aux_coeff.T))
         j3c_oo_k = j3c_oo[:,ki_idx,kj_idx]
         dm_oo_k = contract('uv,vnij->unij', metric, j3c_oo_k, out=buf)
         dm_oo[:,ki_idx,kj_idx] = dm_oo_k
@@ -463,7 +472,8 @@ def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_fact
     ksh_offsets_gpu = cp.asarray(ksh_offsets_cpu, dtype=np.int32)
 
     nksh_per_batch = ksh_offsets_cpu[1:] - ksh_offsets_cpu[:-1]
-    shl_pair_batch_size = nearest_power2(POOL_SIZE // nksh_per_batch.max())
+    shl_pair_batch_size = rhf._get_shl_pair_batch_size(
+        nksh_per_batch, bvk_ncells)
     bas_ij_idx, shl_pair_offsets = cell.aggregate_shl_pairs(
         int3c2e_opt.bas_ij_cache, nsp_per_block=shl_pair_batch_size)
     ao_pair_loc = get_ao_pair_loc(cell.uniq_l_ctr[:,0], int3c2e_opt.bas_ij_cache, cart=True)
@@ -579,7 +589,7 @@ def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_fact
     return ejk
 
 def _j_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, omega=None,
-                       verbose=None):
+                       verbose=None, linear_dep_threshold=LINEAR_DEP_THR):
     '''
     Computes the first-order derivatives of the Coulomb energy
     '''
@@ -694,7 +704,8 @@ def _j_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, omega=None,
     if auxcell.cell.cart:
         raise NotImplementedError
     else:
-        auxvec = cp.linalg.solve(j2c, auxvec)
+        auxvec = rhf._gen_metric_solver(
+            j2c, linear_dep_threshold, auxcell.dimension)(auxvec)
     auxvec = auxcell.C_dot_mat(auxvec)
     j2c = None
 
@@ -784,7 +795,8 @@ def _j_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, omega=None,
     ksh_offsets_gpu = cp.asarray(ksh_offsets_cpu, dtype=np.int32)
 
     nksh_per_batch = ksh_offsets_cpu[1:] - ksh_offsets_cpu[:-1]
-    shl_pair_batch_size = nearest_power2(POOL_SIZE // nksh_per_batch.max())
+    shl_pair_batch_size = rhf._get_shl_pair_batch_size(
+        nksh_per_batch, bvk_ncells)
     bas_ij_idx, shl_pair_offsets = cell.aggregate_shl_pairs(
         int3c2e_opt.bas_ij_cache, nsp_per_block=shl_pair_batch_size)
 

--- a/gpu4pyscf/pbc/df/grad/kuhf.py
+++ b/gpu4pyscf/pbc/df/grad/kuhf.py
@@ -23,7 +23,6 @@ from pyscf.pbc.tools.k2gamma import double_translation_indices
 from gpu4pyscf.lib import logger
 from gpu4pyscf.lib.cupy_helper import (
     contract, asarray, ndarray, unpack_tril, get_avail_mem, empty_aligned)
-from gpu4pyscf.lib.utils import nearest_power2
 from gpu4pyscf.__config__ import props as gpu_specs
 from gpu4pyscf.pbc.df.int3c2e import libpbc, POOL_SIZE, MAX_IMGS_PER_TASK
 from gpu4pyscf.pbc.tools.pbc import madelung, _Gv_wrap_around
@@ -31,9 +30,10 @@ from gpu4pyscf.pbc.df import ft_ao, aft_jk
 from gpu4pyscf.pbc.df.grad.krhf import (
     _split_l_ctr_pattern, get_ao_pair_loc, int3c2e_scheme, factorize_dm,
     _j_energy_per_atom)
-from gpu4pyscf.pbc.df.rsdf_builder import _weighted_coulG_kpts
+from gpu4pyscf.pbc.df.rsdf_builder import (
+    _weighted_coulG_kpts, LINEAR_DEP_THR)
 from gpu4pyscf.pbc.df.int2c2e import Int2c2eOpt, _estimate_sr_2c2e_rcut
-from gpu4pyscf.pbc.df.grad import uhf
+from gpu4pyscf.pbc.df.grad import rhf, uhf
 from gpu4pyscf.pbc.grad.krhf import contract_h1e_dm
 from gpu4pyscf.gto.mole import groupby
 from gpu4pyscf.pbc.gto import int1e
@@ -42,21 +42,24 @@ from gpu4pyscf.pbc.lib.kpts_helper import (
 
 
 def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_factor=1.,
-                        exxdiv=None, omega=None, verbose=None):
+                        exxdiv=None, omega=None, verbose=None,
+                        linear_dep_threshold=LINEAR_DEP_THR):
     '''
     Computes the first-order derivatives of the energy contributions from
     J and K terms per atom.
     '''
     if kpts is None:
         return uhf._jk_energy_per_atom(
-            int3c2e_opt, dm, hermi, j_factor, k_factor, exxdiv, omega, verbose)
+            int3c2e_opt, dm, hermi, j_factor, k_factor, exxdiv, omega, verbose,
+            linear_dep_threshold)
 
     if hermi == 2:
         j_factor = 0
 
     if k_factor == 0:
-        return _j_energy_per_atom(int3c2e_opt, dm[0]+dm[1], hermi,
-                                  omega, verbose) * j_factor
+        return _j_energy_per_atom(int3c2e_opt, dm[0]+dm[1], kpts, hermi,
+                                  omega, verbose,
+                                  linear_dep_threshold) * j_factor
 
     assert hermi == 1 or hermi == 2
     cell = int3c2e_opt.cell
@@ -229,7 +232,12 @@ def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_fact
     buf1 = cp.empty((2, naux, nkpts, nocc, nocc), dtype=np.complex128)
     dm_aux = cp.empty((nkpts_uniq, naux, naux), dtype=np.complex128)
     for j2c_idx, (kp, kp_conj, ki_idx, kj_idx) in enumerate(kpt_iters):
-        metric = aux_coeff.dot(cp.linalg.solve(j2c[j2c_idx], aux_coeff.T))
+        j2c_k = j2c[j2c_idx]
+        if kp == kp_conj:
+            j2c_k = j2c_k.real
+        solve_j2c = rhf._gen_metric_solver(
+            j2c_k, linear_dep_threshold, auxcell.dimension)
+        metric = aux_coeff.dot(solve_j2c(aux_coeff.T))
         j3c_oo_k = j3c_oo[:,:,ki_idx,kj_idx]
         dm_oo_k = contract('uv,svnij->sunij', metric, j3c_oo_k, out=buf)
         dm_oo[:,:,ki_idx,kj_idx] = dm_oo_k
@@ -405,7 +413,8 @@ def _jk_energy_per_atom(int3c2e_opt, dm, kpts=None, hermi=0, j_factor=1., k_fact
     ksh_offsets_gpu = cp.asarray(ksh_offsets_cpu, dtype=np.int32)
 
     nksh_per_batch = ksh_offsets_cpu[1:] - ksh_offsets_cpu[:-1]
-    shl_pair_batch_size = nearest_power2(POOL_SIZE // nksh_per_batch.max())
+    shl_pair_batch_size = rhf._get_shl_pair_batch_size(
+        nksh_per_batch, bvk_ncells)
     bas_ij_idx, shl_pair_offsets = cell.aggregate_shl_pairs(
         int3c2e_opt.bas_ij_cache, nsp_per_block=shl_pair_batch_size)
     ao_pair_loc = get_ao_pair_loc(cell.uniq_l_ctr[:,0], int3c2e_opt.bas_ij_cache, cart=True)

--- a/gpu4pyscf/pbc/df/grad/rhf.py
+++ b/gpu4pyscf/pbc/df/grad/rhf.py
@@ -28,7 +28,8 @@ from gpu4pyscf.df.int3c2e_bdiv import (
 from gpu4pyscf.df.grad.rhf import factorize_dm
 from gpu4pyscf.pbc.df import ft_ao, aft_jk
 from gpu4pyscf.pbc.df.int3c2e import libpbc, POOL_SIZE, MAX_IMGS_PER_TASK, int3c2e_scheme
-from gpu4pyscf.pbc.df.rsdf_builder import _weighted_coulG_kpts
+from gpu4pyscf.pbc.df.rsdf_builder import (
+    _weighted_coulG_kpts, decompose_j2c, LINEAR_DEP_THR)
 from gpu4pyscf.pbc.df.int2c2e import Int2c2eOpt, _estimate_sr_2c2e_rcut
 from gpu4pyscf.gto.mole import groupby
 from gpu4pyscf.pbc.gto import int1e
@@ -37,8 +38,43 @@ from gpu4pyscf.pbc.tools.pbc import madelung
 from gpu4pyscf.__config__ import props as gpu_specs
 
 
+def _gen_metric_solver(j2c, linear_dep_threshold=LINEAR_DEP_THR,
+                       dimension=3):
+    '''
+    Generate a pseudo-inverse solver consistent with the CDERI metric.
+    Mostly copied from pyscf.df.rsdf_builder._precontract_j2c_aux_coeff.
+    '''
+    metric, metric_negative, _ = decompose_j2c(
+        j2c, prefer_ed=True, linear_dep_threshold=linear_dep_threshold)
+    if metric_negative is not None and dimension != 2:
+        raise RuntimeError(
+            'Negative auxiliary metric is only supported for 2D systems')
+    naux = j2c.shape[0]
+
+    def solve(rhs):
+        shape = rhs.shape
+        rhs = rhs.reshape(naux, -1)
+        out = metric.dot(metric.conj().T.dot(rhs))
+        if metric_negative is not None:
+            out -= metric_negative.dot(metric_negative.conj().T.dot(rhs))
+        return out.reshape(shape)
+    return solve
+
+
+def _get_shl_pair_batch_size(nksh_per_batch, bvk_ncells):
+    '''add the constraint of the bvk_ncells to the max_pairs'''
+    max_nksh = int(np.max(nksh_per_batch))
+    max_pairs = POOL_SIZE // (max_nksh * bvk_ncells)
+    if max_pairs < 1:
+        raise RuntimeError(
+            f'CUDA task pool is too small: POOL_SIZE={POOL_SIZE}, '
+            f'max_nksh={max_nksh}, bvk_ncells={bvk_ncells}')
+    return nearest_power2(max_pairs)
+
+
 def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
-                        exxdiv=None, omega=None, verbose=None):
+                        exxdiv=None, omega=None, verbose=None,
+                        linear_dep_threshold=LINEAR_DEP_THR):
     '''
     Computes the first-order derivatives of the energy contributions from
     J and K terms per atom.
@@ -46,7 +82,9 @@ def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
     if hermi == 2:
         j_factor = 0
     if k_factor == 0:
-        return _j_energy_per_atom(int3c2e_opt, dm, hermi, omega, verbose) * j_factor
+        return _j_energy_per_atom(
+            int3c2e_opt, dm, hermi, omega, verbose,
+            linear_dep_threshold) * j_factor
 
     assert hermi == 1 or hermi == 2
     cell = int3c2e_opt.cell
@@ -170,7 +208,9 @@ def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
         raise NotImplementedError
     else:
         aux_coeff = cp.asarray(auxcell.ctr_coeff)
-        metric = aux_coeff.dot(cp.linalg.solve(j2c, aux_coeff.T))
+        solve_j2c = _gen_metric_solver(
+            j2c, linear_dep_threshold, auxcell.dimension)
+        metric = aux_coeff.dot(solve_j2c(aux_coeff.T))
     j2c = aux_coeff = None
     dm_oo = cp.einsum('uv,vij->uij', metric, j3c_oo)
     metric = j3c_oo = None
@@ -325,7 +365,8 @@ def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
     ksh_offsets_gpu = cp.asarray(ksh_offsets_cpu, dtype=np.int32)
 
     nksh_per_batch = ksh_offsets_cpu[1:] - ksh_offsets_cpu[:-1]
-    shl_pair_batch_size = nearest_power2(POOL_SIZE // nksh_per_batch.max())
+    shl_pair_batch_size = _get_shl_pair_batch_size(
+        nksh_per_batch, bvk_ncells)
     bas_ij_idx, shl_pair_offsets = cell.aggregate_shl_pairs(
         int3c2e_opt.bas_ij_cache, nsp_per_block=shl_pair_batch_size)
     ao_pair_loc = get_ao_pair_loc(cell.uniq_l_ctr[:,0], int3c2e_opt.bas_ij_cache, cart=True)
@@ -421,12 +462,14 @@ def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
         ejk += ejk_ewald
     return ejk
 
-def _j_energy_per_atom(int3c2e_opt, dm, hermi=0, omega=None, verbose=None):
+def _j_energy_per_atom(int3c2e_opt, dm, hermi=0, omega=None, verbose=None,
+                       linear_dep_threshold=LINEAR_DEP_THR):
     '''
     Computes the first-order derivatives of the Coulomb energy
     '''
     cell = int3c2e_opt.cell
     auxcell = int3c2e_opt.auxcell
+    bvk_ncells = len(int3c2e_opt.bvkmesh_Ls)
     log = logger.new_logger(cell, verbose)
     t0 = log.init_timer()
 
@@ -512,7 +555,8 @@ def _j_energy_per_atom(int3c2e_opt, dm, hermi=0, omega=None, verbose=None):
     if auxcell.cell.cart:
         raise NotImplementedError
     else:
-        auxvec = cp.linalg.solve(j2c, auxvec)
+        auxvec = _gen_metric_solver(
+            j2c, linear_dep_threshold, auxcell.dimension)(auxvec)
     auxvec = auxcell.C_dot_mat(auxvec)
     j2c = None
 
@@ -602,7 +646,8 @@ def _j_energy_per_atom(int3c2e_opt, dm, hermi=0, omega=None, verbose=None):
     ksh_offsets_gpu = cp.asarray(ksh_offsets_cpu, dtype=np.int32)
 
     nksh_per_batch = ksh_offsets_cpu[1:] - ksh_offsets_cpu[:-1]
-    shl_pair_batch_size = nearest_power2(POOL_SIZE // nksh_per_batch.max())
+    shl_pair_batch_size = _get_shl_pair_batch_size(
+        nksh_per_batch, bvk_ncells)
     bas_ij_idx, shl_pair_offsets = cell.aggregate_shl_pairs(
         int3c2e_opt.bas_ij_cache, nsp_per_block=shl_pair_batch_size)
 

--- a/gpu4pyscf/pbc/df/grad/uhf.py
+++ b/gpu4pyscf/pbc/df/grad/uhf.py
@@ -22,14 +22,15 @@ from pyscf.pbc.tools import k2gamma
 from gpu4pyscf.lib import logger
 from gpu4pyscf.lib.cupy_helper import (
     contract, asarray, ndarray, get_avail_mem, empty_aligned)
-from gpu4pyscf.lib.utils import nearest_power2
 from gpu4pyscf.df.int3c2e_bdiv import (
     _split_l_ctr_pattern, get_ao_pair_loc, SHM_SIZE, LMAX, L_AUX_MAX, THREADS)
 from gpu4pyscf.pbc.df import ft_ao, aft_jk
 from gpu4pyscf.pbc.df.int3c2e import libpbc, POOL_SIZE, MAX_IMGS_PER_TASK
-from gpu4pyscf.pbc.df.rsdf_builder import _weighted_coulG_kpts
+from gpu4pyscf.pbc.df.rsdf_builder import (
+    _weighted_coulG_kpts, LINEAR_DEP_THR)
 from gpu4pyscf.pbc.df.grad.rhf import (
-    int3c2e_scheme, _j_energy_per_atom, factorize_dm)
+    int3c2e_scheme, _j_energy_per_atom, factorize_dm, _gen_metric_solver,
+    _get_shl_pair_batch_size)
 from gpu4pyscf.pbc.df.int2c2e import Int2c2eOpt, _estimate_sr_2c2e_rcut
 from gpu4pyscf.gto.mole import groupby
 from gpu4pyscf.pbc.gto import int1e
@@ -39,7 +40,8 @@ from gpu4pyscf.__config__ import props as gpu_specs
 
 
 def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
-                        exxdiv=None, omega=None, verbose=None):
+                        exxdiv=None, omega=None, verbose=None,
+                        linear_dep_threshold=LINEAR_DEP_THR):
     '''
     Computes the first-order derivatives of the energy contributions from
     J and K terms per atom.
@@ -48,7 +50,8 @@ def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
         j_factor = 0
     if k_factor == 0:
         return _j_energy_per_atom(int3c2e_opt, dm[0]+dm[1], hermi,
-                                  omega, verbose) * j_factor
+                                  omega, verbose,
+                                  linear_dep_threshold) * j_factor
 
     assert hermi == 1 or hermi == 2
     cell = int3c2e_opt.cell
@@ -174,7 +177,9 @@ def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
         raise NotImplementedError
     else:
         aux_coeff = cp.asarray(auxcell.ctr_coeff)
-        metric = aux_coeff.dot(cp.linalg.solve(j2c, aux_coeff.T))
+        solve_j2c = _gen_metric_solver(
+            j2c, linear_dep_threshold, auxcell.dimension)
+        metric = aux_coeff.dot(solve_j2c(aux_coeff.T))
     j2c = aux_coeff = None
     dm_oo = cp.einsum('uv,nvij->nuij', metric, j3c_oo)
     metric = j3c_oo = None
@@ -314,7 +319,8 @@ def _jk_energy_per_atom(int3c2e_opt, dm, hermi=0, j_factor=1., k_factor=1.,
     ksh_offsets_gpu = cp.asarray(ksh_offsets_cpu, dtype=np.int32)
 
     nksh_per_batch = ksh_offsets_cpu[1:] - ksh_offsets_cpu[:-1]
-    shl_pair_batch_size = nearest_power2(POOL_SIZE // nksh_per_batch.max())
+    shl_pair_batch_size = _get_shl_pair_batch_size(
+        nksh_per_batch, bvk_ncells)
     bas_ij_idx, shl_pair_offsets = cell.aggregate_shl_pairs(
         int3c2e_opt.bas_ij_cache, nsp_per_block=shl_pair_batch_size)
     ao_pair_loc = get_ao_pair_loc(cell.uniq_l_ctr[:,0], int3c2e_opt.bas_ij_cache, cart=True)

--- a/gpu4pyscf/pbc/df/tests/test_pbc_df_grad.py
+++ b/gpu4pyscf/pbc/df/tests/test_pbc_df_grad.py
@@ -1026,3 +1026,30 @@ def test_uhf_ejk_ip1_kpts_with_long_range1():
         e1 = eval_jk(i, x, disp)
         e2 = eval_jk(i, x, -disp)
         assert abs((e1 - e2)/(2*disp)- ejk[i,x]) < 1e-6
+
+
+def test_metric_solver_with_linear_dependency():
+    rng = np.random.default_rng(12)
+    a = rng.standard_normal((3, 3)) + 1j*rng.standard_normal((3, 3))
+    vectors = np.linalg.qr(a)[0]
+    eigenvalues = np.array([2., 1e-12, -.5])
+    j2c = vectors @ np.diag(eigenvalues) @ vectors.conj().T
+    rhs = rng.standard_normal((3, 2)) + 1j*rng.standard_normal((3, 2))
+
+    solve_j2c = rhf._gen_metric_solver(
+        cp.asarray(j2c), 1e-10, dimension=2)
+    result = solve_j2c(cp.asarray(rhs)).get()
+
+    keep = np.array([0, 2])
+    expected = vectors[:,keep] @ np.diag(1/eigenvalues[keep])
+    expected = expected @ vectors[:,keep].conj().T @ rhs
+    assert abs(result - expected).max() < 1e-12
+
+
+def test_task_pool_batch_size_includes_bvk_cells():
+    nksh_per_batch = np.array([12, 36, 24])
+    batch_size = rhf._get_shl_pair_batch_size(
+        nksh_per_batch, bvk_ncells=4)
+
+    assert batch_size == 64 # 16383 // (36 * 4) = 113, nearest smaller power of 2 is 64
+    assert batch_size * nksh_per_batch.max() * 4 <= int3c2e.POOL_SIZE # 64 * 36 * 4 <= 16384

--- a/gpu4pyscf/pbc/grad/rhf.py
+++ b/gpu4pyscf/pbc/grad/rhf.py
@@ -272,7 +272,9 @@ def jk_energy_per_atom(mf, dm, kpts=None, j_factor=1, lr_factor=1, sr_factor=1,
             rsdf_omega = 0.3
             int3c2e_opt = SRInt3c2eOpt(cell, with_df.auxcell, rsdf_omega, kmesh).build()
             hermi = 1
-            ej = _jk_energy_per_atom(int3c2e_opt, dm, kpts, hermi, j_factor, 0)
+            ej = _jk_energy_per_atom(
+                int3c2e_opt, dm, kpts, hermi, j_factor, 0,
+                linear_dep_threshold=with_df.linear_dep_threshold)
             j_factor = 0
 
         with_rsjk = mf.rsjk
@@ -317,7 +319,8 @@ def jk_energy_per_atom(mf, dm, kpts=None, j_factor=1, lr_factor=1, sr_factor=1,
             int3c2e_opt = SRInt3c2eOpt(cell, auxcell, rsdf_omega, kmesh).build()
             hermi = 1
             return _jk_energy_per_atom(
-                int3c2e_opt, dm, kpts, hermi, j_factor, k_factor, exxdiv, omega)
+                int3c2e_opt, dm, kpts, hermi, j_factor, k_factor, exxdiv, omega,
+                linear_dep_threshold=with_df.linear_dep_threshold)
 
         def get_k_lr(k_factor, omega, exxdiv):
             with AFTDF(cell).range_coulomb(omega) as mydf:

--- a/gpu4pyscf/pbc/grad/uhf.py
+++ b/gpu4pyscf/pbc/grad/uhf.py
@@ -156,7 +156,9 @@ def jk_energy_per_atom(mf, dm, kpts=None, j_factor=1, lr_factor=1, sr_factor=1,
             rsdf_omega = 0.3
             int3c2e_opt = SRInt3c2eOpt(cell, with_df.auxcell, rsdf_omega, kmesh).build()
             hermi = 1
-            ej = _jk_energy_per_atom(int3c2e_opt, dm[0]+dm[1], kpts, hermi, j_factor, 0)
+            ej = _jk_energy_per_atom(
+                int3c2e_opt, dm[0]+dm[1], kpts, hermi, j_factor, 0,
+                linear_dep_threshold=with_df.linear_dep_threshold)
             j_factor = 0
 
         with_rsjk = mf.rsjk
@@ -198,7 +200,8 @@ def jk_energy_per_atom(mf, dm, kpts=None, j_factor=1, lr_factor=1, sr_factor=1,
             int3c2e_opt = SRInt3c2eOpt(cell, auxcell, rsdf_omega, kmesh).build()
             hermi = 1
             return _jk_energy_per_atom(
-                int3c2e_opt, dm, kpts, hermi, j_factor, k_factor, exxdiv, omega)
+                int3c2e_opt, dm, kpts, hermi, j_factor, k_factor, exxdiv, omega,
+                linear_dep_threshold=with_df.linear_dep_threshold)
 
         def get_k_lr(k_factor, omega, exxdiv):
             with AFTDF(cell).range_coulomb(omega) as mydf:


### PR DESCRIPTION
Two bugs in PBC GDF gradients are fixed:

1. **Task pool overflow**: `_get_shl_pair_batch_size()` now divides the CUDA pair by `bvk_ncells` so that `shell_pairs × aux_shells × bvk_ncells ≤ POOL_SIZE`, preventing illegal memory access.

2. **Ill-conditioned metric inversion**: `_gen_metric_solver()` replaces direct `cp.linalg.solve(j2c, …)` with an eigenvalue-decomposed truncated pseudoinverse using `with_df.linear_dep_threshold`, matching the auxiliary subspace used in SCF CDERI construction.