### PR TITLE
fix invalid load

### DIFF
--- a/gpu4pyscf/lib/gvhf-md/md_contract_j.cu
+++ b/gpu4pyscf/lib/gvhf-md/md_contract_j.cu
@@ -358,7 +358,10 @@ void md_j_1dm_kernel(RysIntEnvVars envs, JKMatrix jk, MDBoundsInfo bounds,
         {
             double *vj_cache = Rp_cache + t_id;
             int task_ij = task_ij0 + tx;
-            int ij_loc0 = pair_ij_loc[task_ij];
+            int ij_loc0 = 0;
+            if (task_ij < npairs_ij) {
+                ij_loc0 = pair_ij_loc[task_ij];
+            }
 #pragma unroll
             for (int n = 0, i = gout_id; n < IJ_SIZE; ++n, i += gout_stride) {
                 if (i >= nf3ij+gout_id) break;

--- a/gpu4pyscf/scf/tests/test_scf_j_engine.py
+++ b/gpu4pyscf/scf/tests/test_scf_j_engine.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import unittest
+import cupy as cp
 import numpy as np
 import pyscf
-from pyscf import lib
+from pyscf import dft, lib
 from gpu4pyscf.scf import j_engine, jk
 from pyscf.scf.hf import get_jk
 
@@ -53,6 +54,33 @@ def test_j_engine():
     ref = get_jk(mol, dm, hermi=1, with_k=False)[0]
     assert abs(vj1 - ref).max() < 5e-9
     assert abs(lib.fp(vj1) - -3491.404124194866) < 1e-9
+
+def test_j_engine_one_density_tail():
+    """Exercise the one-DM (fd|ps) tail with 2 pairs and 8 ij threads.
+
+    Inactive ij lanes must participate in block-wide reductions without reading
+    past the corresponding pair-location entries.
+    """
+    mol = pyscf.M(
+        atom='''
+        O  0.000000  0.000000  0.000000
+        H  0.758602  0.000000  0.504284
+        H  0.758602  0.000000 -0.504284
+        ''',
+        basis='def2-tzvp',
+        charge=1,
+        spin=1,
+        verbose=0,
+    )
+    spin_dm = dft.UKS(mol).get_init_guess()
+    dm = spin_dm[0] + spin_dm[1]
+
+    # Give pair_loc a distinct CUDA allocation boundary so a memory checker can
+    # detect tail reads that spare capacity in CuPy's memory pool may hide.
+    with cp.cuda.using_allocator(None):
+        vj = j_engine.get_j(mol, dm).get()
+    ref = get_jk(mol, dm, with_k=False)[0]
+    assert abs(vj - ref).max() < 1e-9
 
 def test_j_engine_8fold_symmetry():
     mol = pyscf.M(


### PR DESCRIPTION
## Summary

Fix an out-of-bounds read in `md_j_1dm_kernel` when the final `ij` tile contains fewer pairs than CUDA lanes.

## Problem

The one-density MD J kernel loaded `pair_ij_loc[task_ij]` before checking whether `task_ij` represented a valid pair. Tail lanes are required to participate in the block-wide reduction and synchronization, but they do not correspond to real `ij` tasks.

The issue was observed for H2O+ with def2-TZVP in the `(fd|ps)` quartet:

- `npairs_ij = 2`
- `threadsx = 8`
- `tilex = 32`

This leaves lanes `tx=2..7` without corresponding pairs. Although the final `atomicAdd` was already guarded by `task_ij < npairs_ij`, the `pair_ij_loc` lookup occurred before that guard.

The resulting value was normally discarded, so numerical results could remain correct. Whether the read produced a CUDA memory error depended on GPU architecture, compiler optimization, and allocation layout. The error was observed on an A100 but remained latent on another GPU.


Add a focused H2O+/def2-TZVP regression that:

selects the one-density kernel by combining the UKS spin densities;
exercises the observed (fd|ps) partial tile;
bypasses CuPy's memory pool so memory checkers can observe the actual allocation boundary;
verifies the resulting Coulomb matrix against the CPU reference.
A temporary unconditional device assertion before the original lookup confirmed that the test reaches the invalid tail lanes. The test failed with cudaErrorAssert before the fix and passed after guarding the lookup.