### PR TITLE
Fix tests in CUDA 13 + newer version of cutensor, cupy, numpy, etc.

### DIFF
--- a/gpu4pyscf/df/tests/test_df_tddft_ris.py
+++ b/gpu4pyscf/df/tests/test_df_tddft_ris.py
@@ -19,6 +19,7 @@ import pyscf
 from pyscf import lib, gto, scf, dft
 from gpu4pyscf import tdscf
 import gpu4pyscf
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -38,21 +39,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/df/tests/test_df_tddft_ris_nac.py
+++ b/gpu4pyscf/df/tests/test_df_tddft_ris_nac.py
@@ -19,6 +19,7 @@ import pyscf
 from pyscf import lib
 from gpu4pyscf import tdscf, nac
 import pytest
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -42,22 +43,6 @@ def tearDownModule():
     mol.stdout.close()
     molpbe.stdout.close()
     del mol, molpbe
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
 
 class KnownValues(unittest.TestCase):
     def test_nac_pbe_tdaris_singlet_vs_ref_ge(self):

--- a/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
@@ -24,7 +24,7 @@ from gpu4pyscf.df import int3c2e_bdiv as int3c2e
 from gpu4pyscf.df.grad import tdrhf as df_tdrhf_grad
 from gpu4pyscf.df.grad.tdrhf import _jk_energy_per_atom, _jk_energies_per_atom
 from gpu4pyscf.df.grad import rhf as rhf_grad
-from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize, diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -33,24 +33,6 @@ H       0.0000000000     0.7570000000     0.5870000000
 """
 
 bas0 = "def2svpd"
-
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a        , b       ],
-                     [-b.conj(),-a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc, nvir, grad_elec, tda):

--- a/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrhf_grad.py
@@ -24,6 +24,7 @@ from gpu4pyscf.df import int3c2e_bdiv as int3c2e
 from gpu4pyscf.df.grad import tdrhf as df_tdrhf_grad
 from gpu4pyscf.df.grad.tdrhf import _jk_energy_per_atom, _jk_energies_per_atom
 from gpu4pyscf.df.grad import rhf as rhf_grad
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -42,21 +43,6 @@ def diagonalize(a, b, nroots=5):
     h = np.block([[a        , b       ],
                      [-b.conj(),-a.conj()]])
     e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
     sorted_indices = np.argsort(e)
     
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/df/tests/test_df_tdrhf_nac.py
+++ b/gpu4pyscf/df/tests/test_df_tdrhf_nac.py
@@ -20,6 +20,7 @@ from pyscf import lib, gto, scf, dft
 from gpu4pyscf import tdscf, nac
 import gpu4pyscf
 from gpu4pyscf.lib.multi_gpu import num_devices
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -39,21 +40,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/df/tests/test_df_tdrks_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrks_grad.py
@@ -19,6 +19,8 @@ import pytest
 from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
+
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -37,21 +39,6 @@ def diagonalize(a, b, nroots=5):
     h = np.block([[a        , b       ],
                      [-b.conj(),-a.conj()]])
     e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
     sorted_indices = np.argsort(e)
     
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/df/tests/test_df_tdrks_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrks_grad.py
@@ -19,7 +19,7 @@ import pytest
 from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
-from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize, diagonalize_tda
 
 
 atom = """
@@ -29,24 +29,6 @@ H       0.0000000000     0.7570000000     0.5870000000
 """
 
 bas0 = "def2svpd"
-
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a        , b       ],
-                     [-b.conj(),-a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc, nvir, grad_elec, tda):

--- a/gpu4pyscf/df/tests/test_df_tdrks_nac.py
+++ b/gpu4pyscf/df/tests/test_df_tdrks_nac.py
@@ -20,6 +20,7 @@ from pyscf import lib
 from gpu4pyscf import tdscf, nac
 from gpu4pyscf.lib.multi_gpu import num_devices
 import pytest
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -39,21 +40,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/df/tests/test_df_tdrks_ris_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrks_ris_grad.py
@@ -20,6 +20,7 @@ from pyscf import scf, dft, tdscf, lib
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 import gpu4pyscf.tdscf.ris as ris
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -36,21 +37,6 @@ def diagonalize(a, b, nroots=5):
     b = b.reshape(nov, nov)
     h = np.block([[a, b], [-b.conj(), -a.conj()]])
     e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/df/tests/test_df_tdrks_ris_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tdrks_ris_grad.py
@@ -20,7 +20,7 @@ from pyscf import scf, dft, tdscf, lib
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 import gpu4pyscf.tdscf.ris as ris
-from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize, diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -29,22 +29,6 @@ H       0.0000000000     0.7570000000     0.5870000000
 """
 
 bas0 = "cc-pvdz"
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a, b], [-b.conj(), -a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc, nvir, grad_elec, tda):

--- a/gpu4pyscf/df/tests/test_df_tduhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tduhf_grad.py
@@ -20,7 +20,7 @@ import pytest
 from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
-from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize, diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -48,30 +48,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize(a, b, nroots=5):
-    a_aa, a_ab, a_bb = a
-    b_aa, b_ab, b_bb = b
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    a_ab = a_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    a_bb = a_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    b_aa = b_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    b_ab = b_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    b_bb = b_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    a = np.block([[a_aa, a_ab], [a_ab.T, a_bb]])
-    b = np.block([[b_aa, b_ab], [b_ab.T, b_bb]])
-    abba = np.asarray(np.block([[a, b], [-b.conj(), -a.conj()]]))
-    e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc_a, nvir_a, nocc_b, nvir_b, grad_elec, tda):

--- a/gpu4pyscf/df/tests/test_df_tduhf_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tduhf_grad.py
@@ -20,6 +20,7 @@ import pytest
 from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -63,24 +64,6 @@ def diagonalize(a, b, nroots=5):
     b = np.block([[b_aa, b_ab], [b_ab.T, b_bb]])
     abba = np.asarray(np.block([[a, b], [-b.conj(), -a.conj()]]))
     e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    a_aa, a_ab, a_bb = a
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    a_ab = a_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    a_bb = a_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    a = np.block([[a_aa, a_ab], [a_ab.T, a_bb]])
-    e, xy = np.linalg.eig(a)
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/df/tests/test_df_tduks_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tduks_grad.py
@@ -20,6 +20,7 @@ import pytest
 from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
+from gpu4pyscf.df.tests.test_df_tduhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -63,24 +64,6 @@ def diagonalize(a, b, nroots=5):
     b = np.block([[b_aa, b_ab], [b_ab.T, b_bb]])
     abba = np.asarray(np.block([[a, b], [-b.conj(), -a.conj()]]))
     e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    a_aa, a_ab, a_bb = a
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    a_ab = a_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    a_bb = a_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    a = np.block([[a_aa, a_ab], [a_ab.T, a_bb]])
-    e, xy = np.linalg.eig(a)
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/df/tests/test_df_tduks_grad.py
+++ b/gpu4pyscf/df/tests/test_df_tduks_grad.py
@@ -20,7 +20,7 @@ import pytest
 from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
-from gpu4pyscf.df.tests.test_df_tduhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize, diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -48,30 +48,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize(a, b, nroots=5):
-    a_aa, a_ab, a_bb = a
-    b_aa, b_ab, b_bb = b
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    a_ab = a_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    a_bb = a_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    b_aa = b_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    b_ab = b_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    b_bb = b_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    a = np.block([[a_aa, a_ab], [a_ab.T, a_bb]])
-    b = np.block([[b_aa, b_ab], [b_ab.T, b_bb]])
-    abba = np.asarray(np.block([[a, b], [-b.conj(), -a.conj()]]))
-    e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc_a, nvir_a, nocc_b, nvir_b, grad_elec, tda):

--- a/gpu4pyscf/grad/tests/test_tddft_ris_grad.py
+++ b/gpu4pyscf/grad/tests/test_tddft_ris_grad.py
@@ -20,7 +20,7 @@ from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 import gpu4pyscf.tdscf.ris as ris
-from gpu4pyscf.df.tests.test_df_tdrhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize, diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -29,22 +29,6 @@ H       0.0000000000     0.7570000000     0.5870000000
 """
 
 bas0 = "cc-pvdz"
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a, b], [-b.conj(), -a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc, nvir, grad_elec, tda):

--- a/gpu4pyscf/grad/tests/test_tddft_ris_grad.py
+++ b/gpu4pyscf/grad/tests/test_tddft_ris_grad.py
@@ -20,6 +20,7 @@ from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 import gpu4pyscf.tdscf.ris as ris
+from gpu4pyscf.df.tests.test_df_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -36,21 +37,6 @@ def diagonalize(a, b, nroots=5):
     b = b.reshape(nov, nov)
     h = np.block([[a, b], [-b.conj(), -a.conj()]])
     e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/grad/tests/test_tdrhf_grad.py
+++ b/gpu4pyscf/grad/tests/test_tdrhf_grad.py
@@ -53,7 +53,7 @@ def diagonalize_tda(a, nroots=5):
     nocc, nvir = a.shape[:2]
     nov = nocc * nvir
     a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
+    e, xy = np.linalg.eigh(np.asarray(a))
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/grad/tests/test_tdrhf_grad.py
+++ b/gpu4pyscf/grad/tests/test_tdrhf_grad.py
@@ -39,6 +39,10 @@ def diagonalize(a, b, nroots=5):
     h = np.block([[a, b], 
                   [-b.conj(), -a.conj()]])
     e, xy = np.linalg.eig(np.asarray(h))
+    assert np.max(np.abs(e.imag)) < 1e-14
+    assert np.max(np.abs(xy.imag)) < 1e-14
+    e = e.real
+    xy = xy.real
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/grad/tests/test_tdrks_grad.py
+++ b/gpu4pyscf/grad/tests/test_tdrks_grad.py
@@ -20,7 +20,7 @@ from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 from gpu4pyscf.lib.multi_gpu import num_devices
-from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize, diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -29,22 +29,6 @@ H       0.0000000000     0.7570000000     0.5870000000
 """
 
 bas0 = "cc-pvdz"
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a, b], [-b.conj(), -a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc, nvir, tda, singlet=True):

--- a/gpu4pyscf/grad/tests/test_tdrks_grad.py
+++ b/gpu4pyscf/grad/tests/test_tdrks_grad.py
@@ -20,6 +20,7 @@ from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 from gpu4pyscf.lib.multi_gpu import num_devices
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -36,21 +37,6 @@ def diagonalize(a, b, nroots=5):
     b = b.reshape(nov, nov)
     h = np.block([[a, b], [-b.conj(), -a.conj()]])
     e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/grad/tests/test_tduhf_grad.py
+++ b/gpu4pyscf/grad/tests/test_tduhf_grad.py
@@ -61,7 +61,7 @@ def diagonalize_tda(a, nroots=5):
     a_ab = a_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
     a_bb = a_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
     a = np.block([[a_aa, a_ab], [a_ab.T, a_bb]])
-    e, xy = np.linalg.eig(a)
+    e, xy = np.linalg.eigh(a)
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/grad/tests/test_tduhf_grad.py
+++ b/gpu4pyscf/grad/tests/test_tduhf_grad.py
@@ -44,6 +44,10 @@ def diagonalize(a, b, nroots=5):
     b = np.block([[b_aa, b_ab], [b_ab.T, b_bb]])
     abba = np.asarray(np.block([[a, b], [-b.conj(), -a.conj()]]))
     e, xy = np.linalg.eig(abba)
+    assert np.max(np.abs(e.imag)) < 1e-14
+    assert np.max(np.abs(xy.imag)) < 1e-14
+    e = e.real
+    xy = xy.real
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/grad/tests/test_tduks_grad.py
+++ b/gpu4pyscf/grad/tests/test_tduks_grad.py
@@ -20,6 +20,7 @@ from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 from gpu4pyscf.lib.multi_gpu import num_devices
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -43,24 +44,6 @@ def diagonalize(a, b, nroots=5):
     b = np.block([[b_aa, b_ab], [b_ab.T, b_bb]])
     abba = np.asarray(np.block([[a, b], [-b.conj(), -a.conj()]]))
     e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda(a, nroots=5):
-    a_aa, a_ab, a_bb = a
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    a_ab = a_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    a_bb = a_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    a = np.block([[a_aa, a_ab], [a_ab.T, a_bb]])
-    e, xy = np.linalg.eig(a)
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/grad/tests/test_tduks_grad.py
+++ b/gpu4pyscf/grad/tests/test_tduks_grad.py
@@ -20,7 +20,7 @@ from pyscf import scf, dft, tdscf
 import gpu4pyscf
 from gpu4pyscf import scf as gpu_scf
 from gpu4pyscf.lib.multi_gpu import num_devices
-from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize, diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -29,29 +29,6 @@ H       0.0000000000     0.7570000000     0.5870000000
 """
 
 bas0 = "cc-pvdz"
-
-def diagonalize(a, b, nroots=5):
-    a_aa, a_ab, a_bb = a
-    b_aa, b_ab, b_bb = b
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    a_ab = a_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    a_bb = a_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    b_aa = b_aa.reshape((nocc_a * nvir_a, nocc_a * nvir_a))
-    b_ab = b_ab.reshape((nocc_a * nvir_a, nocc_b * nvir_b))
-    b_bb = b_bb.reshape((nocc_b * nvir_b, nocc_b * nvir_b))
-    a = np.block([[a_aa, a_ab], [a_ab.T, a_bb]])
-    b = np.block([[b_aa, b_ab], [b_ab.T, b_bb]])
-    abba = np.asarray(np.block([[a, b], [-b.conj(), -a.conj()]]))
-    e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc_a, nvir_a, nocc_b, nvir_b, tda):

--- a/gpu4pyscf/grad/tests/test_tduks_sf_grad.py
+++ b/gpu4pyscf/grad/tests/test_tduks_sf_grad.py
@@ -32,7 +32,7 @@ def cal_exact_sf_tda_gradient(mf, extype=1, collinear='mcol', collinear_samples=
 
     Casida_matrix = np.block([[A_abab_2d, np.zeros_like(B_abba_2d)], [-np.zeros_like(B_baab_2d), -A_baba_2d]])
 
-    eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    eigenvals, eigenvecs = np.linalg.eigh(Casida_matrix)
     idx = eigenvals.real.argsort()
     eigenvals = eigenvals[idx]
     eigenvecs = eigenvecs[:, idx]
@@ -95,6 +95,10 @@ def cal_exact_sf_tddft_gradient(mf, extype=1, collinear='mcol', collinear_sample
     Casida_matrix = np.block([[A_abab_2d, B_abba_2d], [-B_baab_2d, -A_baba_2d]])
 
     eigenvals, eigenvecs = np.linalg.eig(Casida_matrix)
+    assert np.max(np.abs(eigenvals.imag)) < 1e-14
+    assert np.max(np.abs(eigenvecs.imag)) < 1e-14
+    eigenvals = eigenvals.real
+    eigenvecs = eigenvecs.real
     idx = eigenvals.real.argsort()
     eigenvals = eigenvals[idx]
     eigenvecs = eigenvecs[:, idx]

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -233,7 +233,7 @@ def _get_vxc_diag(hessobj, mo_coeff, mo_occ, max_memory):
             mo_coeff_mask = mo_coeff[mask,:]
             rho = numint.eval_rho2(_sorted_mol, ao[0], mo_coeff_mask, mo_occ, mask, xctype, buf=aow_buf, out=rho)
             vxc = ni.eval_xc_eff(mf.xc, rho, 1, xctype=xctype, spin=0)[1][0]
-            wv = cupy.multiply(weight, vxc, out=vxc)
+            wv = cupy.multiply(weight, vxc)
             aow  = cupy.ndarray((nao_sub, blk_size), memptr=aow_buf.data)
             aow = numint._scale_ao(ao[0], wv, out=aow)
             vtmp = contract('bik,lk->bil', ao[4:10], aow, out=vtmp)
@@ -262,7 +262,7 @@ def _get_vxc_diag(hessobj, mo_coeff, mo_occ, max_memory):
             mo_coeff_mask = mo_coeff[mask,:]
             rho = numint.eval_rho2(_sorted_mol, ao[:4], mo_coeff_mask, mo_occ, mask, xctype, buf=aow_buf, out=rho)
             vxc = ni.eval_xc_eff(mf.xc, rho, 1, xctype=xctype, spin=0)[1]
-            wv = cupy.multiply(weight, vxc, out=vxc)
+            wv = cupy.multiply(weight, vxc)
             aow  = cupy.ndarray((nao_sub, blk_size), memptr=aow_buf.data)
             aow = numint._scale_ao(ao[:4], wv[:4], out=aow)
 
@@ -297,7 +297,7 @@ def _get_vxc_diag(hessobj, mo_coeff, mo_occ, max_memory):
             mo_coeff_mask = mo_coeff[mask,:]
             rho = numint.eval_rho2(_sorted_mol, ao[:10], mo_coeff_mask, mo_occ, mask, xctype, buf=aow_buf, out=rho)
             vxc = ni.eval_xc_eff(mf.xc, rho, 1, xctype=xctype, spin=0)[1]
-            wv = cupy.multiply(weight, vxc, out=vxc)
+            wv = cupy.multiply(weight, vxc)
             wv[4] *= .5  # for the factor 1/2 in tau
             aow  = cupy.ndarray((3, nao_sub, blk_size), memptr=aow_buf.data)
             numint._scale_ao(ao[:4], wv[:4], out=aow[0])
@@ -460,8 +460,8 @@ def _get_vxc_deriv2_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 t1 = log.timer_debug2('eval rho', *t1)
                 vxc, fxc = ni.eval_xc_eff(mf.xc, rho, 2, xctype=xctype, spin=0)[1:3]
                 t1 = log.timer_debug2('eval vxc', *t1)
-                wv1 = cupy.multiply(weight, vxc[0], out=vxc[0])
-                wf = cupy.multiply(weight, fxc[0,0], out=fxc[0,0])
+                wv1 = cupy.multiply(weight, vxc[0])
+                wf = cupy.multiply(weight, fxc[0,0])
                 aow  = cupy.ndarray((3, nao, blk_size), memptr=aow_buf.data)
                 for i in range(1, 4):
                     numint._scale_ao(ao1[i], wv1, out=aow[i-1])
@@ -477,7 +477,7 @@ def _get_vxc_deriv2_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                     wv = contract('xig,ig->xg', ao1[1:,p0:p1,:], ao_dm0[p0:p1,:], out=wv)
                     wv *= 2
                     # aow ~ rho1 ~ d/dR1
-                    wv = cupy.multiply(wf, wv, out=wv)
+                    wv = cupy.multiply(wf, wv)
                     for i in range(3):
                         numint._scale_ao(ao_dm_mask[0], wv[i], out=aow[i])
                     vmat_dm[ia][:,:,mask] += contract('yjg,xjg->xyj', ao_mask[1:4], aow)
@@ -517,8 +517,8 @@ def _get_vxc_deriv2_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 t1 = log.timer_debug2('eval rho', *t1)
                 vxc, fxc = ni.eval_xc_eff(mf.xc, rho, 2, xctype=xctype, spin=0)[1:3]
                 t1 = log.timer_debug2('eval vxc', *t1)
-                wv1 = cupy.multiply(weight, vxc, out=vxc)
-                wf = cupy.multiply(weight, fxc, out=fxc)
+                wv1 = cupy.multiply(weight, vxc)
+                wf = cupy.multiply(weight, fxc)
                 wv1[0] *= .5
                 aow  = cupy.ndarray((3, nao, blk_size), memptr=aow_buf.data)
                 aow = rks_grad._make_dR_dao_w(ao, wv1, out=aow)
@@ -577,8 +577,8 @@ def _get_vxc_deriv2_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 t1 = log.timer_debug2('eval rho', *t1)
                 vxc, fxc = ni.eval_xc_eff(mf.xc, rho, 2, xctype=xctype, spin=0)[1:3]
                 t1 = log.timer_debug2('eval vxc', *t1)
-                wv1 = cupy.multiply(weight, vxc, out=vxc)
-                wf = cupy.multiply(weight, fxc, out=fxc)
+                wv1 = cupy.multiply(weight, vxc)
+                wf = cupy.multiply(weight, fxc)
                 wv1[0] *= .5
                 wv1[4] *= .25
                 aow  = cupy.ndarray((3, nao, blk_size), memptr=aow_buf.data)
@@ -1309,8 +1309,8 @@ def _get_vxc_deriv1_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 t1 = log.timer_debug2('eval rho', *t1)
                 vxc, fxc = ni.eval_xc_eff(mf.xc, rho, 2, xctype=xctype, spin=0)[1:3]
                 t1 = log.timer_debug2('eval vxc', *t1)
-                wv1 = cupy.multiply(weight, vxc[0], out=vxc[0])
-                wf = cupy.multiply(weight, fxc[0,0], out=fxc[0,0])
+                wv1 = cupy.multiply(weight, vxc[0])
+                wf = cupy.multiply(weight, fxc[0,0])
 
                 numint._scale_ao(ao1[0], wv1, out=aow[0])
                 v_ip = rks_grad._d1_dot_(ao1[1:4], aow[0].T, beta=1.0, out=v_ip)
@@ -1319,8 +1319,8 @@ def _get_vxc_deriv1_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 for ia in range(natm):
                     p0, p1 = aoslices[ia][2:]
                 # First order density = rho1 * 2.  *2 is not applied because + c.c. in the end
-                    rho1 = contract('xig,ig->xg', ao1[1:,p0:p1,:], ao_dm0[p0:p1,:], out=wv)
-                    wv = cupy.multiply(wf, rho1,  out=wv)
+                    rho1 = contract('xig,ig->xg', ao1[1:,p0:p1,:], ao_dm0[p0:p1,:])
+                    wv = cupy.multiply(wf, rho1, out=wv)
                     for i in range(3):
                         numint._scale_ao(ao1[0], wv[i],  out=aow[i])
                         numint._scale_ao(mo[0], wv[i], out=mow[i])
@@ -1357,16 +1357,16 @@ def _get_vxc_deriv1_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 t1 = log.timer_debug2('eval rho', *t1)
                 vxc, fxc = ni.eval_xc_eff(mf.xc, rho, 2, xctype=xctype, spin=0)[1:3]
                 t1 = log.timer_debug2('eval vxc', *t1)
-                wv = cupy.multiply(weight, vxc, out=vxc)
+                wv = cupy.multiply(weight, vxc)
                 wv[0] *= .5
-                wf = cupy.multiply(weight, fxc, out=fxc)
+                wf = cupy.multiply(weight, fxc)
                 v_ip = rks_grad._gga_grad_sum_(ao1, wv,  accumulate=True, buf=aow, out=v_ip)
                 mo = contract('xig,ip->xpg', ao1, mocc, out=mo)
                 ao_dm0 =  contract('ik,pil->pkl', dm0, ao1[:4], out=ao_dm0)
                 for ia in range(natm):
                     dR_rho1 = _make_dR_rho1(ao1, ao_dm0, ia, aoslices, xctype,
                                             buf=wv[0], out=dR_rho1)
-                    wv2 = contract('xyg,sxg->syg', wf, dR_rho1, out=dR_rho1)
+                    wv2 = contract('xyg,sxg->syg', wf, dR_rho1)
                     wv2[:,0] *= .5
                     for i in range(3):
                         numint._scale_ao(ao1[:4], wv2[i,:4],  out=aow[i])
@@ -1406,8 +1406,8 @@ def _get_vxc_deriv1_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 t1 = log.timer_debug2('eval rho', *t1)
                 vxc, fxc = ni.eval_xc_eff(mf.xc, rho, 2, xctype=xctype, spin=0)[1:3]
                 t1 = log.timer_debug2('eval vxc', *t0)
-                wv = cupy.multiply(weight, vxc, out=vxc)
-                wf = cupy.multiply(weight, fxc, out=fxc)
+                wv = cupy.multiply(weight, vxc)
+                wf = cupy.multiply(weight, fxc)
                 wv[0] *= .5
                 wv[4] *= .5  # for the factor 1/2 in tau
                 v_ip = rks_grad._gga_grad_sum_(ao1, wv,  accumulate=True, buf=aow, out=v_ip)
@@ -1417,7 +1417,7 @@ def _get_vxc_deriv1_task(hessobj, grids, mo_coeff, mo_occ, max_memory, device_id
                 for ia in range(natm):
                     dR_rho1 = _make_dR_rho1(ao1, ao_dm0, ia, aoslices, xctype,
                                             buf=wv[0], out=dR_rho1)
-                    wv2 = contract('xyg,sxg->syg', wf, dR_rho1, out=dR_rho1)
+                    wv2 = contract('xyg,sxg->syg', wf, dR_rho1)
                     wv2[:,0] *= .5
                     wv2[:,4] *= .25
                     for i in range(3):
@@ -3540,7 +3540,7 @@ def _nr_rks_fxc_mo_task(ni, mol, grids, xc_code, fxc, mo_coeff, mo1, mocc,
             # precompute fxc_w
             fxc_w = cupy.ndarray((ncomp, ncomp, blk_size), memptr=fxc_w_buf.data)
             fxc_w = cupy.multiply(fxc[:,:,p0:p1], weights, out=fxc_w)
-            wv = contract('axg,xyg->ayg', rho1, fxc_w, out=rho1)
+            wv = contract('axg,xyg->ayg', rho1, fxc_w)
 
             for i in range(nset):
                 if xctype == 'LDA':

--- a/gpu4pyscf/md/tests/test_fssh.py
+++ b/gpu4pyscf/md/tests/test_fssh.py
@@ -224,7 +224,7 @@ H    0.444   1.381   0.000
 
         ref = np.array([-78.11999512, -78.12371063, -78.12418365])
         energies = extract_energies(fssh.filename)
-        assert abs(ref - energies).max() < 2e-8
+        assert abs(ref - energies).max() < 3e-6 # Attention: By default ris use single precision
 
     def test_fssh_kTDC(self):
         mol = pyscf.M(

--- a/gpu4pyscf/nac/finite_diff.py
+++ b/gpu4pyscf/nac/finite_diff.py
@@ -18,21 +18,7 @@ from gpu4pyscf import scf, dft
 from gpu4pyscf.lib import logger
 from gpu4pyscf.tdscf import ris
 from scipy.optimize import linear_sum_assignment
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 
 def change_sign(s12_ao, mo_coeff_b ,mo_coeff):

--- a/gpu4pyscf/nac/tests/test_tdrhf_nac_ee.py
+++ b/gpu4pyscf/nac/tests/test_tdrhf_nac_ee.py
@@ -21,6 +21,8 @@ from gpu4pyscf import tdscf, nac
 import gpu4pyscf
 import pytest
 from gpu4pyscf.lib.multi_gpu import num_devices
+from gpu4pyscf.df.tests.test_df_tdrhf_grad import diagonalize_tda
+
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -40,21 +42,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/nac/tests/test_tdrhf_nac_ge.py
+++ b/gpu4pyscf/nac/tests/test_tdrhf_nac_ge.py
@@ -20,6 +20,7 @@ from pyscf import lib, gto, scf, dft
 from gpu4pyscf import tdscf, nac
 import gpu4pyscf
 import pytest
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -39,21 +40,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/nac/tests/test_tdrks_nac_ee.py
+++ b/gpu4pyscf/nac/tests/test_tdrks_nac_ee.py
@@ -20,6 +20,7 @@ from pyscf import lib, gto, scf, dft
 from gpu4pyscf import tdscf, nac
 import gpu4pyscf
 import pytest
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 
 atom = """
@@ -40,21 +41,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/nac/tests/test_tdrks_nac_ge.py
+++ b/gpu4pyscf/nac/tests/test_tdrks_nac_ge.py
@@ -20,6 +20,7 @@ from pyscf import lib, gto, scf, dft
 from gpu4pyscf import tdscf, nac
 import gpu4pyscf
 import pytest
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -39,21 +40,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ee.py
+++ b/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ee.py
@@ -21,6 +21,7 @@ from gpu4pyscf import tdscf, nac
 import gpu4pyscf
 import pytest
 from gpu4pyscf.lib.multi_gpu import num_devices
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -40,21 +41,6 @@ def tearDownModule():
     global mol
     mol.stdout.close()
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ge.py
+++ b/gpu4pyscf/nac/tests/test_tdrks_ris_nac_ge.py
@@ -21,6 +21,7 @@ from gpu4pyscf import tdscf, nac
 import gpu4pyscf
 import pytest
 from gpu4pyscf.lib.multi_gpu import num_devices
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -43,19 +44,6 @@ def tearDownModule():
     mol.stdout.close()
     del mol
 
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 class KnownValues(unittest.TestCase):
     @unittest.skipIf(num_devices > 1, '')

--- a/gpu4pyscf/properties/tests/test_c6.py
+++ b/gpu4pyscf/properties/tests/test_c6.py
@@ -19,19 +19,7 @@ from pyscf import lib, gto
 from gpu4pyscf import dft, tdscf
 from gpu4pyscf.properties import c6
 from gpu4pyscf.tdscf.tests.test_tdrks import diagonalize_tda
-
-
-def diagonalize_casida(a, b, nroots=4):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a        , b       ],
-                  [-b.conj(),-a.conj()]])
-    e = np.linalg.eig(np.asarray(h))[0]
-    lowest_e = np.sort(e[e.real > 0].real)[:nroots]
-    lowest_e = lowest_e[lowest_e > 1e-3]
-    return lowest_e
+from gpu4pyscf.tdscf.tests.test_tdrks import diagonalize as diagonalize_casida
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/properties/tests/test_c6.py
+++ b/gpu4pyscf/properties/tests/test_c6.py
@@ -18,6 +18,7 @@ import cupy as cp
 from pyscf import lib, gto
 from gpu4pyscf import dft, tdscf
 from gpu4pyscf.properties import c6
+from gpu4pyscf.tdscf.tests.test_tdrks import diagonalize_tda
 
 
 def diagonalize_casida(a, b, nroots=4):
@@ -28,16 +29,6 @@ def diagonalize_casida(a, b, nroots=4):
     h = np.block([[a        , b       ],
                   [-b.conj(),-a.conj()]])
     e = np.linalg.eig(np.asarray(h))[0]
-    lowest_e = np.sort(e[e.real > 0].real)[:nroots]
-    lowest_e = lowest_e[lowest_e > 1e-3]
-    return lowest_e
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e = np.linalg.eig(np.asarray(a))[0]
     lowest_e = np.sort(e[e.real > 0].real)[:nroots]
     lowest_e = lowest_e[lowest_e > 1e-3]
     return lowest_e

--- a/gpu4pyscf/solvent/tests/test_pcm_tdscf.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_tdscf.py
@@ -18,52 +18,8 @@ import cupy as cp
 from pyscf import lib, gto
 from gpu4pyscf.tdscf import rhf, rks
 from gpu4pyscf import tdscf
-from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
-
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a        , b       ],
-                     [-b.conj(),-a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_u(a, b, nroots=5):
-    a_aa, a_ab, a_bb = a
-    b_aa, b_ab, b_bb = b
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a*nvir_a,nocc_a*nvir_a))
-    a_ab = a_ab.reshape((nocc_a*nvir_a,nocc_b*nvir_b))
-    a_bb = a_bb.reshape((nocc_b*nvir_b,nocc_b*nvir_b))
-    b_aa = b_aa.reshape((nocc_a*nvir_a,nocc_a*nvir_a))
-    b_ab = b_ab.reshape((nocc_a*nvir_a,nocc_b*nvir_b))
-    b_bb = b_bb.reshape((nocc_b*nvir_b,nocc_b*nvir_b))
-    a = np.block([[ a_aa  , a_ab],
-                     [ a_ab.T, a_bb]])
-    b = np.block([[ b_aa  , b_ab],
-                     [ b_ab.T, b_bb]])
-    abba = np.asarray(np.block([[a        , b       ],
-                                      [-b.conj(),-a.conj()]]))
-    e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize, diagonalize_tda
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize as diagonalize_u
 
 
 class KnownValues(unittest.TestCase):

--- a/gpu4pyscf/solvent/tests/test_pcm_tdscf.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_tdscf.py
@@ -18,21 +18,7 @@ import cupy as cp
 from pyscf import lib, gto
 from gpu4pyscf.tdscf import rhf, rks
 from gpu4pyscf import tdscf
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 
 def diagonalize(a, b, nroots=5):

--- a/gpu4pyscf/solvent/tests/test_pcm_tdscf_grad.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_tdscf_grad.py
@@ -21,7 +21,8 @@ import gpu4pyscf
 from pyscf import lib, gto, scf, dft
 from gpu4pyscf import tdscf
 from gpu4pyscf.solvent.tdscf.pcm import WithSolventTDSCFGradient
-from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize, diagonalize_tda
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize as diagonalize_u
 from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize_tda as diagonalize_tda_u
 
 atom = """
@@ -32,51 +33,6 @@ H       0.0000000000     0.7570000000     0.5870000000
 
 bas0 = "def2svp"
 bas1 = "631g"
-
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a        , b       ],
-                     [-b.conj(),-a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_u(a, b, nroots=5):
-    a_aa, a_ab, a_bb = a
-    b_aa, b_ab, b_bb = b
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a*nvir_a,nocc_a*nvir_a))
-    a_ab = a_ab.reshape((nocc_a*nvir_a,nocc_b*nvir_b))
-    a_bb = a_bb.reshape((nocc_b*nvir_b,nocc_b*nvir_b))
-    b_aa = b_aa.reshape((nocc_a*nvir_a,nocc_a*nvir_a))
-    b_ab = b_ab.reshape((nocc_a*nvir_a,nocc_b*nvir_b))
-    b_bb = b_bb.reshape((nocc_b*nvir_b,nocc_b*nvir_b))
-    a = np.block([[ a_aa  , a_ab],
-                     [ a_ab.T, a_bb]])
-    b = np.block([[ b_aa  , b_ab],
-                     [ b_ab.T, b_bb]])
-    abba = np.asarray(np.block([[a        , b       ],
-                                      [-b.conj(),-a.conj()]]))
-    e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def cal_analytic_gradient(mol, td, tdgrad, nocc, nvir, grad_elec, tda):

--- a/gpu4pyscf/solvent/tests/test_pcm_tdscf_grad.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_tdscf_grad.py
@@ -21,6 +21,8 @@ import gpu4pyscf
 from pyscf import lib, gto, scf, dft
 from gpu4pyscf import tdscf
 from gpu4pyscf.solvent.tdscf.pcm import WithSolventTDSCFGradient
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
+from gpu4pyscf.grad.tests.test_tduhf_grad import diagonalize_tda as diagonalize_tda_u
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -50,21 +52,6 @@ def diagonalize(a, b, nroots=5):
     return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
 def diagonalize_u(a, b, nroots=5):
     a_aa, a_ab, a_bb = a
     b_aa, b_ab, b_bb = b
@@ -82,25 +69,6 @@ def diagonalize_u(a, b, nroots=5):
     abba = np.asarray(np.block([[a        , b       ],
                                       [-b.conj(),-a.conj()]]))
     e, xy = np.linalg.eig(abba)
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
-
-
-def diagonalize_tda_u(a, nroots=5):
-    a_aa, a_ab, a_bb = a
-    nocc_a, nvir_a, nocc_b, nvir_b = a_ab.shape
-    a_aa = a_aa.reshape((nocc_a*nvir_a,nocc_a*nvir_a))
-    a_ab = a_ab.reshape((nocc_a*nvir_a,nocc_b*nvir_b))
-    a_bb = a_bb.reshape((nocc_b*nvir_b,nocc_b*nvir_b))
-    a = np.block([[ a_aa  , a_ab],
-                     [ a_ab.T, a_bb]])
-    e, xy = np.linalg.eig(a)
     sorted_indices = np.argsort(e)
 
     e_sorted = e[sorted_indices]

--- a/gpu4pyscf/solvent/tests/test_pcm_tdscf_nac.py
+++ b/gpu4pyscf/solvent/tests/test_pcm_tdscf_nac.py
@@ -21,6 +21,7 @@ import gpu4pyscf
 from pyscf import lib, gto, scf
 from gpu4pyscf import tdscf, nac, dft
 from gpu4pyscf.solvent.tdscf.pcm import WithSolventTDSCFNacMethod
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize_tda
 
 atom = """
 O       0.0000000000     0.0000000000     0.0000000000
@@ -39,21 +40,6 @@ def setUpModule():
 def tearDownModule():
     global mol 
     del mol
-
-
-def diagonalize_tda(a, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    e, xy = np.linalg.eig(np.asarray(a))
-    sorted_indices = np.argsort(e)
-
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 
 def get_mf(mol, mf, s, mo_coeff, method='CPCM'):

--- a/gpu4pyscf/tdscf/tests/test_ris.py
+++ b/gpu4pyscf/tdscf/tests/test_ris.py
@@ -18,26 +18,10 @@ import numpy as np
 from pyscf import gto, lib
 from gpu4pyscf.dft import rks
 import gpu4pyscf.tdscf.ris as ris
+from gpu4pyscf.grad.tests.test_tdrhf_grad import diagonalize
 
 PLACES = 3
 
-
-def diagonalize(a, b, nroots=5):
-    nocc, nvir = a.shape[:2]
-    nov = nocc * nvir
-    a = a.reshape(nov, nov)
-    b = b.reshape(nov, nov)
-    h = np.block([[a        , b       ],
-                     [-b.conj(),-a.conj()]])
-    e, xy = np.linalg.eig(np.asarray(h))
-    sorted_indices = np.argsort(e)
-    
-    e_sorted = e[sorted_indices]
-    xy_sorted = xy[:, sorted_indices]
-    
-    e_sorted_final = e_sorted[e_sorted > 1e-3]
-    xy_sorted = xy_sorted[:, e_sorted > 1e-3]
-    return e_sorted_final[:nroots], xy_sorted[:, :nroots]
 
 class KnownValues(unittest.TestCase):
     @classmethod

--- a/gpu4pyscf/tdscf/tests/test_tdrks.py
+++ b/gpu4pyscf/tdscf/tests/test_tdrks.py
@@ -37,7 +37,7 @@ def diagonalize_tda(a, nroots=5):
     nocc, nvir = a.shape[:2]
     nov = nocc * nvir
     a = a.reshape(nov, nov)
-    e = np.linalg.eig(np.asarray(a))[0]
+    e = np.linalg.eigh(np.asarray(a))[0]
     lowest_e = np.sort(e[e.real > 0].real)[:nroots]
     lowest_e = lowest_e[lowest_e > 1e-3]
     return lowest_e


### PR DESCRIPTION
- True bug fix:
  - In RKS hessian (`test_hessian_mgga`), there are `cupy.multiply` and `contract` function calls with input and output (`out=something`) pointing to the same memory space, which is absolutely bad idea. This causes a big error in MGGA dFock/dR fxc part.
  - In TDDFT there's a bug when calling `RYS_per_atom_jk_ip1_sum` kernel, fixed in PR #879.

- Adoption to newer version of dependency:
  - In the tip version of numpy, `eig` function always returns complex128 eigenvalue and eigenvectors. This causes TDA and TDDFT tests to fail because of wrong dtype of X and Y (many functions not compatible with complex128). Fix by changing to `eigh` for TDA, and checking and dropping imaginary part for TDDFT.
  - From cupy 13.6.0 to 14.0.0, the treatment of fp32 number + fp64 number is slightly different (within reasonable range). This breaks `test_fssh_td_ris` because the check threshold is too tight (2e-8 for fp32).
