### PR TITLE
Fix stress unit and make optimization parameters more consistent

### DIFF
--- a/gpu4pyscf/geomopt/ase_solver.py
+++ b/gpu4pyscf/geomopt/ase_solver.py
@@ -20,7 +20,6 @@ https://ase-lib.org/ase/optimize.html
 
 from ase.optimize import BFGS
 from ase.filters import UnitCellFilter, StrainFilter
-from ase.constraints import FixCom
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.pbc import gto
@@ -28,7 +27,7 @@ from pyscf.pbc.tools.pyscf_ase import pyscf_to_ase_atoms
 from gpu4pyscf.tools.ase_interface import PySCF
 
 def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
-           restart=False, method_factory=None):
+           restart=False):
     '''Optimize the geometry using ASE.
 
     Kwargs:
@@ -49,9 +48,6 @@ def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
             Maximum number of optimization steps.
         restart : bool
             Whether to restart from a previous optimization state.
-        method_factory : callable
-            A function that takes a new Mole/Cell and returns a fresh PySCF
-            method for each geometry.
     '''
     assert not restart
     if hasattr(method, 'cell'):
@@ -63,10 +59,7 @@ def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
     is_pbc = isinstance(cell, gto.Cell)
 
     atoms = pyscf_to_ase_atoms(cell)
-    atoms.calc = PySCF(method=method, method_factory=method_factory)
-    # fixing the center of mass of a subset of atoms
-    if is_pbc and target != 'lattice':
-        atoms.set_constraint(FixCom())
+    atoms.calc = PySCF(method=method)
 
     if target is None:
         if is_pbc:
@@ -79,7 +72,6 @@ def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
     if logfile is None:
         logfile = '-' # stdout
 
-    # TODO: for cell optimization, optimizer can be cell awared BFGS.
     opt = BFGS(atoms, logfile=logfile)
     converged = opt.run(fmax=fmax, steps=max_steps)
 
@@ -123,9 +115,6 @@ class GeometryOptimizer(lib.StreamObject):
             'atoms' for molecular systems.
         logfile: file object, Path, or str
             File to save the ASE output
-        method_factory : callable
-            A function that takes a new Mole/Cell and returns a fresh PySCF
-            method for each geometry.
 
     Saved results:
         converged : bool
@@ -140,7 +129,6 @@ class GeometryOptimizer(lib.StreamObject):
         self.fmax = 0.05
         self.target = None
         self.logfile = None
-        self.method_factory = None
 
     @property
     def max_cycle(self):
@@ -166,8 +154,7 @@ class GeometryOptimizer(lib.StreamObject):
     def kernel(self):
         self.converged, cell = kernel(
             self.method, self.target, self.logfile,
-            fmax=self.fmax, max_steps=self.max_steps,
-            method_factory=self.method_factory)
+            fmax=self.fmax, max_steps=self.max_steps)
         if isinstance(cell, gto.Cell):
             self.cell = cell
         else:

--- a/gpu4pyscf/geomopt/ase_solver.py
+++ b/gpu4pyscf/geomopt/ase_solver.py
@@ -20,6 +20,7 @@ https://ase-lib.org/ase/optimize.html
 
 from ase.optimize import BFGS
 from ase.filters import UnitCellFilter, StrainFilter
+from ase.constraints import FixCom
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.pbc import gto
@@ -27,7 +28,7 @@ from pyscf.pbc.tools.pyscf_ase import pyscf_to_ase_atoms
 from gpu4pyscf.tools.ase_interface import PySCF
 
 def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
-           restart=False):
+           restart=False, method_factory=None):
     '''Optimize the geometry using ASE.
 
     Kwargs:
@@ -48,6 +49,9 @@ def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
             Maximum number of optimization steps.
         restart : bool
             Whether to restart from a previous optimization state.
+        method_factory : callable
+            A function that takes a new Mole/Cell and returns a fresh PySCF
+            method for each geometry.
     '''
     assert not restart
     if hasattr(method, 'cell'):
@@ -59,7 +63,9 @@ def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
     is_pbc = isinstance(cell, gto.Cell)
 
     atoms = pyscf_to_ase_atoms(cell)
-    atoms.calc = PySCF(method=method)
+    atoms.calc = PySCF(method=method, method_factory=method_factory)
+    if is_pbc and target != 'lattice':
+        atoms.set_constraint(FixCom())
 
     if target is None:
         if is_pbc:
@@ -115,6 +121,9 @@ class GeometryOptimizer(lib.StreamObject):
             'atoms' for molecular systems.
         logfile: file object, Path, or str
             File to save the ASE output
+        method_factory : callable
+            A function that takes a new Mole/Cell and returns a fresh PySCF
+            method for each geometry.
 
     Saved results:
         converged : bool
@@ -129,6 +138,7 @@ class GeometryOptimizer(lib.StreamObject):
         self.fmax = 0.05
         self.target = None
         self.logfile = None
+        self.method_factory = None
 
     @property
     def max_cycle(self):
@@ -154,7 +164,8 @@ class GeometryOptimizer(lib.StreamObject):
     def kernel(self):
         self.converged, cell = kernel(
             self.method, self.target, self.logfile,
-            fmax=self.fmax, max_steps=self.max_steps)
+            fmax=self.fmax, max_steps=self.max_steps,
+            method_factory=self.method_factory)
         if isinstance(cell, gto.Cell):
             self.cell = cell
         else:

--- a/gpu4pyscf/geomopt/ase_solver.py
+++ b/gpu4pyscf/geomopt/ase_solver.py
@@ -64,6 +64,7 @@ def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
 
     atoms = pyscf_to_ase_atoms(cell)
     atoms.calc = PySCF(method=method, method_factory=method_factory)
+    # fixing the center of mass of a subset of atoms
     if is_pbc and target != 'lattice':
         atoms.set_constraint(FixCom())
 
@@ -78,6 +79,7 @@ def kernel(method, target=None, logfile=None, fmax=0.05, max_steps=100,
     if logfile is None:
         logfile = '-' # stdout
 
+    # TODO: for cell optimization, optimizer can be cell awared BFGS.
     opt = BFGS(atoms, logfile=logfile)
     converged = opt.run(fmax=fmax, steps=max_steps)
 

--- a/gpu4pyscf/geomopt/tests/test_pbc_geomopt_ase.py
+++ b/gpu4pyscf/geomopt/tests/test_pbc_geomopt_ase.py
@@ -27,9 +27,6 @@ if ase is not None:
 
 
 class _FakeGradients:
-    def kernel(self):
-        return np.ones((self.cell.natm, 3))
-
     def get_stress(self):
         return np.eye(3)
 
@@ -38,37 +35,18 @@ class _FakeScanner:
     converged = True
 
     def __call__(self, cell):
-        self.cell = cell
         return 0.
 
     def Gradients(self):
-        gradients = _FakeGradients()
-        gradients.cell = self.cell
-        return gradients
+        return _FakeGradients()
 
 
 class _FakeMethod(lib.StreamObject):
     def __init__(self, cell):
         self.cell = cell
-        self.mo_coeff = None
-        self.converged = True
-        self.dm0 = None
-        self.dm = np.ones((1, 1))
 
     def as_scanner(self):
         return _FakeScanner()
-
-    def kernel(self, dm0=None):
-        self.dm0 = dm0
-        return 0.
-
-    def make_rdm1(self):
-        return self.dm
-
-    def Gradients(self):
-        gradients = _FakeGradients()
-        gradients.cell = self.cell
-        return gradients
 
 
 @pytest.mark.skipif(ase is None, reason='ASE not available')
@@ -86,100 +64,6 @@ def test_ase_stress_units():
     assert np.allclose(
         calculator.results['stress'], np.eye(3) * HARTREE2EV / BOHR**3)
 
-
-@pytest.mark.skipif(ase is None, reason='ASE not available')
-def test_ase_method_factory_rebuilds_each_geometry():
-    from gpu4pyscf.tools.ase_interface import PySCF
-
-    cell = pyscf.M(
-        atom='He 0 0 0', a=np.eye(3) * 4., unit='Angstrom',
-        basis='gth-szv', pseudo='gth-pade', precision=1e-8, verbose=0)
-    initial_mesh = cell.mesh.copy()
-    methods = []
-
-    def method_factory(new_cell):
-        method = _FakeMethod(new_cell)
-        method.dm[:] = len(methods) + 1
-        methods.append(method)
-        return method
-
-    atoms = pyscf_to_ase_atoms(cell)
-    calculator = PySCF(
-        method=_FakeMethod(cell), method_factory=method_factory)
-    atoms.set_cell(atoms.cell * 1.4, scale_atoms=True)
-    calculator.calculate(atoms, properties=['stress'])
-    atoms.set_cell(atoms.cell * 1.1, scale_atoms=True)
-    calculator.calculate(atoms, properties=['stress'])
-
-    assert len(methods) == 2
-    assert methods[0] is not methods[1]
-    assert methods[0].cell is not methods[1].cell
-    assert not np.array_equal(methods[0].cell.mesh, initial_mesh)
-    assert not np.array_equal(methods[0].cell.mesh, methods[1].cell.mesh)
-    assert methods[0].dm0 is None
-    assert np.array_equal(methods[1].dm0, methods[0].dm)
-
-
-@pytest.mark.skipif(ase is None, reason='ASE not available')
-def test_ase_multigrid_method_factory():
-    from gpu4pyscf.tools.ase_interface import PySCF
-
-    cell = pyscf.M(
-        atom='He 0 0 0', a=np.eye(3) * 4., unit='Angstrom',
-        basis='gth-szv', pseudo='gth-pade', precision=1e-8,
-        mesh=[15] * 3, verbose=0)
-    methods = []
-
-    def method_factory(new_cell):
-        method = new_cell.RKS(xc='lda,vwn').to_gpu().multigrid_numint()
-        methods.append(method)
-        return method
-
-    atoms = pyscf_to_ase_atoms(cell)
-    atoms.calc = PySCF(
-        method=method_factory(cell), method_factory=method_factory)
-    stress0 = atoms.get_stress()
-    atoms.set_cell(atoms.cell * 1.01, scale_atoms=True)
-    stress1 = atoms.get_stress()
-
-    assert np.isfinite(stress0).all()
-    assert np.isfinite(stress1).all()
-    assert len(methods) == 3
-    assert methods[1] is not methods[2]
-    for method in methods[1:]:
-        ni = method._numint
-        assert ni.mg_envs.nimgs == len(ni.bvkcell.get_lattice_Ls())
-        assert np.array_equal(ni.mesh, method.cell.mesh)
-
-
-@pytest.mark.skipif(ase is None, reason='ASE not available')
-def test_pbc_optimizer_removes_translation(monkeypatch):
-    from gpu4pyscf.geomopt import ase_solver
-
-    captured = []
-
-    class FakeBFGS:
-        def __init__(self, atoms, logfile=None):
-            captured.append(atoms)
-
-        def run(self, fmax, steps):
-            return True
-
-    monkeypatch.setattr(ase_solver, 'BFGS', FakeBFGS)
-    cell = pyscf.M(
-        atom='He 0 0 0; He 1 1 1', a=np.eye(3) * 4., unit='Angstrom',
-        basis='gth-szv', pseudo='gth-pade', mesh=[15] * 3, verbose=0)
-
-    for target in (None, 'atoms', 'cell', 'lattice'):
-        ase_solver.kernel(
-            _FakeMethod(cell), target=target, logfile=None, max_steps=0)
-        system = captured[-1]
-        atoms = getattr(system, 'atoms', system)
-        total_force = atoms.get_forces().sum(axis=0)
-        if target == 'lattice':
-            assert not np.allclose(total_force, 0.)
-        else:
-            assert np.allclose(total_force, 0.)
 
 @pytest.mark.skipif(ase is None, reason='ASE not available')
 def test_ase_optimize_cell():

--- a/gpu4pyscf/geomopt/tests/test_pbc_geomopt_ase.py
+++ b/gpu4pyscf/geomopt/tests/test_pbc_geomopt_ase.py
@@ -16,8 +16,170 @@ try:
     import ase
 except ImportError:
     ase = None
+import numpy as np
 import pyscf
 import pytest
+from pyscf import lib
+from pyscf.data.nist import BOHR, HARTREE2EV
+
+if ase is not None:
+    from pyscf.pbc.tools.pyscf_ase import pyscf_to_ase_atoms
+
+
+class _FakeGradients:
+    def kernel(self):
+        return np.ones((self.cell.natm, 3))
+
+    def get_stress(self):
+        return np.eye(3)
+
+
+class _FakeScanner:
+    converged = True
+
+    def __call__(self, cell):
+        self.cell = cell
+        return 0.
+
+    def Gradients(self):
+        gradients = _FakeGradients()
+        gradients.cell = self.cell
+        return gradients
+
+
+class _FakeMethod(lib.StreamObject):
+    def __init__(self, cell):
+        self.cell = cell
+        self.mo_coeff = None
+        self.converged = True
+        self.dm0 = None
+        self.dm = np.ones((1, 1))
+
+    def as_scanner(self):
+        return _FakeScanner()
+
+    def kernel(self, dm0=None):
+        self.dm0 = dm0
+        return 0.
+
+    def make_rdm1(self):
+        return self.dm
+
+    def Gradients(self):
+        gradients = _FakeGradients()
+        gradients.cell = self.cell
+        return gradients
+
+
+@pytest.mark.skipif(ase is None, reason='ASE not available')
+def test_ase_stress_units():
+    from gpu4pyscf.tools.ase_interface import PySCF
+
+    cell = pyscf.M(
+        atom='He 0 0 0', a=np.eye(3) * 4., unit='Angstrom',
+        basis='gth-szv', pseudo='gth-pade', precision=1e-8, verbose=0)
+    atoms = pyscf_to_ase_atoms(cell)
+
+    calculator = PySCF(method=_FakeMethod(cell))
+    calculator.calculate(atoms, properties=['stress'])
+
+    assert np.allclose(
+        calculator.results['stress'], np.eye(3) * HARTREE2EV / BOHR**3)
+
+
+@pytest.mark.skipif(ase is None, reason='ASE not available')
+def test_ase_method_factory_rebuilds_each_geometry():
+    from gpu4pyscf.tools.ase_interface import PySCF
+
+    cell = pyscf.M(
+        atom='He 0 0 0', a=np.eye(3) * 4., unit='Angstrom',
+        basis='gth-szv', pseudo='gth-pade', precision=1e-8, verbose=0)
+    initial_mesh = cell.mesh.copy()
+    methods = []
+
+    def method_factory(new_cell):
+        method = _FakeMethod(new_cell)
+        method.dm[:] = len(methods) + 1
+        methods.append(method)
+        return method
+
+    atoms = pyscf_to_ase_atoms(cell)
+    calculator = PySCF(
+        method=_FakeMethod(cell), method_factory=method_factory)
+    atoms.set_cell(atoms.cell * 1.4, scale_atoms=True)
+    calculator.calculate(atoms, properties=['stress'])
+    atoms.set_cell(atoms.cell * 1.1, scale_atoms=True)
+    calculator.calculate(atoms, properties=['stress'])
+
+    assert len(methods) == 2
+    assert methods[0] is not methods[1]
+    assert methods[0].cell is not methods[1].cell
+    assert not np.array_equal(methods[0].cell.mesh, initial_mesh)
+    assert not np.array_equal(methods[0].cell.mesh, methods[1].cell.mesh)
+    assert methods[0].dm0 is None
+    assert np.array_equal(methods[1].dm0, methods[0].dm)
+
+
+@pytest.mark.skipif(ase is None, reason='ASE not available')
+def test_ase_multigrid_method_factory():
+    from gpu4pyscf.tools.ase_interface import PySCF
+
+    cell = pyscf.M(
+        atom='He 0 0 0', a=np.eye(3) * 4., unit='Angstrom',
+        basis='gth-szv', pseudo='gth-pade', precision=1e-8,
+        mesh=[15] * 3, verbose=0)
+    methods = []
+
+    def method_factory(new_cell):
+        method = new_cell.RKS(xc='lda,vwn').to_gpu().multigrid_numint()
+        methods.append(method)
+        return method
+
+    atoms = pyscf_to_ase_atoms(cell)
+    atoms.calc = PySCF(
+        method=method_factory(cell), method_factory=method_factory)
+    stress0 = atoms.get_stress()
+    atoms.set_cell(atoms.cell * 1.01, scale_atoms=True)
+    stress1 = atoms.get_stress()
+
+    assert np.isfinite(stress0).all()
+    assert np.isfinite(stress1).all()
+    assert len(methods) == 3
+    assert methods[1] is not methods[2]
+    for method in methods[1:]:
+        ni = method._numint
+        assert ni.mg_envs.nimgs == len(ni.bvkcell.get_lattice_Ls())
+        assert np.array_equal(ni.mesh, method.cell.mesh)
+
+
+@pytest.mark.skipif(ase is None, reason='ASE not available')
+def test_pbc_optimizer_removes_translation(monkeypatch):
+    from gpu4pyscf.geomopt import ase_solver
+
+    captured = []
+
+    class FakeBFGS:
+        def __init__(self, atoms, logfile=None):
+            captured.append(atoms)
+
+        def run(self, fmax, steps):
+            return True
+
+    monkeypatch.setattr(ase_solver, 'BFGS', FakeBFGS)
+    cell = pyscf.M(
+        atom='He 0 0 0; He 1 1 1', a=np.eye(3) * 4., unit='Angstrom',
+        basis='gth-szv', pseudo='gth-pade', mesh=[15] * 3, verbose=0)
+
+    for target in (None, 'atoms', 'cell', 'lattice'):
+        ase_solver.kernel(
+            _FakeMethod(cell), target=target, logfile=None, max_steps=0)
+        system = captured[-1]
+        atoms = getattr(system, 'atoms', system)
+        total_force = atoms.get_forces().sum(axis=0)
+        if target == 'lattice':
+            assert not np.allclose(total_force, 0.)
+        else:
+            assert np.allclose(total_force, 0.)
 
 @pytest.mark.skipif(ase is None, reason='ASE not available')
 def test_ase_optimize_cell():

--- a/gpu4pyscf/tools/ase_interface.py
+++ b/gpu4pyscf/tools/ase_interface.py
@@ -119,7 +119,7 @@ class PySCF(Calculator):
     default_parameters = {}
 
     def __init__(self, restart=None, label='PySCF', atoms=None, directory='.',
-                 method=None, method_factory=None, **kwargs):
+                 method=None, **kwargs):
         """Construct PySCF-calculator object.
 
         Parameters
@@ -129,10 +129,6 @@ class PySCF(Calculator):
             Default is 'PySCF'.
 
         method: A PySCF method class
-
-        method_factory: callable
-            A function that takes a new Mole/Cell and returns a fresh PySCF
-            method. When provided, a new method is built for every geometry.
         """
         Calculator.__init__(self, restart, label=label, atoms=atoms,
                             directory=directory, **kwargs)
@@ -141,9 +137,6 @@ class PySCF(Calculator):
             raise RuntimeError(f'{method} must be an instance of a PySCF method')
 
         self.method = method
-        self.method_factory = method_factory
-        self.base_method = method
-        self.dm0 = None
         self.pbc = hasattr(method, 'cell')
         if self.pbc:
             mol = method.cell
@@ -151,11 +144,9 @@ class PySCF(Calculator):
             mol = method.mol
         self.mol = mol
         self.method_scan = None
-        if method_factory is None and hasattr(method, 'as_scanner'):
+        if hasattr(method, 'as_scanner'):
             # Scanner can utilize the initial guess from previous calculations
             self.method_scan = method.as_scanner()
-        elif method_factory is not None and getattr(method, 'mo_coeff', None) is not None:
-            self.dm0 = method.make_rdm1()
 
     def set(self, **kwargs):
         changed_parameters = Calculator.set(self, **kwargs)
@@ -175,29 +166,15 @@ class PySCF(Calculator):
             _atoms = list(zip(atomic_numbers, positions))
 
         if self.pbc:
-            self.mol = self.mol.set_geom_(
-                _atoms, a=np.asarray(atoms.cell), unit='Angstrom',
-                inplace=self.method_factory is None)
+            self.mol.set_geom_(_atoms, a=np.asarray(atoms.cell), unit='Angstrom')
         else:
-            self.mol = self.mol.set_geom_(
-                _atoms, unit='Angstrom',
-                inplace=self.method_factory is None)
+            self.mol.set_geom_(_atoms, unit='Angstrom')
 
         with_grad = 'forces' in properties or 'stress' in properties
         with_energy = with_grad or 'energy' in properties or 'dipole' in properties
 
         if with_energy:
-            if self.method_factory is not None:
-                base_method = self.method_factory(self.mol)
-                if not isinstance(base_method, lib.StreamObject):
-                    raise RuntimeError(
-                        'method_factory must return a PySCF method')
-                e_tot = base_method.kernel(dm0=self.dm0)
-                if not getattr(base_method, 'converged', True):
-                    raise RuntimeError(f'{base_method} not converged')
-                self.dm0 = base_method.make_rdm1()
-                self.base_method = base_method
-            elif self.method_scan is None:
+            if self.method_scan is None:
                 self.mol.set_geom_(atoms)
                 self.method.reset(self.mol).run()
                 e_tot = self.method.e_tot
@@ -210,7 +187,7 @@ class PySCF(Calculator):
             self.results['energy'] = e_tot * HARTREE2EV
 
         if self.method_scan is None:
-            base_method = self.base_method
+            base_method = self.method
         else:
             base_method = self.method_scan
 

--- a/gpu4pyscf/tools/ase_interface.py
+++ b/gpu4pyscf/tools/ase_interface.py
@@ -119,7 +119,7 @@ class PySCF(Calculator):
     default_parameters = {}
 
     def __init__(self, restart=None, label='PySCF', atoms=None, directory='.',
-                 method=None, **kwargs):
+                 method=None, method_factory=None, **kwargs):
         """Construct PySCF-calculator object.
 
         Parameters
@@ -129,6 +129,10 @@ class PySCF(Calculator):
             Default is 'PySCF'.
 
         method: A PySCF method class
+
+        method_factory: callable
+            A function that takes a new Mole/Cell and returns a fresh PySCF
+            method. When provided, a new method is built for every geometry.
         """
         Calculator.__init__(self, restart, label=label, atoms=atoms,
                             directory=directory, **kwargs)
@@ -137,6 +141,9 @@ class PySCF(Calculator):
             raise RuntimeError(f'{method} must be an instance of a PySCF method')
 
         self.method = method
+        self.method_factory = method_factory
+        self.base_method = method
+        self.dm0 = None
         self.pbc = hasattr(method, 'cell')
         if self.pbc:
             mol = method.cell
@@ -144,9 +151,11 @@ class PySCF(Calculator):
             mol = method.mol
         self.mol = mol
         self.method_scan = None
-        if hasattr(method, 'as_scanner'):
+        if method_factory is None and hasattr(method, 'as_scanner'):
             # Scanner can utilize the initial guess from previous calculations
             self.method_scan = method.as_scanner()
+        elif method_factory is not None and getattr(method, 'mo_coeff', None) is not None:
+            self.dm0 = method.make_rdm1()
 
     def set(self, **kwargs):
         changed_parameters = Calculator.set(self, **kwargs)
@@ -166,15 +175,29 @@ class PySCF(Calculator):
             _atoms = list(zip(atomic_numbers, positions))
 
         if self.pbc:
-            self.mol.set_geom_(_atoms, a=np.asarray(atoms.cell), unit='Angstrom')
+            self.mol = self.mol.set_geom_(
+                _atoms, a=np.asarray(atoms.cell), unit='Angstrom',
+                inplace=self.method_factory is None)
         else:
-            self.mol.set_geom_(_atoms, unit='Angstrom')
+            self.mol = self.mol.set_geom_(
+                _atoms, unit='Angstrom',
+                inplace=self.method_factory is None)
 
         with_grad = 'forces' in properties or 'stress' in properties
         with_energy = with_grad or 'energy' in properties or 'dipole' in properties
 
         if with_energy:
-            if self.method_scan is None:
+            if self.method_factory is not None:
+                base_method = self.method_factory(self.mol)
+                if not isinstance(base_method, lib.StreamObject):
+                    raise RuntimeError(
+                        'method_factory must return a PySCF method')
+                e_tot = base_method.kernel(dm0=self.dm0)
+                if not getattr(base_method, 'converged', True):
+                    raise RuntimeError(f'{base_method} not converged')
+                self.dm0 = base_method.make_rdm1()
+                self.base_method = base_method
+            elif self.method_scan is None:
                 self.mol.set_geom_(atoms)
                 self.method.reset(self.mol).run()
                 e_tot = self.method.e_tot
@@ -187,7 +210,7 @@ class PySCF(Calculator):
             self.results['energy'] = e_tot * HARTREE2EV
 
         if self.method_scan is None:
-            base_method = self.method
+            base_method = self.base_method
         else:
             base_method = self.method_scan
 
@@ -200,7 +223,7 @@ class PySCF(Calculator):
 
         if 'stress' in properties:
             stress = grad_obj.get_stress()
-            self.results['stress'] = stress * (HARTREE2EV / BOHR)
+            self.results['stress'] = stress * (HARTREE2EV / BOHR**3)
 
         if 'dipole' in properties:
             if self.pbc:


### PR DESCRIPTION
Changes:
- `ase_interface.PySCF`: accept method_factory; rebuild method per step  with `dm0` warm-start; use non-inplace `set_geom_` when factory is set. This is aimed at making calculation parameters being smoothly changed, i.e., each new step a new mean filed object will be created.
- Fix stress unit conversion: `HARTREE2EV / BOHR` -> `HARTREE2EV / BOHR**3` (stress is energy per volume).