### PR TITLE
Fix RYS_per_atom_jk_ip1_sum kernel

### DIFF
--- a/gpu4pyscf/grad/tdrhf.py
+++ b/gpu4pyscf/grad/tdrhf.py
@@ -405,7 +405,13 @@ def _jk_energies_per_atom(vhfopt, dm_pairs, j_factor=None, k_factor=None,
             if npairs_ij == 0 or npairs_kl == 0:
                 continue
             llll = f'({l_symb[i]}{l_symb[j]}|{l_symb[k]}{l_symb[l]})'
-            scheme = _ejk_quartets_scheme(mol, uniq_l_ctr[[i, j, k, l]])
+            uniq_l_ctr_ijkl = uniq_l_ctr[[i, j, k, l]]
+            scheme = _ejk_quartets_scheme(mol, uniq_l_ctr_ijkl)
+
+            uniq_l_ijkl = uniq_l_ctr_ijkl[:, 0]
+            nf_ijkl = np.prod((uniq_l_ijkl + 1) * (uniq_l_ijkl + 2) // 2)
+            assert scheme[0] * nf_ijkl <= dd_cache_maxsize
+
             err = kern(
                 ctypes.cast(ejk.data.ptr, ctypes.c_void_p),
                 ctypes.cast(_j_factor.data.ptr, ctypes.c_void_p), j_factor.ctypes,


### PR DESCRIPTION
Fix a problem that `gpu4pyscf.grad.tdrhf._jk_energies_per_atom()` generates random number when `sum_results=True`. This mode is not used in any code path for real application, so nothing is actually affected. But `gpu4pyscf/grad/tests/test_tdrhf_grad.py::KnownValues::test_jk_energies_per_atom_hermi0` will blow up randomly.

The problem is, in `RYS_per_atom_jk_ip1_sum` kernel function, it assumes `dd_cache_size` is greater than or equal to `blockIdx.x * (li+1)*(li+2)/2 * (lj+1)*(lj+2)/2 * (lk+1)*(lk+2)/2 * (ll+1)*(ll+2)/2`, but the caller does not satisfy that, so at https://github.com/pyscf/gpu4pyscf/blame/551d9bb165941a49c0b3d1281a3705680487b1b3/gpu4pyscf/lib/gvhf-rys/rys_contract_jk_ip1.cu#L1434 a block actually steps on the space assigned to another block.