### PR TITLE
A naive implementation of MBIS and Hirshfeld multipoles

### DIFF
--- a/gpu4pyscf/dft/numint.py
+++ b/gpu4pyscf/dft/numint.py
@@ -1073,11 +1073,11 @@ def get_rho(ni, mol, dm, grids, max_memory=2000, verbose=None):
 
     ao_deriv = 0
     ngrids = grids.weights.size
-    rho = cupy.empty(ngrids)
+    rho = cupy.zeros(ngrids)
 
     t1 = t0 = log.init_timer()
     p0 = p1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv, strict_grid_order = True):
         p0, p1 = p1, p1 + weight.size
         if mo_coeff is None:
             dm_mask = dm[idx[:,None],idx]
@@ -1086,6 +1086,7 @@ def get_rho(ni, mol, dm, grids, max_memory=2000, verbose=None):
             mo_coeff_mask = mo_coeff[idx,:]
             rho[p0:p1] = eval_rho2(_sorted_mol, ao, mo_coeff_mask, mo_occ, None, 'LDA')
         t1 = log.timer_debug2('eval rho slice', *t1)
+    assert p1 == ngrids
     t0 = log.timer_debug1('eval rho', *t0)
 
     if FREE_CUPY_CACHE:
@@ -1121,6 +1122,7 @@ def get_rho_naive(mol, dm, grids):
         ao = ni.eval_ao(mol, grids_coords[g0:g1, :], deriv = 0)
         for i_dm in range(nset):
             rho_tot[i_dm, g0:g1] = np.einsum("gi,gj,ij->g", ao, ao, dm[i_dm])
+    assert g1 == ngrids
 
     rho_tot = np.sum(rho_tot, axis = 0)
     return rho_tot
@@ -1168,11 +1170,11 @@ def get_rho_with_derivatives(ni, mol, dm, grids, xc = "r2scan", max_memory=2000,
         rho_dim = 5
 
     ngrids = grids.coords.shape[0]
-    rho_tot = cupy.empty([nset, rho_dim, ngrids])
+    rho_tot = cupy.zeros([nset, rho_dim, ngrids])
 
     t1 = t0 = log.init_timer()
     p0 = p1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv, strict_grid_order = True):
         p0, p1 = p1, p1 + weight.size
         for i_dm in range(nset):
             if mo_coeff is None:
@@ -1183,6 +1185,7 @@ def get_rho_with_derivatives(ni, mol, dm, grids, xc = "r2scan", max_memory=2000,
                 rho_tot[i_dm, :, p0:p1] = eval_rho2(_sorted_mol, ao, mo_coeff_mask, mo_occ[i_dm], None, xctype)
 
         t1 = log.timer_debug2('eval rho slice', *t1)
+    assert p1 == ngrids
     t0 = log.timer_debug1('eval rho', *t0)
 
     if FREE_CUPY_CACHE:
@@ -1222,7 +1225,7 @@ def get_rho_with_derivatives_naive(mol, dm, grids, xc = "r2scan"):
         rho_dim = 4
     else:
         rho_dim = 5
-    rho_tot = np.empty([nset, rho_dim, ngrids])
+    rho_tot = np.zeros([nset, rho_dim, ngrids])
 
     ngrids_per_batch = 4096
     for g0 in range(0, ngrids, ngrids_per_batch):
@@ -1231,6 +1234,7 @@ def get_rho_with_derivatives_naive(mol, dm, grids, xc = "r2scan"):
         for i_dm in range(nset):
             rho = ni.eval_rho(mol, ao, dm[i_dm], xctype = xctype, hermi = 1, with_lapl = False)
             rho_tot[i_dm, :, g0:g1] = rho
+    assert g1 == ngrids
 
     return rho_tot
 
@@ -2054,6 +2058,8 @@ def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
         if nao_sub == 0:
             if strict_grid_order:
                 zero_sized_ao = cupy.ndarray((comp,nao_sub,ip1-ip0), memptr=buf.data)
+                if deriv == 0:
+                    zero_sized_ao = zero_sized_ao[0]
                 yield zero_sized_ao, idx, weight, coords
             continue
 

--- a/gpu4pyscf/dft/numint.py
+++ b/gpu4pyscf/dft/numint.py
@@ -1077,7 +1077,7 @@ def get_rho(ni, mol, dm, grids, max_memory=2000, verbose=None):
 
     t1 = t0 = log.init_timer()
     p0 = p1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv):
         p0, p1 = p1, p1 + weight.size
         if mo_coeff is None:
             dm_mask = dm[idx[:,None],idx]
@@ -1174,7 +1174,7 @@ def get_rho_with_derivatives(ni, mol, dm, grids, xc = "r2scan", max_memory=2000,
 
     t1 = t0 = log.init_timer()
     p0 = p1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv):
         p0, p1 = p1, p1 + weight.size
         for i_dm in range(nset):
             if mo_coeff is None:
@@ -1992,7 +1992,7 @@ def _sparse_index(mol, coords, l_ctr_offsets, ao_loc, opt=None):
     return pad, idx, non0shl_idx, ctr_offsets_slice, ao_loc_slice
 
 def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
-                non0tab=None, blksize=None, buf=None, extra=0, grid_range=None, strict_grid_order=False):
+                non0tab=None, blksize=None, buf=None, extra=0, grid_range=None):
     '''
     Generator loops over grids block-by-block.
     Kwargs:
@@ -2002,7 +2002,6 @@ def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
         blksize: if not given, it will be estimated with avail GPU memory.
         buf: dummy argument for compatibility with PySCF
         grid_range: loop [grid_start, grid_end] in grids only. Both values has to be multiple of MIN_BLK_SIZE.
-        strict_grid_order: if True, no grids will be skipped, even if ao dimension is zero.
     '''
     log = logger.new_logger(mol)
     if grids.coords is None:
@@ -2055,13 +2054,7 @@ def _block_loop(ni, mol, grids, nao=None, deriv=0, max_memory=2000,
         coords = cupy.asarray(grids.coords[ip0:ip1])
         weight = cupy.asarray(grids.weights[ip0:ip1])
 
-        if nao_sub == 0:
-            if strict_grid_order:
-                zero_sized_ao = cupy.ndarray((comp,nao_sub,ip1-ip0), memptr=buf.data)
-                if deriv == 0:
-                    zero_sized_ao = zero_sized_ao[0]
-                yield zero_sized_ao, idx, weight, coords
-            continue
+        # Note: do NOT skip when nao_sub == 0, it'll mess up the grid order!
 
         ao_mask = eval_ao(
             _sorted_mol, coords, deriv,
@@ -2460,6 +2453,8 @@ def _scale_ao(ao, wv, out=None):
     nvar, nao, ngrids = ao.shape
     assert wv.shape == (nvar, ngrids)
     out = ndarray((nao, ngrids), dtype=ao.dtype, buffer=out)
+    if ao.size == 0:
+        return out
     if not ao.flags.c_contiguous:
         return contract('nip,np->ip', ao, wv, out=out)
 

--- a/gpu4pyscf/grad/rks.py
+++ b/gpu4pyscf/grad/rks.py
@@ -456,7 +456,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     rho = cupy.empty([ncomp, ngrids])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
         g0, g1 = g1, g1 + weight.size
         dms_masked = take_last2d(dms, idx, out=dm_mask_buf)
         rho[:, g0:g1] = numint.eval_rho(_sorted_mol, ao, dms_masked, xctype = xctype, hermi = 1)
@@ -492,7 +492,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     del exc
 
     g0 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1):
         g1 = g0 + weight.shape[0]
 
         ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -594,7 +594,7 @@ def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=
     ngrids_full = grids.coords.shape[0]
     rho_drho = cupy.empty([4, ngrids_full])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
         g0, g1 = g1, g1 + weight.size
         dms_masked = take_last2d(dms_sorted, idx, out = dm_mask_buf)
         rho_drho[:, g0:g1] = numint.eval_rho(_sorted_mol, ao, dms_masked, xctype = "NLC", hermi = 1)
@@ -666,7 +666,7 @@ def get_nlc_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=
 
     g0_full = 0
     g0_nonzero = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
         g1_full = g0_full + weight.shape[0]
 
         ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]

--- a/gpu4pyscf/grad/uks.py
+++ b/gpu4pyscf/grad/uks.py
@@ -296,7 +296,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     rho = cupy.empty([2, ncomp, ngrids])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = ao_deriv):
         g0, g1 = g1, g1 + weight.size
         dma_masked = take_last2d(dms[0], idx, out=dm_mask_buf)
         rho[0, :, g0:g1] = numint.eval_rho(_sorted_mol, ao, dma_masked, xctype = xctype, hermi = 1)
@@ -334,7 +334,7 @@ def get_exc_full_response(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
     del exc
 
     g0 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, ao_deriv + 1):
         g1 = g0 + weight.shape[0]
 
         ao = ao[:, :, nonzero_weight_mask[g0:g1]]

--- a/gpu4pyscf/hessian/rks.py
+++ b/gpu4pyscf/hessian/rks.py
@@ -785,7 +785,7 @@ def _get_enlc_deriv2(hessobj, mo_coeff, mo_occ, max_memory, log = None):
     ngrids_full = grids.coords.shape[0]
     rho_drho = cupy.empty([4, ngrids_full])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
         g0, g1 = g1, g1 + weight.size
         dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
         rho_drho[:, g0:g1] = numint.eval_rho(_sorted_mol, ao, dm0_masked, xctype = "NLC", hermi = 1)
@@ -874,7 +874,7 @@ def _get_enlc_deriv2(hessobj, mo_coeff, mo_occ, max_memory, log = None):
 
         g0_full = 0
         g0_nonzero = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 3):
             g1_full = g0_full + weight.shape[0]
 
             ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]
@@ -1012,7 +1012,7 @@ def _get_enlc_deriv2(hessobj, mo_coeff, mo_occ, max_memory, log = None):
 
         g0_full = 0
         g0_nonzero = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 2):
             g1_full = g0_full + weight.shape[0]
 
             ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]
@@ -1141,7 +1141,7 @@ def _get_enlc_deriv2(hessobj, mo_coeff, mo_occ, max_memory, log = None):
         # First two terms in E_{G,G}^{AB} in Eq 37, second piece
         g0_full = 0
         g0_nonzero = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 3):
             g1_full = g0_full + weight.shape[0]
 
             ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]
@@ -1542,7 +1542,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     if xctype == 'LDA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -1616,7 +1616,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'GGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -1727,7 +1727,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'MGGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -2103,7 +2103,7 @@ def _get_vnlc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     ngrids_full = grids.coords.shape[0]
     rho_drho = cupy.empty([4, ngrids_full])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
         g0, g1 = g1, g1 + weight.size
         dm0_masked = take_last2d(dm0_sorted, idx, out = dm_mask_buf)
         rho_drho[:, g0:g1] = numint.eval_rho(_sorted_mol, ao, dm0_masked, xctype = "NLC", hermi = 1)
@@ -2190,7 +2190,7 @@ def _get_vnlc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
 
     g0_full = 0
     g0_nonzero = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 2, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 2):
         g1_full = g0_full + weight.shape[0]
 
         ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]
@@ -2286,7 +2286,7 @@ def _get_vnlc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
 
     g0_full = 0
     g0_nonzero = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 2, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 2):
         g1_full = g0_full + weight.shape[0]
 
         ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]
@@ -2530,7 +2530,7 @@ def _get_vnlc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
 
         g0_full = 0
         g0_nonzero = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1):
             g1_full = g0_full + weight.shape[0]
 
             ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]
@@ -3227,7 +3227,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     if xctype == 'LDA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0):
             g1 = g0 + weight.shape[0]
 
             if ao.size == 0:
@@ -3248,7 +3248,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -3304,7 +3304,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'GGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
             g1 = g0 + weight.shape[0]
 
             if ao.size == 0:
@@ -3325,7 +3325,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -3389,7 +3389,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'MGGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
             g1 = g0 + weight.shape[0]
 
             if ao.size == 0:
@@ -3410,7 +3410,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -3673,7 +3673,7 @@ def nr_rks_fnlc_mo(mf, mol, mo_coeff, mo_occ, dm1s, return_in_mo = True):
     ngrids_full = grids.coords.shape[0]
     rho_drho = cupy.empty([4, ngrids_full])
     g1 = 0
-    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1, strict_grid_order = True):
+    for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1):
         g0, g1 = g1, g1 + weight.size
         if mo_coeff.ndim == 2:
             rho_drho[:, g0:g1] = numint.eval_rho2(_sorted_mol, ao, mo_coeff[idx, :], mo_occ, None, 'GGA')
@@ -3778,7 +3778,7 @@ def nr_rks_fnlc_mo(mf, mol, mo_coeff, mo_occ, dm1s, return_in_mo = True):
 
         rho_drho_t = cupy.empty([n_dm1_batch, 4, ngrids_full])
         g1 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1):
             g0, g1 = g1, g1 + weight.size
             for i_dm in range(n_dm1_batch):
                 dm1_sorted = dm1s_sorted[i_dm + i_dm1_batch, :, :]
@@ -3841,7 +3841,7 @@ def nr_rks_fnlc_mo(mf, mol, mo_coeff, mo_occ, dm1s, return_in_mo = True):
 
         g0_full = 0
         g0_nonzero = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, deriv = 1):
             g1_full = g0_full + weight.shape[0]
 
             ao = ao[:, :, rho_nonzero_mask[g0_full : g1_full]]

--- a/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
+++ b/gpu4pyscf/hessian/tests/test_rks_hessian_grid_response.py
@@ -901,7 +901,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]
@@ -1035,7 +1035,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]
@@ -1175,7 +1175,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]

--- a/gpu4pyscf/hessian/tests/test_uks_hessian_grid_response.py
+++ b/gpu4pyscf/hessian/tests/test_uks_hessian_grid_response.py
@@ -705,7 +705,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]
@@ -829,7 +829,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]
@@ -955,7 +955,7 @@ class KnownValues(unittest.TestCase):
         test_d2E_dAdB_orbital_response = cp.zeros((natm, natm, 3, 3))
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             mu = ao[0]

--- a/gpu4pyscf/hessian/uks.py
+++ b/gpu4pyscf/hessian/uks.py
@@ -957,7 +957,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     if xctype == 'LDA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 0):
             g1 = g0 + weight.shape[0]
 
             if ao.size == 0:
@@ -981,7 +981,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -1042,7 +1042,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'GGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
             g1 = g0 + weight.shape[0]
 
             if ao.size == 0:
@@ -1066,7 +1066,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -1133,7 +1133,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'MGGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
             g1 = g0 + weight.shape[0]
 
             if ao.size == 0:
@@ -1157,7 +1157,7 @@ def _get_exc_deriv2_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
         assert g1 == ngrids
 
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 3):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -1488,7 +1488,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     if xctype == 'LDA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 1):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -1574,7 +1574,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'GGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]
@@ -1696,7 +1696,7 @@ def _get_vxc_deriv1_grid_response(hessobj, mo_coeff, mo_occ, max_memory):
 
     elif xctype == 'MGGA':
         g0 = 0
-        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2, strict_grid_order = True):
+        for ao, idx, weight, _ in ni.block_loop(_sorted_mol, grids, nao, deriv = 2):
             g1 = g0 + weight.shape[0]
 
             ao = ao[:, :, nonzero_weight_mask[g0:g1]]

--- a/gpu4pyscf/qmmm/hirshfeld.py
+++ b/gpu4pyscf/qmmm/hirshfeld.py
@@ -1,0 +1,338 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cupy as cp
+import numpy as np
+
+import pyscf
+from pyscf.data.elements import charge as charge_of_element
+from pyscf.gto.mole import ANG_OF
+from pyscf.dft.LebedevGrid import LEBEDEV_NGRID, MakeAngularGrid
+from gpu4pyscf.lib import logger
+from gpu4pyscf.dft.numint import NumInt
+from gpu4pyscf.solvent.pcm import natm_without_ghost
+from gpu4pyscf.dft.gen_grid import Grids
+from gpu4pyscf.dft.uks import UKS
+from gpu4pyscf.scf.uhf import UHF as UHF_GPU
+from pyscf.scf.uhf import UHF as UHF_CPU
+
+HIRSHFELD_REMOVE_ZERO_RHO_GRID_THRESHOLD = 1e-10
+
+_neutral_atom_spin = [
+       # Z    El  Name           Ground level  2S  S    Mult.  Source
+       # ---  --  -------------  ------------  --  ---  -----  -------------------------------
+    1, # 1    H   Hydrogen       2S<1/2>       1   1/2  2      NIST term
+    0, # 2    He  Helium         1S0           0   0    1      NIST term
+    1, # 3    Li  Lithium        2S<1/2>       1   1/2  2      NIST term
+    0, # 4    Be  Beryllium      1S0           0   0    1      NIST term
+    1, # 5    B   Boron          2P*<1/2>      1   1/2  2      NIST term
+    2, # 6    C   Carbon         3P0           2   1    3      NIST term
+    3, # 7    N   Nitrogen       4S*<3/2>      3   3/2  4      NIST term
+    2, # 8    O   Oxygen         3P<2>         2   1    3      NIST term
+    1, # 9    F   Fluorine       2P*<3/2>      1   1/2  2      NIST term
+    0, # 10   Ne  Neon           1S0           0   0    1      NIST term
+    1, # 11   Na  Sodium         2S<1/2>       1   1/2  2      NIST term
+    0, # 12   Mg  Magnesium      1S0           0   0    1      NIST term
+    1, # 13   Al  Aluminum       2P*<1/2>      1   1/2  2      NIST term
+    2, # 14   Si  Silicon        3P0           2   1    3      NIST term
+    3, # 15   P   Phosphorus     4S*<3/2>      3   3/2  4      NIST term
+    2, # 16   S   Sulfur         3P<2>         2   1    3      NIST term
+    1, # 17   Cl  Chlorine       2P*<3/2>      1   1/2  2      NIST term
+    0, # 18   Ar  Argon          1S0           0   0    1      NIST term
+    1, # 19   K   Potassium      2S<1/2>       1   1/2  2      NIST term
+    0, # 20   Ca  Calcium        1S0           0   0    1      NIST term
+    1, # 21   Sc  Scandium       2D<3/2>       1   1/2  2      NIST term
+    2, # 22   Ti  Titanium       3F<2>         2   1    3      NIST term
+    3, # 23   V   Vanadium       4F<3/2>       3   3/2  4      NIST term
+    6, # 24   Cr  Chromium       7S<3>         6   3    7      NIST term
+    5, # 25   Mn  Manganese      6S<5/2>       5   5/2  6      NIST term
+    4, # 26   Fe  Iron           5D<4>         4   2    5      NIST term
+    3, # 27   Co  Cobalt         4F<9/2>       3   3/2  4      NIST term
+    2, # 28   Ni  Nickel         3F<4>         2   1    3      NIST term
+    1, # 29   Cu  Copper         2S<1/2>       1   1/2  2      NIST term
+    0, # 30   Zn  Zinc           1S0           0   0    1      NIST term
+    1, # 31   Ga  Gallium        2P*<1/2>      1   1/2  2      NIST term
+    2, # 32   Ge  Germanium      3P0           2   1    3      NIST term
+    3, # 33   As  Arsenic        4S*<3/2>      3   3/2  4      NIST term
+    2, # 34   Se  Selenium       3P<2>         2   1    3      NIST term
+    1, # 35   Br  Bromine        2P*<3/2>      1   1/2  2      NIST term
+    0, # 36   Kr  Krypton        1S0           0   0    1      NIST term
+    1, # 37   Rb  Rubidium       2S<1/2>       1   1/2  2      NIST term
+    0, # 38   Sr  Strontium      1S0           0   0    1      NIST term
+    1, # 39   Y   Yttrium        2D<3/2>       1   1/2  2      NIST term
+    2, # 40   Zr  Zirconium      3F<2>         2   1    3      NIST term
+    5, # 41   Nb  Niobium        6D<1/2>       5   5/2  6      NIST term
+    6, # 42   Mo  Molybdenum     7S<3>         6   3    7      NIST term
+    5, # 43   Tc  Technetium     6S<5/2>       5   5/2  6      NIST term
+    4, # 44   Ru  Ruthenium      5F<5>         4   2    5      NIST term
+    3, # 45   Rh  Rhodium        4F<9/2>       3   3/2  4      NIST term
+    0, # 46   Pd  Palladium      1S0           0   0    1      NIST term
+    1, # 47   Ag  Silver         2S<1/2>       1   1/2  2      NIST term
+    0, # 48   Cd  Cadmium        1S0           0   0    1      NIST term
+    1, # 49   In  Indium         2P*<1/2>      1   1/2  2      NIST term
+    2, # 50   Sn  Tin            3P0           2   1    3      NIST term
+    3, # 51   Sb  Antimony       4S*<3/2>      3   3/2  4      NIST term
+    2, # 52   Te  Tellurium      3P<2>         2   1    3      NIST term
+    1, # 53   I   Iodine         2P*<3/2>      1   1/2  2      NIST term
+    0, # 54   Xe  Xenon          1S0           0   0    1      NIST term
+    1, # 55   Cs  Cesium         2S<1/2>       1   1/2  2      NIST term
+    0, # 56   Ba  Barium         1S0           0   0    1      NIST term
+    1, # 57   La  Lanthanum      2D<3/2>       1   1/2  2      NIST term
+    0, # 58   Ce  Cerium         1G*<4>        0   0    1      NIST term
+    3, # 59   Pr  Praseodymium   4I*<9/2>      3   3/2  4      NIST term
+    4, # 60   Nd  Neodymium      5I<4>         4   2    5      NIST term
+    5, # 61   Pm  Promethium     6H*<5/2>      5   5/2  6      NIST term
+    6, # 62   Sm  Samarium       7F0           6   3    7      NIST term
+    7, # 63   Eu  Europium       8S*<7/2>      7   7/2  8      NIST term
+    8, # 64   Gd  Gadolinium     9D*<2>        8   4    9      NIST term
+    5, # 65   Tb  Terbium        6H*<15/2>     5   5/2  6      NIST term
+    4, # 66   Dy  Dysprosium     5I<8>         4   2    5      NIST term
+    3, # 67   Ho  Holmium        4I*<15/2>     3   3/2  4      NIST term
+    2, # 68   Er  Erbium         3H<6>         2   1    3      NIST term
+    1, # 69   Tm  Thulium        2F*<7/2>      1   1/2  2      NIST term
+    0, # 70   Yb  Ytterbium      1S0           0   0    1      NIST term
+    1, # 71   Lu  Lutetium       2D<3/2>       1   1/2  2      NIST term
+    2, # 72   Hf  Hafnium        3F<2>         2   1    3      NIST term
+    3, # 73   Ta  Tantalum       4F<3/2>       3   3/2  4      NIST term
+    4, # 74   W   Tungsten       5D0           4   2    5      NIST term
+    5, # 75   Re  Rhenium        6S<5/2>       5   5/2  6      NIST term
+    4, # 76   Os  Osmium         5D<4>         4   2    5      NIST term
+    3, # 77   Ir  Iridium        4F<9/2>       3   3/2  4      NIST term
+    2, # 78   Pt  Platinum       3D<3>         2   1    3      NIST term
+    1, # 79   Au  Gold           2S<1/2>       1   1/2  2      NIST term
+    0, # 80   Hg  Mercury        1S0           0   0    1      NIST term
+    1, # 81   Tl  Thallium       2P*<1/2>      1   1/2  2      NIST term
+    2, # 82   Pb  Lead           (1/2,1/2)0    2   1    3      Hund/config (NIST)
+    3, # 83   Bi  Bismuth        4S*<3/2>      3   3/2  4      NIST term
+    2, # 84   Po  Polonium       3P<2>         2   1    3      NIST term
+    1, # 85   At  Astatine       2P*<3/2>      1   1/2  2      NIST term
+    0, # 86   Rn  Radon          1S0           0   0    1      NIST term
+    1, # 87   Fr  Francium       2S<1/2>       1   1/2  2      NIST term
+    0, # 88   Ra  Radium         1S0           0   0    1      NIST term
+    1, # 89   Ac  Actinium       2D<3/2>       1   1/2  2      NIST term
+    2, # 90   Th  Thorium        3F<2>         2   1    3      NIST term
+    3, # 91   Pa  Protactinium   4K<11/2>      3   3/2  4      NIST term
+    4, # 92   U   Uranium        5L*<6>        4   2    5      NIST term
+    5, # 93   Np  Neptunium      6L<11/2>      5   5/2  6      NIST term
+    6, # 94   Pu  Plutonium      7F0           6   3    7      NIST term
+    7, # 95   Am  Americium      8S*<7/2>      7   7/2  8      NIST term
+    8, # 96   Cm  Curium         9D*<2>        8   4    9      NIST term
+    5, # 97   Bk  Berkelium      6H*<15/2>     5   5/2  6      NIST term
+    4, # 98   Cf  Californium    5I<8>         4   2    5      NIST term
+    3, # 99   Es  Einsteinium    4I*<15/2>     3   3/2  4      NIST term
+    2, # 100  Fm  Fermium        3H<6>         2   1    3      NIST term
+    1, # 101  Md  Mendelevium    2F*<7/2>      1   1/2  2      NIST term
+    0, # 102  No  Nobelium       1S0           0   0    1      NIST term
+    1, # 103  Lr  Lawrencium     2P*<1/2>      1   1/2  2      NIST term
+    2, # 104  Rf  Rutherfordium  3F<2>         2   1    3      NIST term
+    3, # 105  Db  Dubnium        4F<3/2>       3   3/2  4      NIST term
+    4, # 106  Sg  Seaborgium     0             4   2    5      Hund/config (NIST)
+    5, # 107  Bh  Bohrium        <5/2>         5   5/2  6      Hund/config (NIST)
+    4, # 108  Hs  Hassium        <4>           4   2    5      Hund/config (NIST)
+]
+
+def hirshfeld_kernel(mol, grids, dm, make_mf):
+    log = logger.new_logger(mol)
+
+    dm = cp.asarray(dm)
+    if dm.ndim == 3:
+        assert dm.shape[0] == 2
+        dm = dm[0] + dm[1]
+    assert dm.shape == (mol.nao, mol.nao)
+
+    natm = natm_without_ghost(mol)
+    if natm != mol.natm:
+        raise NotImplementedError("Ghost atoms are not supported in Hirshfeld yet")
+
+    assert callable(make_mf)
+
+    elements = mol.elements
+    unique_elements = list(set(elements))
+
+    mf_per_element = {}
+    for element in unique_elements:
+        Z = charge_of_element(element)
+        assert 0 < Z and Z < len(_neutral_atom_spin)
+        spin = _neutral_atom_spin[Z - 1]
+        charge = 0 # Only support neutral atoms for now
+
+        mol_atom = pyscf.M(
+            atom = f"{element} 0 0 0",
+            basis = mol.basis,
+            ecp = mol.ecp,
+            charge = charge,
+            spin = spin,
+            verbose = mol.verbose,
+        )
+
+        mf_atom = make_mf(mol_atom)
+
+        if not (isinstance(mf_atom, UHF_GPU) or isinstance(mf_atom, UHF_CPU)):
+            log.warn("We highly recommend using unrestricted method to perform atomic calculation.")
+
+        mf_atom.kernel()
+        assert mf_atom.converged
+
+        mf_per_element[element] = mf_atom
+
+    if grids.coords is None:
+        grids.build()
+
+    grid_coords = cp.asarray(grids.coords)
+    grid_weights = cp.asarray(grids.weights)
+    ni = NumInt()
+    grid_rho = ni.get_rho(mol, dm, grids)
+
+    rho_nonzero_mask = cp.logical_and(
+        grid_rho >= HIRSHFELD_REMOVE_ZERO_RHO_GRID_THRESHOLD,
+        cp.abs(grid_weights) > 1e-14,
+    )
+
+    grid_rho = grid_rho[rho_nonzero_mask]
+    grid_coords = cp.ascontiguousarray(grid_coords[rho_nonzero_mask, :])
+    grid_weights = grid_weights[rho_nonzero_mask]
+    grid_w_rho = grid_weights * grid_rho
+    ngrids = grid_coords.shape[0]
+
+    nelec = float(cp.sum(grid_w_rho))
+    log.info(f"Total number of electrons integrated by Hirshfeld grid = {nelec}")
+
+    atom_coords = cp.asarray(mol.atom_coords())
+
+    atomic_rho = []
+    for i_atom in range(natm):
+        element = elements[i_atom]
+        mf_atom = mf_per_element[element]
+
+        atom_grid_rij = cp.linalg.norm(grid_coords - atom_coords[i_atom], axis = 1)
+
+        mol_atom = mf_atom.mol
+        L_max = np.max(mol_atom._bas[:, ANG_OF])
+        n_angular_grid = LEBEDEV_NGRID[L_max]
+        if n_angular_grid > 1:
+            angular_grid = cp.asarray(MakeAngularGrid(n_angular_grid))
+        else:
+            angular_grid = cp.array([[0, 0, 1.0, 1.0]])
+        spherical_average_grid_coords = angular_grid[None, :, :3] * atom_grid_rij[:, None, None] # Centered at the atom
+        spherical_average_grid_coords = spherical_average_grid_coords.reshape(ngrids * n_angular_grid, 3)
+        del atom_grid_rij
+
+        fake_grids = Grids(pyscf.M())
+        fake_grids.coords = spherical_average_grid_coords
+        fake_grids.weights = spherical_average_grid_coords[:, 0] # Just need a correct shape
+        def just_raise(*args, **kwargs):
+            raise RuntimeError("Should never be called")
+        fake_grids.build = just_raise
+
+        dm_atom = mf_atom.make_rdm1()
+        if dm_atom.ndim == 3:
+            assert dm_atom.shape[0] == 2
+            dm_atom = dm_atom[0] + dm_atom[1]
+        assert dm_atom.shape == (mol_atom.nao, mol_atom.nao)
+
+        ni = NumInt()
+        rho_atom = ni.get_rho(mol_atom, dm_atom, fake_grids)
+        rho_atom = rho_atom.reshape(ngrids, n_angular_grid)
+
+        del spherical_average_grid_coords, dm_atom
+
+        rho_atom = cp.sum(rho_atom * angular_grid[:, 3], axis = 1) # Spherical averaged
+        del angular_grid
+        nelec_atom = float(cp.sum(rho_atom * grid_weights))
+        log.info(f"Hirshfeld grid intergation of atom {element} = {nelec_atom}")
+        atomic_rho.append(rho_atom)
+
+    atomic_rho = cp.stack(atomic_rho, axis = 0)
+    sum_atomic_rho = cp.sum(atomic_rho, axis = 0)
+
+    sum_atomic_rho_nonzero_mask = sum_atomic_rho >= HIRSHFELD_REMOVE_ZERO_RHO_GRID_THRESHOLD
+    atom_partition = cp.zeros_like(atomic_rho)
+    atom_partition[:, sum_atomic_rho_nonzero_mask] = atomic_rho[:, sum_atomic_rho_nonzero_mask] / sum_atomic_rho[sum_atomic_rho_nonzero_mask]
+    del sum_atomic_rho, sum_atomic_rho_nonzero_mask, atomic_rho
+
+    # Hirshfeld Multipoles
+
+    partitioned_w_rho = atom_partition * grid_w_rho[None, :]
+    partitioned_nelec = cp.sum(partitioned_w_rho, axis = 1)
+    atom_charges = cp.asarray(mol.atom_charges(), dtype = cp.float64)
+    charges = atom_charges - partitioned_nelec
+
+    log.info("Hirshfeld Charge (a.u.)")
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {charges[i_atom]:13.8f}")
+
+    atom_grid_vecrij = grid_coords[None, :, :] - atom_coords[:, None, :]
+
+    dipoles = -cp.einsum("Ag,Agx->Ax", partitioned_w_rho, atom_grid_vecrij)
+
+    log.info("Hirshfeld Dipole x y z (a.u.)")
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {dipoles[i_atom, 0]:13.8f}  {dipoles[i_atom, 1]:13.8f}  {dipoles[i_atom, 2]:13.8f}")
+
+    # ORCA did not remove trace, and we follow them
+    quadrupoles = -cp.einsum("Ag,Agx,Agy->Axy", partitioned_w_rho, atom_grid_vecrij, atom_grid_vecrij)
+
+    log.info("Hirshfeld Quadrupole xx yy zz xy xz yz (a.u.)")
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {quadrupoles[i_atom, 0, 0]:13.8f}  {quadrupoles[i_atom, 1, 1]:13.8f}  {quadrupoles[i_atom, 2, 2]:13.8f}  "
+                 f"{0.5 * (quadrupoles[i_atom, 0, 1] + quadrupoles[i_atom, 1, 0]):13.8f}  "
+                 f"{0.5 * (quadrupoles[i_atom, 0, 2] + quadrupoles[i_atom, 2, 0]):13.8f}  "
+                 f"{0.5 * (quadrupoles[i_atom, 1, 2] + quadrupoles[i_atom, 2, 1]):13.8f}")
+
+    # ORCA did not remove trace, and we follow them
+    octupoles = -cp.einsum("Ag,Agx,Agy,Agz->Axyz", partitioned_w_rho, atom_grid_vecrij, atom_grid_vecrij, atom_grid_vecrij)
+
+    log.info("Hirshfeld Octupole xxx yyy zzz xxy xxz xyy xyz xzz yyz yzz (a.u.)")
+    octupole_xyz_term = octupoles[i_atom, 0, 1, 2] + octupoles[i_atom, 0, 2, 1] + octupoles[i_atom, 1, 0, 2] \
+                        + octupoles[i_atom, 1, 2, 0] + octupoles[i_atom, 2, 0, 1] + octupoles[i_atom, 2, 1, 0] # Just to make linter happy
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {octupoles[i_atom, 0, 0, 0]:13.8f}  {octupoles[i_atom, 1, 1, 1]:13.8f}  {octupoles[i_atom, 2, 2, 2]:13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 1] + octupoles[i_atom, 0, 1, 0] + octupoles[i_atom, 1, 0, 0]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 2] + octupoles[i_atom, 0, 2, 0] + octupoles[i_atom, 2, 0, 0]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 1, 1] + octupoles[i_atom, 1, 0, 1] + octupoles[i_atom, 1, 1, 0]):13.8f}  "
+                 f"{1.0/6.0 * octupole_xyz_term:13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 2, 2] + octupoles[i_atom, 2, 0, 2] + octupoles[i_atom, 2, 2, 0]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 1, 1, 2] + octupoles[i_atom, 1, 2, 1] + octupoles[i_atom, 2, 1, 1]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 1, 2, 2] + octupoles[i_atom, 2, 1, 2] + octupoles[i_atom, 2, 2, 1]):13.8f}  "
+                 f"")
+
+    return charges.get(), dipoles.get(), quadrupoles.get(), octupoles.get()
+
+def hirshfeld(mol, grids, dm, xc = "wB97X-V", xc_grid = (99,590), nlc_grid = (50,194), auxbasis = None,
+              conv_tol = 1e-10, max_cycle = 100, nlc = None, disp = None):
+    """
+        Original Hirshfeld algorithm following:
+        Hirshfeld, F. L. (1977). Bonded-atom fragments for describing molecular charge densities. Theoretica chimica acta, 44(2), 129-138.
+
+        i.e. Use atomic density of neutral atoms regardless of total molecular charge, and perform spherical averaging for atomic density.
+    """
+
+    def _make_mf(mol):
+        if xc is None or xc.upper() == "HF":
+            mf = UHF_GPU(mol)
+        else:
+            mf = UKS(mol, xc = xc)
+            mf.grids.atom_grid = xc_grid
+            mf.nlcgrids.atom_grid = nlc_grid
+        if nlc is not None:
+            mf.nlc = nlc
+        if disp is not None:
+            mf.disp = disp
+        mf.conv_tol = conv_tol
+        mf.max_cycle = max_cycle
+        if auxbasis is not None:
+            mf = mf.density_fit(auxbasis = auxbasis)
+        return mf
+
+    return hirshfeld_kernel(mol, grids, dm, make_mf = _make_mf)

--- a/gpu4pyscf/qmmm/hirshfeld.py
+++ b/gpu4pyscf/qmmm/hirshfeld.py
@@ -30,8 +30,8 @@ from pyscf.scf.uhf import UHF as UHF_CPU
 HIRSHFELD_REMOVE_ZERO_RHO_GRID_THRESHOLD = 1e-10
 
 _neutral_atom_spin = [
-       # Z    El  Name           Ground level  2S  S    Mult.  Source
-       # ---  --  -------------  ------------  --  ---  -----  -------------------------------
+    #    Z    El  Name           Ground level  2S  S    Mult.  Source
+    #    ---  --  -------------  ------------  --  ---  -----  -------------------------------
     1, # 1    H   Hydrogen       2S<1/2>       1   1/2  2      NIST term
     0, # 2    He  Helium         1S0           0   0    1      NIST term
     1, # 3    Li  Lithium        2S<1/2>       1   1/2  2      NIST term

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -99,8 +99,8 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
         raise NotImplementedError("GTH pseudopotential is not supported in MBIS yet")
 
     if mol.charge < 0:
-        log.warning("MBIS does not handle negative charge well, particularly when the negative charge is diffuse. If you see a shell with huge width on one atom, "\
-                    "it is likely due to the diffused charge got fitted onto that random atom.")
+        log.warning("MBIS does not handle negative charge well, particularly when the negative charge is diffuse. "
+                    "If you see a shell with huge width on one atom, it is likely due to the diffused charge got fitted onto that random atom.")
 
     atom_coords = cp.asarray(mol.atom_coords())
     atom_charges = cp.asarray(mol.atom_charges(), dtype = cp.int32)
@@ -190,11 +190,12 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
             break
 
     assert converged, f"MBIS not converged in {max_cycle} iterations; last max_delta_rhoA0 = {max_delta_rhoA0:.3e} > conv_tol = {conv_tol:.3e}"
-    log.info(f"MBIS converged!")
+    log.info("MBIS converged!")
 
     n_shell = shell_atom_indices.shape[0]
     for i_shell in range(n_shell):
-        log.info(f"MBIS shell {i_shell} from atom {shell_atom_indices[i_shell]} has population = {shell_populations[i_shell]} and width = {shell_widths[i_shell]}")
+        log.info(f"MBIS shell {i_shell} from atom {shell_atom_indices[i_shell]} has "
+                 "population = {shell_populations[i_shell]} and width = {shell_widths[i_shell]}")
 
     if not compute_multipoles:
         return shell_populations.get(), shell_widths.get(), shell_atom_indices
@@ -233,9 +234,9 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
 
     log.info("MBIS Quadrupole xx yy zz xy xz yz (a.u.)")
     for i_atom in range(mol.natm):
-        log.info(f"{mol.elements[i_atom]:2s}  {quadrupoles[i_atom, 0, 0]:13.8f}  {quadrupoles[i_atom, 1, 1]:13.8f}  {quadrupoles[i_atom, 2, 2]:13.8f}  "\
-                 f"{0.5 * (quadrupoles[i_atom, 0, 1] + quadrupoles[i_atom, 1, 0]):13.8f}  "\
-                 f"{0.5 * (quadrupoles[i_atom, 0, 2] + quadrupoles[i_atom, 2, 0]):13.8f}  "\
+        log.info(f"{mol.elements[i_atom]:2s}  {quadrupoles[i_atom, 0, 0]:13.8f}  {quadrupoles[i_atom, 1, 1]:13.8f}  {quadrupoles[i_atom, 2, 2]:13.8f}  "
+                 f"{0.5 * (quadrupoles[i_atom, 0, 1] + quadrupoles[i_atom, 1, 0]):13.8f}  "
+                 f"{0.5 * (quadrupoles[i_atom, 0, 2] + quadrupoles[i_atom, 2, 0]):13.8f}  "
                  f"{0.5 * (quadrupoles[i_atom, 1, 2] + quadrupoles[i_atom, 2, 1]):13.8f}")
 
     # ORCA did not remove trace, and we follow them
@@ -243,14 +244,15 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
 
     log.info("MBIS Octupole xxx yyy zzz xxy xxz xyy xyz xzz yyz yzz (a.u.)")
     for i_atom in range(mol.natm):
-        log.info(f"{mol.elements[i_atom]:2s}  {octupoles[i_atom, 0, 0, 0]:13.8f}  {octupoles[i_atom, 1, 1, 1]:13.8f}  {octupoles[i_atom, 2, 2, 2]:13.8f}  "\
-                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 1] + octupoles[i_atom, 0, 1, 0] + octupoles[i_atom, 1, 0, 0]):13.8f}  "\
-                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 2] + octupoles[i_atom, 0, 2, 0] + octupoles[i_atom, 2, 0, 0]):13.8f}  "\
-                 f"{1.0/3.0 * (octupoles[i_atom, 0, 1, 1] + octupoles[i_atom, 1, 0, 1] + octupoles[i_atom, 1, 1, 0]):13.8f}  "\
-                 f"{1.0/6.0 * (octupoles[i_atom, 0, 1, 2] + octupoles[i_atom, 0, 2, 1] + octupoles[i_atom, 1, 0, 2] + octupoles[i_atom, 1, 2, 0] + octupoles[i_atom, 2, 0, 1] + octupoles[i_atom, 2, 1, 0]):13.8f}  "\
-                 f"{1.0/3.0 * (octupoles[i_atom, 0, 2, 2] + octupoles[i_atom, 2, 0, 2] + octupoles[i_atom, 2, 2, 0]):13.8f}  "\
-                 f"{1.0/3.0 * (octupoles[i_atom, 1, 1, 2] + octupoles[i_atom, 1, 2, 1] + octupoles[i_atom, 2, 1, 1]):13.8f}  "\
-                 f"{1.0/3.0 * (octupoles[i_atom, 1, 2, 2] + octupoles[i_atom, 2, 1, 2] + octupoles[i_atom, 2, 2, 1]):13.8f}  "\
+        log.info(f"{mol.elements[i_atom]:2s}  {octupoles[i_atom, 0, 0, 0]:13.8f}  {octupoles[i_atom, 1, 1, 1]:13.8f}  {octupoles[i_atom, 2, 2, 2]:13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 1] + octupoles[i_atom, 0, 1, 0] + octupoles[i_atom, 1, 0, 0]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 2] + octupoles[i_atom, 0, 2, 0] + octupoles[i_atom, 2, 0, 0]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 1, 1] + octupoles[i_atom, 1, 0, 1] + octupoles[i_atom, 1, 1, 0]):13.8f}  "
+                 f"{1.0/6.0 * (octupoles[i_atom, 0, 1, 2] + octupoles[i_atom, 0, 2, 1] + octupoles[i_atom, 1, 0, 2] + octupoles[i_atom, 1, 2, 0]
+                               + octupoles[i_atom, 2, 0, 1] + octupoles[i_atom, 2, 1, 0]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 2, 2] + octupoles[i_atom, 2, 0, 2] + octupoles[i_atom, 2, 2, 0]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 1, 1, 2] + octupoles[i_atom, 1, 2, 1] + octupoles[i_atom, 2, 1, 1]):13.8f}  "
+                 f"{1.0/3.0 * (octupoles[i_atom, 1, 2, 2] + octupoles[i_atom, 2, 1, 2] + octupoles[i_atom, 2, 2, 1]):13.8f}  "
                  f"")
 
     return charges.get(), dipoles.get(), quadrupoles.get(), octupoles.get()

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -211,6 +211,7 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     rho0_nonzero_mask = rho0 >= MBIS_REMOVE_ZERO_RHO_GRID_THRESHOLD
     atom_partition = cp.zeros_like(atom_rho)
     atom_partition[:, rho0_nonzero_mask] = atom_rho[:, rho0_nonzero_mask] / rho0[rho0_nonzero_mask]
+    del rho0, rho0_nonzero_mask, atom_rho
 
     # MBIS Multipoles
 

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -89,6 +89,7 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     if dm.ndim == 3:
         assert dm.shape[0] == 2
         dm = dm[0] + dm[1]
+    assert dm.shape == (mol.nao, mol.nao)
 
     natm = natm_without_ghost(mol)
     if natm != mol.natm:
@@ -124,7 +125,7 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     grid_weights = grid_weights[rho_nonzero_mask]
     grid_w_rho = grid_weights * grid_rho
 
-    nelec = float(cp.sum(grid_weights * grid_rho))
+    nelec = float(cp.sum(grid_w_rho))
     log.info(f"Total number of electrons integrated by MBIS grid = {nelec}")
 
     atom_grid_vecrij = grid_coords[None, :, :] - atom_coords[:, None, :]
@@ -200,8 +201,6 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     if not compute_multipoles:
         return shell_populations.get(), shell_widths.get(), shell_atom_indices
 
-    # MBIS Multipoles
-
     shell_rho = _mbis_density_on_grid(atom_grid_rij, shell_atom_indices, shell_populations, shell_widths)
     atom_rho = []
     for i_atom in range(mol.natm):
@@ -213,9 +212,11 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     atom_partition = cp.zeros_like(atom_rho)
     atom_partition[:, rho0_nonzero_mask] = atom_rho[:, rho0_nonzero_mask] / rho0[rho0_nonzero_mask]
 
+    # MBIS Multipoles
+
     partitioned_w_rho = atom_partition * grid_w_rho[None, :]
     partitioned_nelec = cp.sum(partitioned_w_rho, axis = 1)
-    charges = atom_charges.astype(cp.float32) - partitioned_nelec
+    charges = atom_charges.astype(cp.float64) - partitioned_nelec
 
     log.info("MBIS Charge (a.u.)")
     for i_atom in range(mol.natm):

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -243,13 +243,14 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     octupoles = -cp.einsum("Ag,Agx,Agy,Agz->Axyz", partitioned_w_rho, atom_grid_vecrij, atom_grid_vecrij, atom_grid_vecrij)
 
     log.info("MBIS Octupole xxx yyy zzz xxy xxz xyy xyz xzz yyz yzz (a.u.)")
+    octupole_xyz_term = octupoles[i_atom, 0, 1, 2] + octupoles[i_atom, 0, 2, 1] + octupoles[i_atom, 1, 0, 2] \
+                        + octupoles[i_atom, 1, 2, 0] + octupoles[i_atom, 2, 0, 1] + octupoles[i_atom, 2, 1, 0] # Just to make linter happy
     for i_atom in range(mol.natm):
         log.info(f"{mol.elements[i_atom]:2s}  {octupoles[i_atom, 0, 0, 0]:13.8f}  {octupoles[i_atom, 1, 1, 1]:13.8f}  {octupoles[i_atom, 2, 2, 2]:13.8f}  "
                  f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 1] + octupoles[i_atom, 0, 1, 0] + octupoles[i_atom, 1, 0, 0]):13.8f}  "
                  f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 2] + octupoles[i_atom, 0, 2, 0] + octupoles[i_atom, 2, 0, 0]):13.8f}  "
                  f"{1.0/3.0 * (octupoles[i_atom, 0, 1, 1] + octupoles[i_atom, 1, 0, 1] + octupoles[i_atom, 1, 1, 0]):13.8f}  "
-                 f"{1.0/6.0 * (octupoles[i_atom, 0, 1, 2] + octupoles[i_atom, 0, 2, 1] + octupoles[i_atom, 1, 0, 2] + octupoles[i_atom, 1, 2, 0]
-                               + octupoles[i_atom, 2, 0, 1] + octupoles[i_atom, 2, 1, 0]):13.8f}  "
+                 f"{1.0/6.0 * octupole_xyz_term:13.8f}  "
                  f"{1.0/3.0 * (octupoles[i_atom, 0, 2, 2] + octupoles[i_atom, 2, 0, 2] + octupoles[i_atom, 2, 2, 0]):13.8f}  "
                  f"{1.0/3.0 * (octupoles[i_atom, 1, 1, 2] + octupoles[i_atom, 1, 2, 1] + octupoles[i_atom, 2, 1, 1]):13.8f}  "
                  f"{1.0/3.0 * (octupoles[i_atom, 1, 2, 2] + octupoles[i_atom, 2, 1, 2] + octupoles[i_atom, 2, 2, 1]):13.8f}  "

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -1,0 +1,235 @@
+
+import cupy as cp
+import numpy as np
+
+from gpu4pyscf.lib import logger
+from gpu4pyscf.dft.numint import NumInt
+from gpu4pyscf.solvent.pcm import natm_without_ghost
+
+MBIS_REMOVE_ZERO_RHO_GRID_THRESHOLD = 1e-10
+
+def _period_of_element(Z):
+    for period, upper in enumerate((2, 10, 18, 36, 54, 86, 118), start = 1):
+        if Z <= upper:
+            return period
+    raise ValueError(f"Z = {Z} not supported by _period_of_element()")
+
+def _neutral_atom_shell_populations(Z):
+    orbital_occupations = (
+        (1, 2),
+        (2, 2),
+        (2, 6),
+        (3, 2),
+        (3, 6),
+        (4, 2),
+        (3, 10),
+        (4, 6),
+        (5, 2),
+        (4, 10),
+        (5, 6),
+        (6, 2),
+        (4, 14),
+        (5, 10),
+        (6, 6),
+        (7, 2),
+        (5, 14),
+        (6, 10),
+        (7, 6),
+    )
+    n_shell = _period_of_element(Z)
+    population_of_shell = np.zeros(n_shell)
+    remaining = Z
+    for principal_n, capacity in orbital_occupations:
+        occupation = min(remaining, capacity)
+        population_of_shell[principal_n - 1] += occupation
+        remaining -= occupation
+        if remaining == 0:
+            break
+    assert remaining == 0, f"Z = {Z} not supported by _neutral_atom_shell_populations()"
+    return population_of_shell
+
+def _initial_width(Z):
+    n_shell = _period_of_element(Z)
+    if n_shell == 1:
+        return np.array([0.5 / Z])
+    i_shell = np.arange(n_shell, dtype=float)
+    Z_exponent = 1.0 - i_shell / (n_shell - 1)
+    return 0.5 / np.power(float(Z), Z_exponent) # Eq between 19 and 20, \sigma_{Ai} = a_0 / 2 Z_A^{1 - (i-1)/(m_A-1)}
+
+def _mbis_density_on_grid(atom_grid_rij, shell_atom_indices, populations, widths):
+    shell_grid_rij = atom_grid_rij[shell_atom_indices]
+    prefactors = populations / (8.0 * np.pi * widths**3)
+    return prefactors[:, None] * cp.exp(-shell_grid_rij / widths[:, None]) # Eq 7
+
+def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, compute_multipoles = True):
+    """
+        Implementation follows:
+        Verstraelen, T., Vandenbrande, S., Heidar-Zadeh, F., Vanduyfhuys, L., Van Speybroeck, V., Waroquier, M., & Ayers, P. W. (2016).
+        Minimal basis iterative stockholder: atoms in molecules for force-field development.
+        Journal of Chemical Theory and Computation, 12(8), 3894-3912.
+    """
+    assert 0.0 <= damping and damping <= 1.0
+
+    log = logger.new_logger(mol)
+
+    dm = cp.asarray(dm)
+    if dm.ndim == 3:
+        assert dm.shape[0] == 2
+        dm = dm[0] + dm[1]
+
+    natm = natm_without_ghost(mol)
+    if natm != mol.natm:
+        raise NotImplementedError("Ghost atoms are not supported in MBIS yet")
+    if len(mol._ecpbas) > 0:
+        raise NotImplementedError("ECP is not supported in MBIS yet")
+    if mol.pseudo:
+        raise NotImplementedError("GTH pseudopotential is not supported in MBIS yet")
+
+    atom_coords = cp.asarray(mol.atom_coords())
+    atom_charges = cp.asarray(mol.atom_charges(), dtype = cp.int32)
+    assert cp.all(atom_charges > 0)
+
+    if grids.coords is None:
+        grids.build()
+
+    grid_coords = cp.asarray(grids.coords)
+    grid_weights = cp.asarray(grids.weights)
+    ni = NumInt()
+    grid_rho = ni.get_rho(mol, dm, grids)
+
+    rho_nonzero_mask = cp.logical_and(
+        grid_rho >= MBIS_REMOVE_ZERO_RHO_GRID_THRESHOLD,
+        cp.abs(grid_weights) > 1e-14,
+    )
+
+    grid_rho = grid_rho[rho_nonzero_mask]
+    grid_coords = cp.ascontiguousarray(grid_coords[rho_nonzero_mask, :])
+    grid_weights = grid_weights[rho_nonzero_mask]
+    grid_w_rho = grid_weights * grid_rho
+
+    nelec = float(cp.sum(grid_weights * grid_rho))
+    log.info(f"Total number of electrons integrated by MBIS grid = {nelec}")
+
+    atom_grid_vecrij = grid_coords[None, :, :] - atom_coords[:, None, :]
+    atom_grid_rij = cp.linalg.norm(atom_grid_vecrij, axis=2)
+
+    shell_populations = []
+    shell_widths = []
+    shell_atom_indices = []
+    atom_shell_offsets = []
+    n_shell_offset = 0
+    for i_atom in range(mol.natm):
+        Z = int(atom_charges[i_atom])
+        shell_population = _neutral_atom_shell_populations(Z)
+        shell_populations.append(shell_population)
+        shell_width = _initial_width(Z)
+        shell_widths.append(shell_width)
+        n_shell_of_atom = shell_population.shape[0]
+        shell_atom_indices.extend([i_atom] * n_shell_of_atom)
+        atom_shell_offsets.append(n_shell_offset)
+        n_shell_offset += n_shell_of_atom
+    atom_shell_offsets.append(n_shell_offset)
+    shell_populations = cp.asarray(np.concatenate(shell_populations))
+    shell_widths = cp.asarray(np.concatenate(shell_widths))
+    shell_atom_indices = np.asarray(shell_atom_indices, dtype = np.int32)
+
+    converged = False
+    for i_cycle in range(max_cycle):
+        old_shell_rho = _mbis_density_on_grid(atom_grid_rij, shell_atom_indices, shell_populations, shell_widths)
+        old_rho0 = cp.sum(old_shell_rho, axis = 0)
+
+        rho0_nonzero_mask = old_rho0 >= MBIS_REMOVE_ZERO_RHO_GRID_THRESHOLD
+        integration_prefactor = cp.zeros_like(grid_rho)
+        integration_prefactor[rho0_nonzero_mask] = grid_w_rho[rho0_nonzero_mask] / old_rho0[rho0_nonzero_mask] # w (from integration) * rho / rho0 in Eq 18,19
+        del old_rho0
+        target_shell_populations = old_shell_rho @ integration_prefactor # Eq 18
+        target_shell_widths = (old_shell_rho * atom_grid_rij[shell_atom_indices]) @ integration_prefactor
+        target_shell_widths /= 3.0 * target_shell_populations # Eq 19
+        del integration_prefactor
+
+        assert cp.all(target_shell_populations >= 0.0)
+
+        new_shell_populations = damping * shell_populations + (1.0 - damping) * target_shell_populations
+        new_shell_widths = damping * shell_widths + (1.0 - damping) * target_shell_widths
+
+        new_shell_rho = _mbis_density_on_grid(atom_grid_rij, shell_atom_indices, new_shell_populations, new_shell_widths)
+        max_delta_rhoA0 = 0
+        for i_atom in range(mol.natm):
+            s0, s1 = atom_shell_offsets[i_atom], atom_shell_offsets[i_atom + 1]
+            old_rhoA0 = cp.sum(old_shell_rho[s0:s1, :], axis = 0)
+            new_rhoA0 = cp.sum(new_shell_rho[s0:s1, :], axis = 0)
+            delta_rhoA0 = cp.sum(grid_weights * (new_rhoA0 - old_rhoA0)**2) # Eq 20
+            max_delta_rhoA0 = max(max_delta_rhoA0, float(delta_rhoA0))
+        max_delta_rhoA0 = float(np.sqrt(max_delta_rhoA0))
+        del old_shell_rho, new_shell_rho
+        log.info(f"MBIS i_cycle = {i_cycle:4d} max_delta_rhoA0 = {max_delta_rhoA0:.6e}")
+
+        shell_populations = new_shell_populations
+        shell_widths = new_shell_widths
+        if max_delta_rhoA0 < conv_tol:
+            converged = True
+            break
+
+    assert converged, f"MBIS not converged in {max_cycle} iterations; last max_delta_rhoA0 = {max_delta_rhoA0:.3e} > conv_tol = {conv_tol:.3e}"
+    log.info(f"MBIS converged!")
+
+    n_shell = shell_atom_indices.shape[0]
+    for i_shell in range(n_shell):
+        log.info(f"MBIS shell {i_shell} from atom {shell_atom_indices[i_shell]} has population = {shell_populations[i_shell]} and width = {shell_widths[i_shell]}")
+
+    if not compute_multipoles:
+        return shell_populations.get(), shell_widths.get(), shell_atom_indices
+
+    # MBIS Multipoles
+
+    shell_rho = _mbis_density_on_grid(atom_grid_rij, shell_atom_indices, shell_populations, shell_widths)
+    atom_rho = []
+    for i_atom in range(mol.natm):
+        s0, s1 = atom_shell_offsets[i_atom], atom_shell_offsets[i_atom + 1]
+        atom_rho.append(cp.sum(shell_rho[s0:s1, :], axis = 0))
+    atom_rho = cp.vstack(atom_rho)
+    rho0 = cp.sum(atom_rho, axis = 0)
+    rho0_nonzero_mask = rho0 >= MBIS_REMOVE_ZERO_RHO_GRID_THRESHOLD
+    atom_partition = cp.zeros_like(atom_rho)
+    atom_partition[:, rho0_nonzero_mask] = atom_rho[:, rho0_nonzero_mask] / rho0[rho0_nonzero_mask]
+
+    partitioned_w_rho = atom_partition * grid_w_rho[None, :]
+    partitioned_nelec = cp.sum(partitioned_w_rho, axis = 1)
+    charges = atom_charges.astype(cp.float32) - partitioned_nelec
+
+    log.info("MBIS Charge (a.u.)")
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {charges[i_atom]:13.8f}")
+
+    dipoles = -cp.einsum("Ag,Agx->Ax", partitioned_w_rho, atom_grid_vecrij)
+
+    log.info("MBIS Dipole x y z (a.u.)")
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {dipoles[i_atom, 0]:13.8f}  {dipoles[i_atom, 1]:13.8f}  {dipoles[i_atom, 2]:13.8f}")
+
+    # ORCA did not remove trace, and we follow them
+    quadrupoles = -cp.einsum("Ag,Agx,Agy->Axy", partitioned_w_rho, atom_grid_vecrij, atom_grid_vecrij)
+
+    log.info("MBIS Quadrupole xx yy zz xy xz yz (a.u.)")
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {quadrupoles[i_atom, 0, 0]:13.8f}  {quadrupoles[i_atom, 1, 1]:13.8f}  {quadrupoles[i_atom, 2, 2]:13.8f}  "\
+                 f"{0.5 * (quadrupoles[i_atom, 0, 1] + quadrupoles[i_atom, 1, 0]):13.8f}  "\
+                 f"{0.5 * (quadrupoles[i_atom, 0, 2] + quadrupoles[i_atom, 2, 0]):13.8f}  "\
+                 f"{0.5 * (quadrupoles[i_atom, 1, 2] + quadrupoles[i_atom, 2, 1]):13.8f}")
+
+    # ORCA did not remove trace, and we follow them
+    octupoles = -cp.einsum("Ag,Agx,Agy,Agz->Axyz", partitioned_w_rho, atom_grid_vecrij, atom_grid_vecrij, atom_grid_vecrij)
+
+    log.info("MBIS Octupole xxx yyy zzz xxy xxz xyy xyz xzz yyz yzz (a.u.)")
+    for i_atom in range(mol.natm):
+        log.info(f"{mol.elements[i_atom]:2s}  {octupoles[i_atom, 0, 0, 0]:13.8f}  {octupoles[i_atom, 1, 1, 1]:13.8f}  {octupoles[i_atom, 2, 2, 2]:13.8f}  "\
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 1] + octupoles[i_atom, 0, 1, 0] + octupoles[i_atom, 1, 0, 0]):13.8f}  "\
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 0, 2] + octupoles[i_atom, 0, 2, 0] + octupoles[i_atom, 2, 0, 0]):13.8f}  "\
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 1, 1] + octupoles[i_atom, 1, 0, 1] + octupoles[i_atom, 1, 1, 0]):13.8f}  "\
+                 f"{1.0/6.0 * (octupoles[i_atom, 0, 1, 2] + octupoles[i_atom, 0, 2, 1] + octupoles[i_atom, 1, 0, 2] + octupoles[i_atom, 1, 2, 0] + octupoles[i_atom, 2, 0, 1] + octupoles[i_atom, 2, 1, 0]):13.8f}  "\
+                 f"{1.0/3.0 * (octupoles[i_atom, 0, 2, 2] + octupoles[i_atom, 2, 0, 2] + octupoles[i_atom, 2, 2, 0]):13.8f}  "\
+                 f"{1.0/3.0 * (octupoles[i_atom, 1, 1, 2] + octupoles[i_atom, 1, 2, 1] + octupoles[i_atom, 2, 1, 1]):13.8f}  "\
+                 f"{1.0/3.0 * (octupoles[i_atom, 1, 2, 2] + octupoles[i_atom, 2, 1, 2] + octupoles[i_atom, 2, 2, 1]):13.8f}  "\
+                 f"")
+
+    return charges.get(), dipoles.get(), quadrupoles.get(), octupoles.get()

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -99,8 +99,8 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
         raise NotImplementedError("GTH pseudopotential is not supported in MBIS yet")
 
     if mol.charge < 0:
-        log.warning("MBIS does not handle negative charge well, particularly when the negative charge is diffuse. "
-                    "If you see a shell with huge width on one atom, it is likely due to the diffused charge got fitted onto that random atom.")
+        log.warn("MBIS does not handle negative charge well, particularly when the negative charge is diffuse. "
+                 "If you see a shell with huge width on one atom, it is likely due to the diffused charge got fitted onto that random atom.")
 
     atom_coords = cp.asarray(mol.atom_coords())
     atom_charges = cp.asarray(mol.atom_charges(), dtype = cp.int32)

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -1,3 +1,16 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import cupy as cp
 import numpy as np
@@ -116,6 +129,7 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
 
     atom_grid_vecrij = grid_coords[None, :, :] - atom_coords[:, None, :]
     atom_grid_rij = cp.linalg.norm(atom_grid_vecrij, axis=2)
+    del atom_grid_vecrij
 
     shell_populations = []
     shell_widths = []
@@ -145,7 +159,7 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
         rho0_nonzero_mask = old_rho0 >= MBIS_REMOVE_ZERO_RHO_GRID_THRESHOLD
         integration_prefactor = cp.zeros_like(grid_rho)
         integration_prefactor[rho0_nonzero_mask] = grid_w_rho[rho0_nonzero_mask] / old_rho0[rho0_nonzero_mask] # w (from integration) * rho / rho0 in Eq 18,19
-        del old_rho0
+        del old_rho0, rho0_nonzero_mask
         target_shell_populations = old_shell_rho @ integration_prefactor # Eq 18
         target_shell_widths = (old_shell_rho * atom_grid_rij[shell_atom_indices]) @ integration_prefactor
         target_shell_widths /= 3.0 * target_shell_populations # Eq 19
@@ -164,6 +178,7 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
             new_rhoA0 = cp.sum(new_shell_rho[s0:s1, :], axis = 0)
             delta_rhoA0 = cp.sum(grid_weights * (new_rhoA0 - old_rhoA0)**2) # Eq 20
             max_delta_rhoA0 = max(max_delta_rhoA0, float(delta_rhoA0))
+            del old_rhoA0, new_rhoA0
         max_delta_rhoA0 = float(np.sqrt(max_delta_rhoA0))
         del old_shell_rho, new_shell_rho
         log.info(f"MBIS i_cycle = {i_cycle:4d} max_delta_rhoA0 = {max_delta_rhoA0:.6e}")
@@ -204,6 +219,8 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     log.info("MBIS Charge (a.u.)")
     for i_atom in range(mol.natm):
         log.info(f"{mol.elements[i_atom]:2s}  {charges[i_atom]:13.8f}")
+
+    atom_grid_vecrij = grid_coords[None, :, :] - atom_coords[:, None, :]
 
     dipoles = -cp.einsum("Ag,Agx->Ax", partitioned_w_rho, atom_grid_vecrij)
 

--- a/gpu4pyscf/qmmm/mbis.py
+++ b/gpu4pyscf/qmmm/mbis.py
@@ -85,6 +85,10 @@ def mbis(mol, grids, dm, conv_tol = 1e-8, max_cycle = 500, damping = 0.1, comput
     if mol.pseudo:
         raise NotImplementedError("GTH pseudopotential is not supported in MBIS yet")
 
+    if mol.charge < 0:
+        log.warning("MBIS does not handle negative charge well, particularly when the negative charge is diffuse. If you see a shell with huge width on one atom, "\
+                    "it is likely due to the diffused charge got fitted onto that random atom.")
+
     atom_coords = cp.asarray(mol.atom_coords())
     atom_charges = cp.asarray(mol.atom_charges(), dtype = cp.int32)
     assert cp.all(atom_charges > 0)

--- a/gpu4pyscf/qmmm/tests/test_hirshfeld.py
+++ b/gpu4pyscf/qmmm/tests/test_hirshfeld.py
@@ -1,0 +1,285 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import cupy as cp
+import pyscf
+import gpu4pyscf
+from gpu4pyscf.scf.hf  import RHF
+from gpu4pyscf.scf.uhf import UHF
+from gpu4pyscf.dft.rks import RKS
+from gpu4pyscf.dft.uks import UKS
+from gpu4pyscf.dft.gen_grid import Grids
+from gpu4pyscf.qmmm.hirshfeld import hirshfeld, hirshfeld_kernel
+
+class KnownValues(unittest.TestCase):
+    def test_hirshfeld_neutral_rhf(self):
+        mol = pyscf.M(
+            atom = """
+                O  0.0000  0.7375 -0.0528
+                Ar 3.0 0.0 0.0
+                O  0.0000 -0.7375 -0.1528
+                H  0.8190  0.8170  0.4220
+                H -0.8190 -0.8170  1.4220
+                Kr 10.0 0.0 0.1
+            """,
+            basis = "def2-svp",
+            verbose = 0,
+        )
+        mf = RHF(mol).density_fit(auxbasis = "def2-universal-jkfit")
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = Grids(mol)
+        grids.atom_grid = (99,590)
+
+        test_charges, test_dipoles, test_quadrupoles, test_octupoles = hirshfeld(mol, grids, dm, xc = "HF", auxbasis = "def2-universal-jkfit")
+
+        ### Reference Q-Chem input
+        # $rem
+        # JOBTYPE force
+        # BASIS def2-svp
+        # METHOD HF
+        # XC_GRID       000099000590
+        # NL_GRID       000050000194
+        # SYMMETRY      FALSE
+        # SYM_IGNORE    TRUE
+        # MAX_SCF_CYCLES 100
+        # PURECART 1111
+        # SCF_CONVERGENCE 10
+        # THRESH        14
+        # ri_j        True
+        # ri_k        True
+        # aux_basis RIJK-def2-TZVP
+        # HIRSHFELD True
+        # HIRSHITER False
+        # $end
+        ref_energy = -3428.7481489134
+        ref_charges = np.array([ -0.197481,  0.046375, -0.172539,  0.128914,  0.194641,  0.000029, ])
+
+        assert abs(test_energy - ref_energy) < 3e-9
+        assert np.max(np.abs(test_charges - ref_charges)) < 2e-4
+
+    def test_hirshfeld_charged_uhf(self):
+        mol = pyscf.M(
+            atom = """
+                F -1.2 0.0 0.0
+                Li 0 0 0
+                F  1.2 0.0 0.0
+            """,
+            basis = {"Li" : "sto-6g", "F" : "def2-qzvp"},
+            charge = -1,
+            verbose = 0,
+        )
+        mf = UHF(mol).density_fit(auxbasis = "def2-universal-jkfit")
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = Grids(mol)
+        grids.atom_grid = (99,590)
+        grids.radi_method = gpu4pyscf.dft.radi.euler_macLaurin
+        grids.prune = None
+        grids.radii_adjust = None
+
+        test_charges, test_dipoles, test_quadrupoles, test_octupoles = hirshfeld(mol, grids, dm, xc = "HF", auxbasis = "def2-universal-jkfit")
+
+        ### Reference Q-Chem input
+        # $rem
+        # JOBTYPE force
+        # BASIS gen
+        # METHOD HF
+        # XC_GRID       000099000590
+        # NL_GRID       000050000194
+        # SYMMETRY      FALSE
+        # SYM_IGNORE    TRUE
+        # MAX_SCF_CYCLES 100
+        # PURECART 1111
+        # SCF_CONVERGENCE 10
+        # THRESH        14
+        # ri_j        True
+        # ri_k        True
+        # aux_basis RIJK-def2-TZVP
+        # HIRSHFELD True
+        # HIRSHITER False
+        # $end
+
+        # $basis
+        # Li     0
+        # S   6   1.00
+        #       0.1671758462D+03       0.9163596281D-02
+        #       0.3065150840D+02       0.4936149294D-01
+        #       0.8575187477D+01       0.1685383049D+00
+        #       0.2945808337D+01       0.3705627997D+00
+        #       0.1143943581D+01       0.4164915298D+00
+        #       0.4711391391D+00       0.1303340841D+00
+        # SP   6   1.00
+        #       0.6597563981D+01      -0.1325278809D-01       0.3759696623D-02
+        #       0.1305830092D+01      -0.4699171014D-01       0.3767936984D-01
+        #       0.4058510193D+00      -0.3378537151D-01       0.1738967435D+00
+        #       0.1561455158D+00       0.2502417861D+00       0.4180364347D+00
+        #       0.6781410394D-01       0.5951172526D+00       0.4258595477D+00
+        #       0.3108416550D-01       0.2407061763D+00       0.1017082955D+00
+        # ****
+        # F     0
+        # S   8   1.00
+        #  132535.9734500              0.47387482743D-04
+        #   19758.1125880              0.37070120897D-03
+        #    4485.1996947              0.19450784713D-02
+        #    1273.8151020              0.80573291994D-02
+        #     418.93831236             0.27992880781D-01
+        #     152.55721985             0.82735120175D-01
+        #      59.821524823            0.19854169012
+        #      24.819076932            0.34860632233
+        # S   2   1.00
+        #     100.74446673             0.10505068816
+        #      30.103728290            0.94068472434
+        # S   1   1.00
+        #      10.814283272            1.0000000
+        # S   1   1.00
+        #       4.8172886770           1.0000000
+        # S   1   1.00
+        #       1.6559334213           1.0000000
+        # S   1   1.00
+        #       0.64893519582          1.0000000
+        # S   1   1.00
+        #       0.24778104545          1.0000000
+        # P   5   1.00
+        #     240.96654114             0.30389933451D-02
+        #      57.020699781            0.24357738582D-01
+        #      18.126952120            0.11442925768
+        #       6.6457404621           0.37064659853
+        #       2.6375722892           0.79791551766
+        # P   1   1.00
+        #       1.0638217200           1.0000000
+        # P   1   1.00
+        #       0.41932562750          1.0000000
+        # P   1   1.00
+        #       0.15747588299          1.0000000
+        # D   1   1.00
+        #       5.01400000             1.0000000
+        # D   1   1.00
+        #       1.72500000             1.0000000
+        # D   1   1.00
+        #       0.58600000             1.0000000
+        # F   1   1.00
+        #       3.56200000             1.0000000
+        # F   1   1.00
+        #       1.14800000             1.0000000
+        # G   1   1.00
+        #       2.37600000             1.0000000
+        # ****
+        # $end
+        ref_energy = -206.3071084879
+        ref_charges = np.array([ -0.598679,  0.197359, -0.598679, ])
+
+        assert abs(test_energy - ref_energy) < 3e-9
+        assert np.max(np.abs(test_charges - ref_charges)) < 1e-5
+
+    def test_hirshfeld_neutral_rks(self):
+        mol = pyscf.M(
+            atom = """
+                C      0.000000    0.000000    0.000000
+                H      0.629312    0.629312    0.629312
+                F     -0.768949   -0.768949    0.768949
+                Cl    -1.022775    1.022775   -1.022775
+                Br     1.115470   -1.115470   -1.115470
+            """,
+            basis = "def2-svp",
+            verbose = 0,
+        )
+        mf = RKS(mol, xc = "wB97MV").density_fit(auxbasis = "def2-universal-jkfit")
+        mf.grids.atom_grid = (99, 590)
+        mf.nlcgrids.atom_grid = (50, 194)
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = mf.grids
+
+        def _make_mf(mol):
+            mf = UKS(mol, xc = "wB97MV").density_fit(auxbasis = "def2-universal-jkfit")
+            mf.grids.atom_grid = (99, 590)
+            mf.nlcgrids.atom_grid = (50, 194)
+            mf.conv_tol = 1e-10
+            return mf
+
+        test_charges, test_dipoles, test_quadrupoles, test_octupoles = hirshfeld_kernel(mol, grids, dm, make_mf = _make_mf)
+
+        ref_energy = -3172.1209095366
+        ref_charges = np.array([  0.145544,  0.054114, -0.084534, -0.054412, -0.060709, ])
+
+        assert abs(test_energy - ref_energy) < 1e-5
+        assert np.max(np.abs(test_charges - ref_charges)) < 1e-4
+
+
+    def test_hirshfeld_charged_ecp(self):
+        mol = pyscf.M(
+            atom = """
+                I -2.0 0.0 0.0
+                H 0 0 0
+                I  2.0 0.1 0.0
+            """,
+            basis = "def2-svp",
+            ecp = "def2-svp",
+            charge = -1,
+            verbose = 4,
+        )
+        mf = UKS(mol, xc = "wB97X").density_fit(auxbasis = "def2-universal-jkfit")
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = Grids(mol)
+        grids.atom_grid = (99,590)
+
+        test_charges, test_dipoles, test_quadrupoles, test_octupoles = hirshfeld(mol, grids, dm, xc = "wB97X", auxbasis = "def2-universal-jkfit")
+
+        ### Reference ORCA input
+        # !wB97X def2-SVP DEFGRID3 Hirshfeld
+
+        # * xyz -1 1
+        #                 I -2.0 0.0 0.0
+        #                 H 0 0 0
+        #                 I  2.0 0.1 0.0
+        # *
+        ref_energy = -596.19707049266685
+        ### This is ORCA result. From ORCA document:
+        ### In ORCA, the pro-atomic density within the Hirshfeld method is calculated via density fitting with a set of Gaussian s-functions per element.
+        ### So it is a bit different from our result.
+        ### Q-Chem ECP + Hirshfeld doesn't work.
+        # ref_charges = np.array([ -0.529947,  0.061624, -0.531676 ])
+        ### So we just check against an old result, i.e. This is a consistency test.
+        ref_charges = np.array([ -0.51646553,  0.03472508, -0.51825951 ])
+
+        assert abs(test_energy - ref_energy) < 1e-4
+        assert np.max(np.abs(test_charges - ref_charges)) < 1e-6
+
+if __name__ == "__main__":
+    print("Full Tests for Hirshfeld multipole")
+    unittest.main()

--- a/gpu4pyscf/qmmm/tests/test_mbis.py
+++ b/gpu4pyscf/qmmm/tests/test_mbis.py
@@ -1,0 +1,379 @@
+# Copyright 2021-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import cupy as cp
+import pyscf
+from gpu4pyscf.scf.hf  import RHF
+from gpu4pyscf.scf.uhf import UHF
+from gpu4pyscf.dft.rks import RKS
+from gpu4pyscf.dft.uks import UKS
+from gpu4pyscf.dft.gen_grid import Grids
+from gpu4pyscf.qmmm.mbis import mbis
+
+class KnownValues(unittest.TestCase):
+    def test_mbis_rhf(self):
+        mol = pyscf.M(
+            atom = """
+                O  0.0000  0.7375 -0.0528
+                Ar 3.0 0.0 0.0
+                O  0.0000 -0.7375 -0.1528
+                H  0.8190  0.8170  0.4220
+                H -0.8190 -0.8170  1.4220
+                Kr 10.0 0.0 0.1
+            """,
+            basis = "def2-svp",
+            verbose = 0,
+        )
+        mf = RHF(mol).density_fit(auxbasis = "def2-universal-jkfit")
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = Grids(mol)
+        grids.atom_grid = (99,590)
+
+        test_charges, test_dipoles, test_quadrupoles, test_octupoles = mbis(mol, grids, dm)
+
+        ### Reference ORCA input
+        # ! HF DEF2-SVP TightSCF MBIS
+
+        # *XYZ 0 1
+        # O  0.0000  0.7375 -0.0528
+        # Ar 3.0 0.0 0.0
+        # O  0.0000 -0.7375 -0.1528
+        # H  0.8190  0.8170  0.4220
+        # H -0.8190 -0.8170  1.4220
+        # Kr 10.0 0.0 0.1
+        # *
+
+        # %method
+        # MBIS_LARGEPRINT TRUE
+        # end
+        ref_energy = -3428.74836336563203
+        ref_charges = np.array([ -0.434717, -0.007150, -0.269490,  0.446555,  0.264804,  0.000032, ])
+        ref_dipoles = np.array([
+            [-0.041973, -0.136388, -0.062346],
+            [ 0.089139, -0.037956, -0.033764],
+            [ 0.043744,  0.145279, -0.118807],
+            [ 0.029044, -0.001060,  0.014901],
+            [-0.040549,  0.029240,  0.075222],
+            [ 0.001148, -0.000346, -0.001124],
+        ])
+        ref_quadrupoles_orca_shape = np.array([
+            [ -4.232479,  -3.953297,  -4.297775,  0.038177,  0.061874,  0.086958],
+            [ -8.640563,  -8.468726,  -8.437907,  0.028931,  0.029546, -0.010502],
+            [ -4.374082,  -3.956366,  -4.252054, -0.031096, -0.079295,  0.010022],
+            [ -0.241443,  -0.233252,  -0.244380,  0.000400,  0.006490, -0.000383],
+            [ -0.718140,  -0.692559,  -0.722051,  0.003976,  0.003360, -0.008766],
+            [-12.973837, -12.973442, -12.973462,  0.000041,  0.000086, -0.000001],
+        ])
+        ref_quadrupoles = np.zeros((mol.natm, 3, 3))
+        ref_quadrupoles[:, 0, 0] = ref_quadrupoles_orca_shape[:, 0]
+        ref_quadrupoles[:, 1, 1] = ref_quadrupoles_orca_shape[:, 1]
+        ref_quadrupoles[:, 2, 2] = ref_quadrupoles_orca_shape[:, 2]
+        ref_quadrupoles[:, 0, 1] = ref_quadrupoles[:, 1, 0] = ref_quadrupoles_orca_shape[:, 3]
+        ref_quadrupoles[:, 0, 2] = ref_quadrupoles[:, 2, 0] = ref_quadrupoles_orca_shape[:, 4]
+        ref_quadrupoles[:, 1, 2] = ref_quadrupoles[:, 2, 1] = ref_quadrupoles_orca_shape[:, 5]
+        ref_octupoles_orca_shape = np.array([
+            [-0.226183,  0.299418, -0.201317, -0.082593, -0.168408,  0.031377, -0.007359, -0.059904, -0.050612, -0.107788],
+            [ 1.061837, -0.166123, -0.146957, -0.092879, -0.103728,  0.284886,  0.022325,  0.192540, -0.058588, -0.055291],
+            [ 0.214378, -0.255909, -0.750374,  0.134926, -0.249658,  0.035722, -0.008278,  0.172565, -0.201107,  0.170053],
+            [ 0.019067,  0.006566,  0.014910,  0.003795,  0.004336,  0.005429, -0.000371,  0.010907,  0.001581, -0.002522],
+            [-0.063466,  0.082347,  0.104127,  0.031548,  0.040824, -0.024044,  0.010057, -0.010704,  0.039112,  0.022798],
+            [ 0.005829, -0.001493, -0.005046, -0.000510, -0.001581,  0.001364,  0.000001,  0.001393, -0.001568, -0.000498],
+        ])
+        ref_octupoles = np.zeros((mol.natm, 3, 3, 3))
+        ref_octupoles[:, 0, 0, 0] = ref_octupoles_orca_shape[:, 0]
+        ref_octupoles[:, 1, 1, 1] = ref_octupoles_orca_shape[:, 1]
+        ref_octupoles[:, 2, 2, 2] = ref_octupoles_orca_shape[:, 2]
+        ref_octupoles[:, 0, 0, 1] = ref_octupoles[:, 0, 1, 0] = ref_octupoles[:, 1, 0, 0] = ref_octupoles_orca_shape[:, 3]
+        ref_octupoles[:, 0, 0, 2] = ref_octupoles[:, 0, 2, 0] = ref_octupoles[:, 2, 0, 0] = ref_octupoles_orca_shape[:, 4]
+        ref_octupoles[:, 0, 1, 1] = ref_octupoles[:, 1, 0, 1] = ref_octupoles[:, 1, 1, 0] = ref_octupoles_orca_shape[:, 5]
+        ref_octupoles[:, 0, 1, 2] = ref_octupoles[:, 0, 2, 1] = ref_octupoles[:, 1, 0, 2] = ref_octupoles[:, 1, 2, 0] = ref_octupoles[:, 2, 0, 1] = ref_octupoles[:, 2, 1, 0] = ref_octupoles_orca_shape[:, 6]
+        ref_octupoles[:, 0, 2, 2] = ref_octupoles[:, 2, 0, 2] = ref_octupoles[:, 2, 2, 0] = ref_octupoles_orca_shape[:, 7]
+        ref_octupoles[:, 1, 1, 2] = ref_octupoles[:, 1, 2, 1] = ref_octupoles[:, 2, 1, 1] = ref_octupoles_orca_shape[:, 8]
+        ref_octupoles[:, 1, 2, 2] = ref_octupoles[:, 2, 1, 2] = ref_octupoles[:, 2, 2, 1] = ref_octupoles_orca_shape[:, 9]
+
+        assert abs(test_energy - ref_energy) < 3e-3
+        assert np.max(np.abs(test_charges - ref_charges)) < 1e-4
+        assert np.max(np.abs(test_dipoles - ref_dipoles)) < 1e-4
+        assert np.max(np.abs(test_quadrupoles - ref_quadrupoles)) < 3e-4
+        assert np.max(np.abs(test_octupoles - ref_octupoles)) < 5e-4
+
+    def test_mbis_uhf(self):
+        mol = pyscf.M(
+            atom = """
+                C      0.751600   -0.022500   -0.020900
+                H      1.114611    1.036945   -0.070252
+                H      1.425195   -0.765480   -0.086513
+                C     -0.751600    0.022500    0.020900
+                H     -1.166900   -0.833400    0.568700
+                H     -1.115700    0.932600    0.515100
+                H     -1.185000    0.004400   -0.987500
+            """,
+            basis = "def2-svp",
+            charge = 0,
+            spin = 1,
+            verbose = 0,
+        )
+        mf = UHF(mol).density_fit(auxbasis = "def2-universal-jkfit")
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = Grids(mol)
+        grids.atom_grid = (99,590)
+
+        test_charges, test_dipoles, test_quadrupoles, test_octupoles = mbis(mol, grids, dm)
+
+        ### Reference ORCA input
+        # ! UHF DEF2-SVP TightSCF MBIS
+
+        # *XYZ 0 2
+        # C      0.751600   -0.022500   -0.020900
+        # H      1.114611    1.036945   -0.070252
+        # H      1.425195   -0.765480   -0.086513
+        # C     -0.751600    0.022500    0.020900
+        # H     -1.166900   -0.833400    0.568700
+        # H     -1.115700    0.932600    0.515100
+        # H     -1.185000    0.004400   -0.987500
+        # *
+
+        # %method
+        # MBIS_LARGEPRINT TRUE
+        # end
+        ref_energy = -78.53051246228665
+        ref_charges = np.array([ -0.205005,  0.072520,  0.117649, -0.268727,  0.088103,  0.101233,  0.094227, ])
+        ref_dipoles = np.array([
+            [-0.078226, -0.039803, -0.004656],
+            [-0.001643,  0.074782, -0.002074],
+            [ 0.049522, -0.047391, -0.004075],
+            [ 0.065578, -0.002901, -0.005529],
+            [-0.011259, -0.048658,  0.030992],
+            [-0.012812,  0.050277,  0.026834],
+            [-0.014467, -0.001207, -0.056023],
+        ])
+        ref_quadrupoles_orca_shape = np.array([
+            [-4.824590, -4.679704, -4.600241, -0.002897,  0.006717,  0.000808],
+            [-0.564636, -0.569426, -0.590391, -0.008137,  0.000058,  0.001029],
+            [-0.459656, -0.471293, -0.492972, -0.001660, -0.001425, -0.000196],
+            [-4.888772, -4.741776, -4.770745, -0.011820, -0.001720, -0.000645],
+            [-0.532825, -0.543627, -0.542792, -0.006815,  0.001946,  0.002455],
+            [-0.514160, -0.527752, -0.526260,  0.004737,  0.001844, -0.001993],
+            [-0.530109, -0.536188, -0.541702, -0.001059, -0.005993,  0.000292],
+        ])
+        ref_quadrupoles = np.zeros((mol.natm, 3, 3))
+        ref_quadrupoles[:, 0, 0] = ref_quadrupoles_orca_shape[:, 0]
+        ref_quadrupoles[:, 1, 1] = ref_quadrupoles_orca_shape[:, 1]
+        ref_quadrupoles[:, 2, 2] = ref_quadrupoles_orca_shape[:, 2]
+        ref_quadrupoles[:, 0, 1] = ref_quadrupoles[:, 1, 0] = ref_quadrupoles_orca_shape[:, 3]
+        ref_quadrupoles[:, 0, 2] = ref_quadrupoles[:, 2, 0] = ref_quadrupoles_orca_shape[:, 4]
+        ref_quadrupoles[:, 1, 2] = ref_quadrupoles[:, 2, 1] = ref_quadrupoles_orca_shape[:, 5]
+        ref_octupoles_orca_shape = np.array([
+            [ 0.355595, -0.305559, -0.013791, -0.077817, -0.032610, -0.305003, -0.003629, -0.216232, -0.025838, -0.070222],
+            [-0.018827,  0.079790, -0.002129,  0.031058, -0.004883, -0.016412,  0.001083, -0.020223,  0.000245,  0.032523],
+            [ 0.052193, -0.062686, -0.006471, -0.014600, -0.001437,  0.007842, -0.000686,  0.017698, -0.000361, -0.022211],
+            [-0.399013, -0.096826,  0.161903,  0.013851,  0.019154,  0.296749, -0.004111,  0.271843, -0.219002,  0.002636],
+            [-0.000016, -0.049306,  0.034932, -0.015585,  0.008427,  0.011259,  0.002490,  0.013881,  0.001783, -0.016186],
+            [-0.008240,  0.047928,  0.029822,  0.015545,  0.006893,  0.008478, -0.001930,  0.011187,  0.000798,  0.017043],
+            [-0.008763, -0.002825, -0.047771,  0.001349, -0.014213,  0.013746, -0.000768,  0.007682, -0.025727,  0.000224],
+        ])
+        ref_octupoles = np.zeros((mol.natm, 3, 3, 3))
+        ref_octupoles[:, 0, 0, 0] = ref_octupoles_orca_shape[:, 0]
+        ref_octupoles[:, 1, 1, 1] = ref_octupoles_orca_shape[:, 1]
+        ref_octupoles[:, 2, 2, 2] = ref_octupoles_orca_shape[:, 2]
+        ref_octupoles[:, 0, 0, 1] = ref_octupoles[:, 0, 1, 0] = ref_octupoles[:, 1, 0, 0] = ref_octupoles_orca_shape[:, 3]
+        ref_octupoles[:, 0, 0, 2] = ref_octupoles[:, 0, 2, 0] = ref_octupoles[:, 2, 0, 0] = ref_octupoles_orca_shape[:, 4]
+        ref_octupoles[:, 0, 1, 1] = ref_octupoles[:, 1, 0, 1] = ref_octupoles[:, 1, 1, 0] = ref_octupoles_orca_shape[:, 5]
+        ref_octupoles[:, 0, 1, 2] = ref_octupoles[:, 0, 2, 1] = ref_octupoles[:, 1, 0, 2] = ref_octupoles[:, 1, 2, 0] = ref_octupoles[:, 2, 0, 1] = ref_octupoles[:, 2, 1, 0] = ref_octupoles_orca_shape[:, 6]
+        ref_octupoles[:, 0, 2, 2] = ref_octupoles[:, 2, 0, 2] = ref_octupoles[:, 2, 2, 0] = ref_octupoles_orca_shape[:, 7]
+        ref_octupoles[:, 1, 1, 2] = ref_octupoles[:, 1, 2, 1] = ref_octupoles[:, 2, 1, 1] = ref_octupoles_orca_shape[:, 8]
+        ref_octupoles[:, 1, 2, 2] = ref_octupoles[:, 2, 1, 2] = ref_octupoles[:, 2, 2, 1] = ref_octupoles_orca_shape[:, 9]
+
+        assert abs(test_energy - ref_energy) < 2e-5
+        assert np.max(np.abs(test_charges - ref_charges)) < 5e-5
+        assert np.max(np.abs(test_dipoles - ref_dipoles)) < 5e-5
+        assert np.max(np.abs(test_quadrupoles - ref_quadrupoles)) < 2e-4
+        assert np.max(np.abs(test_octupoles - ref_octupoles)) < 5e-4
+
+    def test_mbis_rks(self):
+        mol = pyscf.M(
+            atom = """
+                C      0.000000    0.000000    0.000000
+                H      0.629312    0.629312    0.629312
+                F     -0.768949   -0.768949    0.768949
+                Cl    -1.022775    1.022775   -1.022775
+                Br     1.115470   -1.115470   -1.115470
+            """,
+            basis = "def2-svp",
+            ecp = "def2-svp",
+            verbose = 0,
+        )
+        mf = RKS(mol, xc = "PBE").density_fit(auxbasis = "def2-universal-jkfit")
+        mf.grids.atom_grid = (99, 590)
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = mf.grids
+
+        test_shell_populations, test_shell_widths, test_shell_atom_indices = mbis(mol, grids, dm, compute_multipoles = False)
+
+        ### Reference ORCA input
+        # ! PBE def2-svp TightSCF DEFGRID3 MBIS
+
+        # *XYZ 0 1
+        # C      0.000000    0.000000    0.000000
+        # H      0.629312    0.629312    0.629312
+        # F     -0.768949   -0.768949    0.768949
+        # Cl    -1.022775    1.022775   -1.022775
+        # Br     1.115470   -1.115470   -1.115470
+        # *
+
+        # %method
+        # MBIS_LARGEPRINT TRUE
+        # end
+        ref_energy = -3171.61135289084723
+        ref_shell_atom_indices = np.array([0,0, 1, 2,2, 3,3,3, 4,4,4,4], dtype = np.int32)
+        ref_valence_shell_populations = np.array([ 4.091516, 0.870251, 7.544253, 8.586013, 9.661445, ])
+        ref_valence_shell_widths = np.array([ 0.501597, 0.371141, 0.337167, 0.518189, 0.551814, ])
+        valence_shell_indices = len(ref_shell_atom_indices) - 1 - np.unique(ref_shell_atom_indices[::-1], return_index = True)[1]
+
+        assert abs(test_energy - ref_energy) < 5e-4
+        assert np.all(test_shell_atom_indices == ref_shell_atom_indices)
+        assert np.max(np.abs(test_shell_populations[valence_shell_indices] - ref_valence_shell_populations)) < 5e-4
+        assert np.max(np.abs(test_shell_widths[valence_shell_indices] - ref_valence_shell_widths)) < 3e-5
+
+    def test_mbis_uks(self):
+        mol = pyscf.M(
+            atom = """
+                H      1.8853     -0.0401      1.0854
+                C      1.2699     -0.0477      0.1772
+                H      1.5840      0.8007     -0.4449
+                H      1.5089     -0.9636     -0.3791
+                C     -0.2033      0.0282      0.5345
+                H     -0.4993     -0.8287      1.1714
+                H     -0.4235      0.9513      1.1064
+                O     -0.9394      0.0157     -0.6674
+                H     -1.8540      0.0626     -0.4252
+            """,
+            basis = "6-31g",
+            verbose = 0,
+        )
+        mf = UKS(mol, xc = "wB97MV").density_fit(auxbasis = "def2-universal-jkfit")
+        mf.grids.atom_grid = (99, 590)
+        mf.nlcgrids.atom_grid = (50, 194)
+        mf.conv_tol = 1e-10
+
+        test_energy = mf.kernel()
+        assert mf.converged
+
+        dm = mf.make_rdm1()
+
+        grids = mf.grids
+
+        test_charges, test_dipoles, test_quadrupoles, test_octupoles = mbis(mol, grids, dm)
+
+        ### Reference ORCA input
+        # ! wB97M-V 6-31G TightSCF DEFGRID3 MBIS
+
+        # *XYZ 0 1
+        #   H      1.8853     -0.0401      1.0854
+        #   C      1.2699     -0.0477      0.1772
+        #   H      1.5840      0.8007     -0.4449
+        #   H      1.5089     -0.9636     -0.3791
+        #   C     -0.2033      0.0282      0.5345
+        #   H     -0.4993     -0.8287      1.1714
+        #   H     -0.4235      0.9513      1.1064
+        #   O     -0.9394      0.0157     -0.6674
+        #   H     -1.8540      0.0626     -0.4252
+        # *
+
+        # %method
+        # MBIS_LARGEPRINT TRUE
+        # end
+        ref_energy = -154.90319593093577
+        ref_charges = np.array([  0.117186, -0.420738,  0.134820,  0.134753,  0.180223,  0.032960,  0.032951, -0.633758,  0.421603, ])
+        ref_dipoles = np.array([
+            [ 0.017113,  0.000541,  0.034242],
+            [-0.037792,  0.000936, -0.018536],
+            [ 0.004548,  0.030361, -0.024600],
+            [ 0.001878, -0.032385, -0.022251],
+            [-0.020487, -0.004667, -0.152211],
+            [-0.003377, -0.047545,  0.025437],
+            [ 0.000736,  0.049394,  0.021883],
+            [ 0.035161,  0.003982,  0.152033],
+            [-0.003109,  0.000205,  0.002150],
+        ])
+        ref_quadrupoles_orca_shape = np.array([
+            [-0.515032, -0.520371, -0.525178, -0.000623, -0.010598,  0.000272],
+            [-5.014804, -4.962680, -4.929532,  0.004351,  0.058871, -0.001303],
+            [-0.487768, -0.502440, -0.501109, -0.005069,  0.002106,  0.004693],
+            [-0.487080, -0.503970, -0.500481,  0.003854,  0.001376, -0.004663],
+            [-4.101315, -3.995645, -3.950766,  0.007312,  0.076506, -0.001696],
+            [-0.584720, -0.605972, -0.584801, -0.004211,  0.011924,  0.010115],
+            [-0.584134, -0.608067, -0.583413,  0.003111,  0.010815, -0.009413],
+            [-4.235539, -4.493263, -4.370167, -0.008869,  0.053753,  0.002204],
+            [-0.266421, -0.261132, -0.250649,  0.000356,  0.003732,  0.000220],
+        ])
+        ref_quadrupoles = np.zeros((mol.natm, 3, 3))
+        ref_quadrupoles[:, 0, 0] = ref_quadrupoles_orca_shape[:, 0]
+        ref_quadrupoles[:, 1, 1] = ref_quadrupoles_orca_shape[:, 1]
+        ref_quadrupoles[:, 2, 2] = ref_quadrupoles_orca_shape[:, 2]
+        ref_quadrupoles[:, 0, 1] = ref_quadrupoles[:, 1, 0] = ref_quadrupoles_orca_shape[:, 3]
+        ref_quadrupoles[:, 0, 2] = ref_quadrupoles[:, 2, 0] = ref_quadrupoles_orca_shape[:, 4]
+        ref_quadrupoles[:, 1, 2] = ref_quadrupoles[:, 2, 1] = ref_quadrupoles_orca_shape[:, 5]
+        ref_octupoles_orca_shape = np.array([
+            [ 0.015708,  0.002527,  0.031941, -0.000547,  0.008271, -0.002028,  0.000458, -0.003699,  0.020285, -0.000173],
+            [ 0.343862,  0.037233, -0.097685, -0.038176, -0.254288, -0.163899,  0.016613, -0.174204,  0.140883, -0.006867],
+            [-0.003382,  0.031765, -0.028056,  0.008328, -0.013457, -0.007328, -0.000552, -0.007512, -0.001288,  0.008999],
+            [-0.005737, -0.029971, -0.025889, -0.010245, -0.012586, -0.008216,  0.001569, -0.008486, -0.000595, -0.010197],
+            [-0.213450, -0.031980, -0.154812,  0.015932,  0.023653,  0.068174, -0.005042,  0.208991, -0.212431,  0.001006],
+            [ 0.012995, -0.049963,  0.007492, -0.019385,  0.008915,  0.014179,  0.001461,  0.008619, -0.007251, -0.010913],
+            [ 0.018137,  0.044551,  0.004974,  0.021105,  0.007010,  0.014401, -0.003205,  0.009920, -0.008653,  0.011763],
+            [ 0.294780,  0.006843, -0.073839, -0.012596, -0.100903,  0.040943,  0.003176, -0.117808,  0.110438, -0.005769],
+            [ 0.006033,  0.000384, -0.002924, -0.000194,  0.003007, -0.000577, -0.000038, -0.001549,  0.002913, -0.000251],
+        ])
+        ref_octupoles = np.zeros((mol.natm, 3, 3, 3))
+        ref_octupoles[:, 0, 0, 0] = ref_octupoles_orca_shape[:, 0]
+        ref_octupoles[:, 1, 1, 1] = ref_octupoles_orca_shape[:, 1]
+        ref_octupoles[:, 2, 2, 2] = ref_octupoles_orca_shape[:, 2]
+        ref_octupoles[:, 0, 0, 1] = ref_octupoles[:, 0, 1, 0] = ref_octupoles[:, 1, 0, 0] = ref_octupoles_orca_shape[:, 3]
+        ref_octupoles[:, 0, 0, 2] = ref_octupoles[:, 0, 2, 0] = ref_octupoles[:, 2, 0, 0] = ref_octupoles_orca_shape[:, 4]
+        ref_octupoles[:, 0, 1, 1] = ref_octupoles[:, 1, 0, 1] = ref_octupoles[:, 1, 1, 0] = ref_octupoles_orca_shape[:, 5]
+        ref_octupoles[:, 0, 1, 2] = ref_octupoles[:, 0, 2, 1] = ref_octupoles[:, 1, 0, 2] = ref_octupoles[:, 1, 2, 0] = ref_octupoles[:, 2, 0, 1] = ref_octupoles[:, 2, 1, 0] = ref_octupoles_orca_shape[:, 6]
+        ref_octupoles[:, 0, 2, 2] = ref_octupoles[:, 2, 0, 2] = ref_octupoles[:, 2, 2, 0] = ref_octupoles_orca_shape[:, 7]
+        ref_octupoles[:, 1, 1, 2] = ref_octupoles[:, 1, 2, 1] = ref_octupoles[:, 2, 1, 1] = ref_octupoles_orca_shape[:, 8]
+        ref_octupoles[:, 1, 2, 2] = ref_octupoles[:, 2, 1, 2] = ref_octupoles[:, 2, 2, 1] = ref_octupoles_orca_shape[:, 9]
+
+        assert abs(test_energy - ref_energy) < 1e-4
+        assert np.max(np.abs(test_charges - ref_charges)) < 3e-3
+        assert np.max(np.abs(test_dipoles - ref_dipoles)) < 3e-4
+        assert np.max(np.abs(test_quadrupoles - ref_quadrupoles)) < 1e-2
+        assert np.max(np.abs(test_octupoles - ref_octupoles)) < 5e-2
+
+if __name__ == "__main__":
+    print("Full Tests for MBIS")
+    unittest.main()

--- a/gpu4pyscf/qmmm/tests/test_mbis.py
+++ b/gpu4pyscf/qmmm/tests/test_mbis.py
@@ -375,5 +375,5 @@ class KnownValues(unittest.TestCase):
         assert np.max(np.abs(test_octupoles - ref_octupoles)) < 5e-2
 
 if __name__ == "__main__":
-    print("Full Tests for MBIS")
+    print("Full Tests for MBIS multipole")
     unittest.main()


### PR DESCRIPTION
The current implementation is fast but requires huge amount of GPU memory.

Additionally, fix a bug in get_rho function, when a block of grid is far away from any atom (never encountered in normal use case), get_rho skip this block of grids in block_loop and mess up the grid order.